### PR TITLE
Fix setting record at offset index (EM:RAP)

### DIFF
--- a/SwatDB/SwatDBRecordsetWrapper.php
+++ b/SwatDB/SwatDBRecordsetWrapper.php
@@ -448,14 +448,17 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 				$this->removed_objects[] = $this->objects[$offset];
 				$this->objects[$offset] = $value;
 			} else {
+				$index_field = $this->index_field;
+
 				// update object index field value
-				$value->{$this->index_field} = $offset;
+				$value->{$index_field} = $offset;
 
 				// find and replace ordinally indexed objects
-				$keys = array_keys($this->objects, $value, true);
-				foreach ($keys as $key) {
-					$this->removed_objects[] = $this->objects[$key];
-					$this->objects[$key] = $value;
+				foreach ($this->objects as $key => $object) {
+					if ($object->{$index_field} === $value->{$index_field}) {
+						$this->removed_objects[] = $object;
+						$this->objects[$key] = $value;
+					}
 				}
 
 				// add object to indexed array


### PR DESCRIPTION
Same as #87 but for EM:RAP branch.

Old code would never have worked as array_keys() with a new object as a value would always return an empty array and would never replace the object in the ordinal indexed array.