### PR TITLE
having an empty no_records_message should short-circuit the display, just not output a message

### DIFF
--- a/Swat/SwatTableView.php
+++ b/Swat/SwatTableView.php
@@ -72,7 +72,7 @@ class SwatTableView extends SwatView implements SwatUIParent
 	 * No records message text
 	 *
 	 * A message to show if the table view has no records to display. If
-	 * null, no message is displayed.
+	 * set to an empty string, no message is displayed.
 	 *
 	 * @var string
 	 */
@@ -296,8 +296,8 @@ class SwatTableView extends SwatView implements SwatUIParent
 			}
 		}
 
-		if ($row_count == 0 && $show_no_records) {
-			if ($this->no_records_message !== null) {
+		if ($row_count === 0 && $show_no_records) {
+			if ($this->no_records_message != '') {
 				$div = new SwatHtmlTag('div');
 				$div->class = 'swat-none';
 				$div->setContent($this->no_records_message,


### PR DESCRIPTION
Without this, setting:

```
$view->no_records_message = '';
$view->display();
```

will still output `<table>` tags, table-rows, etc. when you would expect it to just not show anything. If this is the expected behavior and I'm just wrong, I could update my code to check if there are 0 rows and set the visibility of the view.
