### PR TITLE
Fix issue when multiple records need to be ignored

### DIFF
--- a/SwatDB/SwatDBRecordsetWrapper.php
+++ b/SwatDB/SwatDBRecordsetWrapper.php
@@ -969,15 +969,14 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		foreach ($recordset as $record) {
 			$record_id = $record->getInternalValue($binding_field);
 
+			// if recordset being attached references records not in
+			// this recordset, ignore them
+			if (!isset($this[$record_id])) {
+				continue;
+			}
+
 			if ($record_id !== $current_record_id) {
 				$current_record_id = $record_id;
-
-				// if recordset being attached references records not in
-				// this recordset, ignore them
-				if (!isset($this[$record_id])) {
-					continue;
-				}
-
 				$current_recordset = $this[$record_id]->$name;
 			}
 


### PR DESCRIPTION
The previous fix to ignore records that are not referenced in the parent
set only worked for the first record referencing a parent. If there was
more than one record referencing the same non-existent parent it still
failed.

This moves the ignore check outside the current_record_id check and
fixes the issue.
