### PR TITLE
Add getAttributes() method to SwatDBDataObject

### DIFF
--- a/SwatDB/SwatDBDataObject.php
+++ b/SwatDB/SwatDBDataObject.php
@@ -496,7 +496,7 @@ class SwatDBDataObject extends SwatObject
 	 * This array is useful for places where get_object_vars() is useful but we
 	 * also want to return the protected properties alongside the public onces.
 	 * For example when using getter and setter methods instead of public
-	 * properities on a dataobject.
+	 * properties on a dataobject.
 	 *
 	 * @return array an array of public and protected properties.
 	 *

--- a/SwatDB/SwatDBDataObject.php
+++ b/SwatDB/SwatDBDataObject.php
@@ -505,12 +505,10 @@ class SwatDBDataObject extends SwatObject
 	 */
 	public function getAttributes()
 	{
-		$property_array = array_merge(
+		return array_merge(
 			$this->getPublicProperties(),
 			$this->getProtectedProperties()
 		);
-
-		return $property_array;
 	}
 
 	// }}}

--- a/SwatDB/SwatDBDataObject.php
+++ b/SwatDB/SwatDBDataObject.php
@@ -488,6 +488,32 @@ class SwatDBDataObject extends SwatObject
 	}
 
 	// }}}
+	// {{{ public function getAttributes()
+
+	/**
+	 * Returns an array of the public and protected properties of this object
+	 *
+	 * This array is useful for places where get_object_vars() is useful but we
+	 * also want to return the protected properties alongside the public onces.
+	 * For example when using getter and setter methods instead of public
+	 * properities on a dataobject.
+	 *
+	 * @return array an array of public and protected properties.
+	 *
+	 * @see SwatDBDataObject::getPublicProperties()
+	 * @see SwatDBDataObject::getProtectedProperties()
+	 */
+	public function getAttributes()
+	{
+		$property_array = array_merge(
+			$this->getPublicProperties(),
+			$this->getProtectedProperties()
+		);
+
+		return $property_array;
+	}
+
+	// }}}
 	// {{{ protected function setInternalValue()
 
 	protected function setInternalValue($name, $value)


### PR DESCRIPTION
Now that we're using getter and setter patterns in our dataobjects we
can no longer use `get_object_vars()` on the dataobject to get all the
properties we care about, for example when editing with admin tools.

`getAttributes()` is a replacement for places where we have relied on
`get_object_vars()` in the past to remedy this.

https://hippoeducation.tpondemand.com/entity/672