### PR TITLE
Drop the deprecated constants in SwatFormField

### DIFF
--- a/Swat/SwatFormField.php
+++ b/Swat/SwatFormField.php
@@ -36,16 +36,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 	 */
 	const SHOW_OPTIONAL = 2;
 
-	/**
-	 * @deprecated Use {@link SwatFormField::SHOW_REQUIRED} instead.
-	 */
-	const DISPLAY_REQUIRED = 1;
-
-	/**
-	 * @deprecated Use {@link SwatFormField::SHOW_OPTIONAL} instead.
-	 */
-	const DISPLAY_OPTIONAL = 2;
-
 	// }}}
 	// {{{ public properties
 

--- a/package.php
+++ b/package.php
@@ -4,7 +4,7 @@
 
 require_once 'PEAR/PackageFileManager2.php';
 
-$version = '2.1.12';
+$version = '2.2.0';
 $notes = <<<EOT
 No release notes for you!
 EOT;


### PR DESCRIPTION
This bumps the minor version of Swat as well, because it breaks backwards compatibility.

All sites have already been updated, and other packages will be cleaned up, and require this new version of Swat.
