### PR TITLE
Don't assign by reference when building serialized array representations of objects

### DIFF
--- a/SwatDB/SwatDBDataObject.php
+++ b/SwatDB/SwatDBDataObject.php
@@ -1371,14 +1371,14 @@ class SwatDBDataObject extends SwatObject
 		}
 
 		foreach ($this->getSerializablePrivateProperties() as $property) {
-			$data[$property] = &$this->$property;
+			$data[$property] = $this->$property;
 		}
 
 		$reflector = new ReflectionObject($this);
 		foreach ($reflector->getProperties() as $property) {
 			if ($property->isPublic() && !$property->isStatic()) {
 				$name = $property->getName();
-				$data[$name] = &$this->$name;
+				$data[$name] = $this->$name;
 			}
 		}
 

--- a/SwatDB/SwatDBRecordsetWrapper.php
+++ b/SwatDB/SwatDBRecordsetWrapper.php
@@ -646,8 +646,9 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 			'options',
 		);
 
-		foreach ($private_properties as $property)
-			$data[$property] = &$this->$property;
+		foreach ($private_properties as $property) {
+			$data[$property] = $this->$property;
+		}
 
 		return serialize($data);
 	}
@@ -659,8 +660,9 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 	{
 		$data = unserialize($data);
 
-		foreach ($data as $property => $value)
+		foreach ($data as $property => $value) {
 			$this->$property = $value;
+		}
 	}
 
 	// }}}


### PR DESCRIPTION
https://trello.com/c/PAhw3A3i/458-fix-swatdb-session-serialization-issue-on-newer-versions-of-php-than-5-3

Assigning by reference causes session corruption on newer versions of PHP. Copy-on-write semantics of arrays means this code will not use more memory or be slower than the code that assigned by reference.