### PR TITLE
Add support for multiple error and exception loggers

### DIFF
--- a/Swat/SwatError.php
+++ b/Swat/SwatError.php
@@ -238,6 +238,32 @@ class SwatError
 	}
 
 	// }}}
+	// {{{ public function getFile()
+
+	/**
+	 * Gets the file location where the error occurred
+	 *
+	 * @return string file location of error
+	 */
+	public function getFile()
+	{
+		return $this->file;
+	}
+
+	// }}}
+	// {{{ public function getLine()
+
+	/**
+	 * Gets the line number where the error occurred
+	 *
+	 * @return integer line number of error
+	 */
+	public function getLine()
+	{
+		return $this->line;
+	}
+
+	// }}}
 	// {{{ public function log()
 
 	/**

--- a/Swat/SwatError.php
+++ b/Swat/SwatError.php
@@ -76,9 +76,9 @@ class SwatError
 	protected static $displayer = null;
 
 	/**
-	 * @var SwatErrorLogger
+	 * @var array
 	 */
-	protected static $logger = null;
+	protected static $loggers = array();
 
 	/**
 	 * @var integer
@@ -100,7 +100,25 @@ class SwatError
 	 */
 	public static function setLogger(SwatErrorLogger $logger)
 	{
-		self::$logger = $logger;
+		self::$loggers = array($logger);
+	}
+
+	// }}}
+	// {{{ public static function addLogger()
+
+	/**
+	 * Adds an object to the array of objects that log SwatError objects when they are processed
+	 *
+	 * For example:
+	 * <code>
+	 * SwatError::addLogger(new CustomLogger());
+	 * </code>
+	 *
+	 * @param SwatErrorLogger $logger the object to add to the array of objects that log exceptions
+	 */
+	public static function addLogger(SwatErrorLogger $logger)
+	{
+		self::$loggers[] = $logger;
 	}
 
 	// }}}
@@ -229,11 +247,12 @@ class SwatError
 	 */
 	public function log()
 	{
-		if (self::$logger === null) {
+		if (count(self::$loggers) === 0) {
 			error_log($this->getSummary(), 0);
 		} else {
-			$logger = self::$logger;
-			$logger->log($this);
+			foreach (self::$loggers as $logger) {
+				$logger->log($this);
+			}
 		}
 	}
 

--- a/Swat/SwatError.php
+++ b/Swat/SwatError.php
@@ -107,14 +107,16 @@ class SwatError
 	// {{{ public static function addLogger()
 
 	/**
-	 * Adds an object to the array of objects that log SwatError objects when they are processed
+	 * Adds an object to the array of objects that log SwatError objects
+	 * when they are processed
 	 *
 	 * For example:
 	 * <code>
 	 * SwatError::addLogger(new CustomLogger());
 	 * </code>
 	 *
-	 * @param SwatErrorLogger $logger the object to add to the array of objects that log exceptions
+	 * @param SwatErrorLogger $logger the object to add to the array of objects
+	 *                                           that log exceptions
 	 */
 	public static function addLogger(SwatErrorLogger $logger)
 	{

--- a/Swat/exceptions/SwatException.php
+++ b/Swat/exceptions/SwatException.php
@@ -51,9 +51,9 @@ class SwatException extends Exception
 	protected static $displayer = null;
 
 	/**
-	 * @var SwatExceptionLogger
+	 * @var array
 	 */
-	protected static $logger = null;
+	protected static $loggers = array();
 
 	// }}}
 	// {{{ private properties
@@ -80,9 +80,25 @@ class SwatException extends Exception
 	 */
 	public static function setLogger(SwatExceptionLogger $logger)
 	{
-		self::$logger = $logger;
+		self::$loggers = array($logger);
 	}
 
+	// }}}
+	// {{{ public static function addLogger()
+
+	/**
+	 * Adds an object to the array of objects that log SwatException objects when they are processed
+	 *
+	 * For example:
+	 * <code>
+	 * SwatException::addLogger(new CustomLogger());
+	 *
+	 * @param SwatExceptionLogger $logger the object to add to the array of objects that log exceptions
+	 */
+	public static function addLogger(SwatExceptionLogger $logger)
+	{
+		self::$loggers[] = $logger;
+	}
 	// }}}
 	// {{{ public static function setDisplayer()
 
@@ -207,11 +223,12 @@ class SwatException extends Exception
 	 */
 	public function log()
 	{
-		if (self::$logger === null) {
+		if (count(self::$loggers) === 0) {
 			error_log($this->getSummary(), 0);
 		} else {
-			$logger = self::$logger;
-			$logger->log($this);
+			foreach (self::$loggers as $logger) {
+				$logger->log($this);
+			}
 		}
 	}
 

--- a/Swat/exceptions/SwatException.php
+++ b/Swat/exceptions/SwatException.php
@@ -93,12 +93,13 @@ class SwatException extends Exception
 	 * <code>
 	 * SwatException::addLogger(new CustomLogger());
 	 *
-	 * @param SwatExceptionLogger $logger the object to add to the array of objects that log exceptions
+	 * @param SwatExceptionLogger $logger the object to add to the array of exception loggers
 	 */
 	public static function addLogger(SwatExceptionLogger $logger)
 	{
 		self::$loggers[] = $logger;
 	}
+
 	// }}}
 	// {{{ public static function setDisplayer()
 

--- a/Swat/exceptions/SwatException.php
+++ b/Swat/exceptions/SwatException.php
@@ -87,13 +87,16 @@ class SwatException extends Exception
 	// {{{ public static function addLogger()
 
 	/**
-	 * Adds an object to the array of objects that log SwatException objects when they are processed
+	 * Adds an object to the array of objects that log SwatException objects
+	 * when they are processed
 	 *
 	 * For example:
 	 * <code>
 	 * SwatException::addLogger(new CustomLogger());
+	 * </code>
 	 *
-	 * @param SwatExceptionLogger $logger the object to add to the array of exception loggers
+	 * @param SwatExceptionLogger $logger the object to add to the array of
+	 *                                           exception loggers
 	 */
 	public static function addLogger(SwatExceptionLogger $logger)
 	{


### PR DESCRIPTION
This will be used in the Sentry integration, so that any sites that are configured to use sentry can still log errors and exceptions with SwatErrorLogger and SwatExceptionLogger as a back up.