### PR TITLE
Add default blank titles to year/month/day flydowns

### DIFF
--- a/Swat/SwatDateEntry.php
+++ b/Swat/SwatDateEntry.php
@@ -112,7 +112,7 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 	 *
 	 * @var boolean
 	 */
-	public $show_blank_titles = false;
+	public $show_blank_titles = true;
 
 	// }}}
 	// {{{ public function __construct()


### PR DESCRIPTION
Blank titles visibility is controlled by the new `$show_blank_titles` flag, and there are individual methods that can be subclassed if different titles are needed.

I left it as an all or nothing flag on purpose as having some fields showing blank titles and others not seemed weird.

This has the benefit on making subclasses such as `StoreCardExpiry` more simple (see https://github.com/silverorange/store/pull/32), and allows us to reuse the blank titles in other places.

This also makes a bunch of methods protected instead of private. Will not break anything, and in theory will help us subclass if we ever need to.

Plus, some code cleanup that helped me debug this as I was building it.
