### PR TITLE
Add optional wrapping div around SwatFormField notes and contents.

### DIFF
--- a/Swat/SwatFormField.php
+++ b/Swat/SwatFormField.php
@@ -292,12 +292,13 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 		} else {
 			if ($this->show_notes_first) {
 				if ($this->wrap_content_and_notes) {
+					$this->displayTitle();
+
 					$content_wrapper->open();
 					$this->displayNotes();
 					$this->displayContent();
 					$content_wrapper->close();
 
-					$this->displayTitle();
 					$this->displayMessages();
 				} else {
 					$this->displayTitle();
@@ -308,6 +309,7 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 			} else {
 				if ($this->wrap_content_and_notes) {
 					$this->displayTitle();
+
 					$content_wrapper->open();
 					$this->displayContent();
 					$this->displayNotes();


### PR DESCRIPTION
This is controlled by a new `$wrap_content_and_notes` flag, and leads to a giant nested if block, but the logic is easiest to follow like this, and probably easier than the prior logic.
