### PR TITLE
Create composite widgets before copying

### DIFF
--- a/Swat/SwatWidget.php
+++ b/Swat/SwatWidget.php
@@ -497,6 +497,9 @@ abstract class SwatWidget extends SwatUIObject
 	 */
 	public function copy($id_suffix = '')
 	{
+		// create composite widgets so that they can be copied
+		$this->confirmCompositeWidgets();
+
 		$copy = parent::copy($id_suffix);
 
 		if ($id_suffix != '' && $copy->id !== null)


### PR DESCRIPTION
Currently, a composite widget (i.e. `SwatDateEntry`) in a replicator,
won't have the composite widgets (year, month, day) copied when the form
is processed. See `SwatWidgetCellRenderer::getClonedWidgets()`. The copy
occurs before the composite widgets have been created.