### PR TITLE
Don't fail when adding records with no parent.

### DIFF
--- a/SwatDB/SwatDBRecordsetWrapper.php
+++ b/SwatDB/SwatDBRecordsetWrapper.php
@@ -971,6 +971,13 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 
 			if ($record_id !== $current_record_id) {
 				$current_record_id = $record_id;
+
+				// if recordset being attached references records not in
+				// this recordset, ignore them
+				if (!isset($this[$record_id])) {
+					continue;
+				}
+
 				$current_recordset = $this[$record_id]->$name;
 			}
 


### PR DESCRIPTION
When you use SwatDBRecordsetWrapper::attachSubRecordset() and the
recordset being added contains records that point to records not in this
recordset, those records should be ignored.

For example:

set of images -> 1, 2, 3, 4, 5, 6
set of dimensions referring to images -> (1,2), (2,2), (3,1), (4,10)

If the dimensions are attached to the images the dimension binding
(4,10) which does not match any image should be ignored rather than
causing an error.
