### PR TITLE
Add SwatString::getTimePeriodParts()

### DIFF
--- a/Swat/SwatString.php
+++ b/Swat/SwatString.php
@@ -1528,8 +1528,16 @@ class SwatString extends SwatObject
 			);
 		}
 
+		if (isset($parts['weeks'])) {
+			$weeks = $parts['weeks'];
+			$parts['weeks'] = sprintf(
+				Swat::ngettext('%s week', '%s weeks', $weeks),
+				$weeks
+			);
+		}
+
 		if (isset($parts['days'])) {
-			$weeks = $parts['days'];
+			$days = $parts['days'];
 			$parts['days'] = sprintf(
 				Swat::ngettext('%s day', '%s days', $days),
 				$days


### PR DESCRIPTION
Breaks `getHumanReadableTimePeriodParts()` into two methods:
- `getTimePeriodParts()` keeps all the logic of defining the `$interval_parts` you want returned, and calculating them.
- `getHumanReadableTimePeriodParts()` is rewritten to use `getTimePeriodParts()` internally, but maintain old behaviour.

Using `getTimePeriodParts()` means you can keep the benefits over a straight `DateInterval`, without being forced to use `getHumanReadableTimePeriodParts()` strings.
