### PR TITLE
Don't display an empty conjunction.

### DIFF
--- a/Swat/SwatString.php
+++ b/Swat/SwatString.php
@@ -1337,7 +1337,9 @@ class SwatString extends SwatObject
 						$list.= ($display_final_delimiter
 							&& count($iterator) > 2) ? $delimiter : ' ';
 
-						$list.= $conjunction.' ';
+						if ($conjunction != '') {
+							$list.= $conjunction.' ';
+						}
 					} else {
 						$list.= $delimiter;
 					}


### PR DESCRIPTION
Prevents two spaces from being displayed when the conjunction is null or
an empty string.
