### PR TITLE
Fix SwatDate exception when generating intervals from 0s.

### DIFF
--- a/Swat/SwatDate.php
+++ b/Swat/SwatDate.php
@@ -891,9 +891,7 @@ class SwatDate extends DateTime implements Serializable
 				$interval_spec.= $minutes.'M';
 			}
 
-			if ($seconds > 0) {
-				$interval_spec.= $seconds.'S';
-			}
+			$interval_spec.= $seconds.'S';
 		}
 
 		return new DateInterval($interval_spec);


### PR DESCRIPTION
always include the seconds part in the interval. 0 second intervals will no longer throw a DateInterval exception.
