### PR TITLE
Fix hasDateProperty()

### DIFF
--- a/SwatDB/SwatDBDataObject.php
+++ b/SwatDB/SwatDBDataObject.php
@@ -390,7 +390,7 @@ class SwatDBDataObject extends SwatObject
 	 */
 	public function hasDateProperty($name)
 	{
-		return array_key_exists($name, $this->date_properties);
+		return in_array($name, $this->date_properties);
 	}
 
 	// }}}


### PR DESCRIPTION
To our shame we didn't test this when adding it in #19. The date_properties array is an array of properties, not an indexed array of values. So use the correct in_array().
