### PR TITLE
Remove vim fold markers

### DIFF
--- a/Swat/Swat.php
+++ b/Swat/Swat.php
@@ -9,7 +9,6 @@
  */
 class Swat
 {
-	// {{{ constants
 
 	/**
 	 * The gettext domain for Swat
@@ -18,18 +17,12 @@ class Swat
 	 */
 	const GETTEXT_DOMAIN = 'swat';
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * Whether or not this package is initialized
 	 *
 	 * @var boolean
 	 */
 	private static $is_initialized = false;
-
-	// }}}
-	// {{{ public static function _()
 
 	/**
 	 * Translates a phrase
@@ -45,9 +38,6 @@ class Swat
 		return self::gettext($message);
 	}
 
-	// }}}
-	// {{{ public static function gettext()
-
 	/**
 	 * Translates a phrase
 	 *
@@ -62,9 +52,6 @@ class Swat
 	{
 		return dgettext(self::GETTEXT_DOMAIN, $message);
 	}
-
-	// }}}
-	// {{{ public static function ngettext()
 
 	/**
 	 * Translates a plural phrase
@@ -92,9 +79,6 @@ class Swat
 			$singular_message, $plural_message, $number);
 	}
 
-	// }}}
-	// {{{ public static function setupGettext()
-
 	public static function setupGettext()
 	{
 		$path = '@DATA-DIR@/Swat/locale';
@@ -105,9 +89,6 @@ class Swat
 		bindtextdomain(self::GETTEXT_DOMAIN, $path);
 		bind_textdomain_codeset(self::GETTEXT_DOMAIN, 'UTF-8');
 	}
-
-	// }}}
-	// {{{ public static function displayMethods()
 
 	/**
 	 * Displays the methods of an object
@@ -126,9 +107,6 @@ class Swat
 
 		echo '</ul>';
 	}
-
-	// }}}
-	// {{{ public static function displayProperties()
 
 	/**
 	 * Displays the properties of an object
@@ -152,9 +130,6 @@ class Swat
 		echo '</ul>';
 	}
 
-	// }}}
-	// {{{ public static function printObject()
-
 	/**
 	 * Displays an object's properties and values recursively
 	 *
@@ -169,9 +144,6 @@ class Swat
 	{
 		echo '<pre>'.print_r($object, true).'</pre>';
 	}
-
-	// }}}
-	// {{{ public static function displayInlineJavaScript()
 
 	/**
 	 * Displays inline JavaScript properly encapsulating the script in a CDATA
@@ -188,9 +160,6 @@ class Swat
 		}
 	}
 
-	// }}}
-	// {{{ public static function init()
-
 	public static function init()
 	{
 		if (self::$is_initialized) {
@@ -202,9 +171,6 @@ class Swat
 		self::$is_initialized = true;
 	}
 
-	// }}}
-	// {{{ private function __construct()
-
 	/**
 	 * Don't allow instantiation of the Swat object
 	 *
@@ -214,10 +180,7 @@ class Swat
 	{
 	}
 
-	// }}}
 }
-
-// {{{ dummy dngettext()
 
 /*
  * Define a dummy dngettext() for when gettext is not available.
@@ -249,9 +212,6 @@ if (!function_exists("dngettext")) {
 
 }
 
-// }}}
-// {{{ dummy dgettext()
-
 /*
  * Define a dummy dgettext() for when gettext is not available.
  */
@@ -275,7 +235,5 @@ if (!function_exists("dgettext")) {
 	}
 
 }
-
-// }}}
 
 ?>

--- a/Swat/SwatAbstractMenu.php
+++ b/Swat/SwatAbstractMenu.php
@@ -17,7 +17,6 @@
  */
 abstract class SwatAbstractMenu extends SwatControl
 {
-	// {{{ public properties
 
 	/**
 	 * Whether or not a mouse click outside this menu will hide this menu
@@ -39,9 +38,6 @@ abstract class SwatAbstractMenu extends SwatControl
 	 */
 	public $auto_sub_menu_display = true;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new menu object
 	 *
@@ -60,9 +56,6 @@ abstract class SwatAbstractMenu extends SwatControl
 		$this->addStyleSheet('packages/swat/styles/swat-menu.css');
 	}
 
-	// }}}
-	// {{{ public function setMenuItemValues()
-
 	/**
 	 * Sets the value of all {@link SwatMenuItem} objects within this menu
 	 *
@@ -79,9 +72,6 @@ abstract class SwatAbstractMenu extends SwatControl
 		}
 	}
 
-	// }}}
-	// {{{ protected function getJavaScriptClass()
-
 	/**
 	 * Gets the name of the JavaScript class to instantiate for this menu
 	 *
@@ -95,9 +85,6 @@ abstract class SwatAbstractMenu extends SwatControl
 	{
 		return 'YAHOO.widget.Menu';
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript used by this menu control
@@ -135,7 +122,6 @@ abstract class SwatAbstractMenu extends SwatControl
 		);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatAbstractOverlay.php
+++ b/Swat/SwatAbstractOverlay.php
@@ -18,7 +18,6 @@
  */
 abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
 {
-	// {{{ public properties
 
 	/**
 	 * Access key
@@ -35,9 +34,6 @@ abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
 	 * @var string
 	 */
 	public $value = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new overlay widget
@@ -63,9 +59,6 @@ abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
 			'packages/swat/javascript/swat-z-index-manager.js'
 		);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this overlay widget
@@ -96,9 +89,6 @@ abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function getState()
-
 	/**
 	 * Gets the current state of this simple color selector widget
 	 *
@@ -110,9 +100,6 @@ abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
 	{
 		return $this->value;
 	}
-
-	// }}}
-	// {{{ public function setState()
 
 	/**
 	 * Sets the current state of this simple color selector widget
@@ -126,9 +113,6 @@ abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
 		$this->value = $state;
 	}
 
-	// }}}
-	// {{{ abstract protected function getInlineJavaScript()
-
 	/**
 	 * Gets inline JavaScript
 	 *
@@ -140,7 +124,6 @@ abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
 			SwatString::quoteJavaScriptString(Swat::_('Close')));
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatAccordion.php
+++ b/Swat/SwatAccordion.php
@@ -14,7 +14,6 @@
  */
 class SwatAccordion extends SwatNoteBook
 {
-	// {{{ public properties
 
 	/**
 	 * Whether or not to animate the opening/closing of the accordion
@@ -31,9 +30,6 @@ class SwatAccordion extends SwatNoteBook
 	 * @var boolean
 	 */
 	public $always_open = false;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new accordion view
@@ -52,9 +48,6 @@ class SwatAccordion extends SwatNoteBook
 		$this->addStyleSheet('packages/swat/styles/swat-accordion.css');
 		$this->addJavaScript('packages/swat/javascript/swat-accordion.js');
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this notebook
@@ -116,9 +109,6 @@ class SwatAccordion extends SwatNoteBook
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets the inline JavaScript used by this accordion view
 	 *
@@ -142,15 +132,11 @@ class SwatAccordion extends SwatNoteBook
 		return $javascript;
 	}
 
-	// }}}
-	// {{{ protected function getJavaScriptClassName()
-
 	protected function getJavaScriptClassName()
 	{
 		return 'SwatAccordion';
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatActionItem.php
+++ b/Swat/SwatActionItem.php
@@ -11,7 +11,6 @@
  */
 class SwatActionItem extends SwatControl implements SwatUIParent
 {
-	// {{{ public properties
 
 	/**
 	 * A unique identifier for this action item
@@ -34,9 +33,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 	 */
 	public $widget = null;
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this action item
 	 *
@@ -50,9 +46,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 		if ($this->widget !== null)
 			$this->widget->init();
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this item
@@ -68,9 +61,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 
 		$this->widget->display();
 	}
-
-	// }}}
-	// {{{ public function setWidget()
 
 	/**
 	 * Sets the widget to use for this item
@@ -91,9 +81,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 		$this->widget = $widget;
 		$widget->parent = $this;
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child object
@@ -120,9 +107,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 				'SwatActionItem object.', 0, $child);
 	}
 
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this action item
 	 *
@@ -142,9 +126,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this action item
 	 *
@@ -163,9 +144,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -204,9 +182,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -233,9 +208,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -255,9 +227,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -273,9 +242,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -301,7 +267,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 		return $copy;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatActions.php
+++ b/Swat/SwatActions.php
@@ -9,7 +9,6 @@
  */
 class SwatActions extends SwatControl implements SwatUIParent
 {
-	// {{{ public properties
 
 	/**
 	 * Selected action
@@ -39,9 +38,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 	 */
 	public $auto_reset = true;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * The available actions for this actions selector indexed by id
 	 *
@@ -50,9 +46,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 	 * @var array
 	 */
 	protected $action_items_by_id = array();
-
-	// }}}
-	// {{{ private properties
 
 	/**
 	 * The available actions for this actions selector.
@@ -79,9 +72,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 	 */
 	private $selector;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new actions list
 	 *
@@ -99,9 +89,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		$this->addStyleSheet('packages/swat/styles/swat-actions.css');
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this action item
 	 *
@@ -114,9 +101,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		foreach ($this->action_items as $action_item)
 			$action_item->init();
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this list of actions
@@ -199,9 +183,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Figures out what action item is selected
 	 *
@@ -227,9 +208,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ public function addActionItem()
-
 	/**
 	 * Adds an action item
 	 *
@@ -247,9 +225,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		if ($item->id !== null)
 			$this->action_items_by_id[$item->id] = $item;
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child object
@@ -276,9 +251,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 				'SwatAction object.', 0, $child);
 	}
 
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this actions list
 	 *
@@ -296,9 +268,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this actions
@@ -320,9 +289,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getActionItems()
-
 	/**
 	 * Gets the array of current SwatActions
 	 *
@@ -334,9 +300,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 	{
 		return $this->action_items;
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -375,9 +338,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -411,9 +371,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -433,9 +390,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -451,9 +405,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function setViewSelector()
 
 	/**
 	 * Sets the optional view and selector of this actions control
@@ -492,9 +443,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		$this->selector = $selector;
 	}
 
-	// }}}
-	// {{{ public function copy()
-
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
 	 *
@@ -524,9 +472,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		return $copy;
 	}
 
-	// }}}
-	// {{{ public function hasMessage()
-
 	/**
 	 * Checks for the presence of messages
 	 *
@@ -547,9 +492,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		return $has_message;
 	}
 
-	// }}}
-	// {{{ protected function displayButton()
-
 	/**
 	 * Displays the button for this action list
 	 *
@@ -561,9 +503,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		$button->setFromStock('apply');
 		$button->display();
 	}
-
-	// }}}
-	// {{{ protected function createCompositeWidgets()
 
 	/**
 	 * Creates and the composite flydown and button widgets of this actions
@@ -579,9 +518,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		$button = new SwatButton($this->id.'_apply_button');
 		$this->addCompositeWidget($button, 'apply_button');
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets inline JavaScript required to show and hide selected action items
@@ -627,9 +563,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		return $javascript;
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScriptTranslations()
-
 	/**
 	 * Gets translatable string resources for the JavaScript object for
 	 * this widget
@@ -655,9 +588,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 			$select_an_item_and_an_action_text);
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this actions list
 	 *
@@ -671,7 +601,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatBooleanCellRenderer.php
+++ b/Swat/SwatBooleanCellRenderer.php
@@ -9,7 +9,6 @@
  */
 class SwatBooleanCellRenderer extends SwatCellRenderer
 {
-	// {{{ public properties
 
 	/**
 	 * Value of this cell
@@ -54,9 +53,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
 	 * @see SwatBooleanCellRenderer::setFromStock()
 	 */
 	public $stock_id = null;
-
-	// }}}
-	// {{{ public function setFromStock()
 
 	/**
 	 * Sets the values of this boolean cell renderer to a stock type
@@ -110,9 +106,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
 			$this->content_type = $content_type;
 	}
 
-	// }}}
-	// {{{ public function render()
-
 	/**
 	 * Renders the contents of this cell
 	 *
@@ -139,9 +132,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
 			$this->renderFalse();
 	}
 
-	// }}}
-	// {{{ public function getDataSpecificCSSClassNames()
-
 	/**
 	 * Gets the data specific CSS class names for this cell renderer
 	 *
@@ -159,9 +149,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
 			return array();
 	}
 
-	// }}}
-	// {{{ protected function renderTrue()
-
 	/**
 	 * Renders a true value for this boolean cell renderer
 	 */
@@ -173,9 +160,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
 			echo $this->true_content;
 	}
 
-	// }}}
-	// {{{ protected function renderFalse()
-
 	/**
 	 * Renders a false value for this boolean cell renderer
 	 */
@@ -186,9 +170,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
 		else
 			echo $this->false_content;
 	}
-
-	// }}}
-	// {{{ protected function displayCheck()
 
 	/**
 	 * Renders a checkmark image for this boolean cell renderer
@@ -206,7 +187,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
 		$image_tag->display();
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatButton.php
+++ b/Swat/SwatButton.php
@@ -12,7 +12,6 @@
  */
 class SwatButton extends SwatInputControl
 {
-	// {{{ public properties
 
 	/**
 	 * The visible text on this button
@@ -82,9 +81,6 @@ class SwatButton extends SwatInputControl
 	 */
 	public $confirmation_message = null;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * A CSS class set by the stock_id of this button
 	 *
@@ -102,9 +98,6 @@ class SwatButton extends SwatInputControl
 	 * @var boolean
 	 */
 	protected $clicked = false;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new button
@@ -124,9 +117,6 @@ class SwatButton extends SwatInputControl
 		$this->requires_id = true;
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this widget
 	 *
@@ -144,9 +134,6 @@ class SwatButton extends SwatInputControl
 		else
 			$this->setFromStock($this->stock_id, false);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this button
@@ -169,9 +156,6 @@ class SwatButton extends SwatInputControl
 		}
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Does button processing
 	 *
@@ -191,9 +175,6 @@ class SwatButton extends SwatInputControl
 		}
 	}
 
-	// }}}
-	// {{{ public function hasBeenClicked()
-
 	/**
 	 * Returns whether this button has been clicked
 	 *
@@ -203,9 +184,6 @@ class SwatButton extends SwatInputControl
 	{
 		return $this->clicked;
 	}
-
-	// }}}
-	// {{{ public function setFromStock()
 
 	/**
 	 * Sets the values of this button to a stock type
@@ -270,9 +248,6 @@ class SwatButton extends SwatInputControl
 		$this->stock_class = $class;
 	}
 
-	// }}}
-	// {{{ protected function getInputTag()
-
 	/**
 	 * Get the HTML tag to display for this button
 	 *
@@ -302,9 +277,6 @@ class SwatButton extends SwatInputControl
 		return $tag;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this button
 	 *
@@ -329,9 +301,6 @@ class SwatButton extends SwatInputControl
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function getJavaScriptClass()
-
 	/**
 	 * Gets the name of the JavaScript class to instantiate for this button
 	 *
@@ -345,9 +314,6 @@ class SwatButton extends SwatInputControl
 	{
 		return 'SwatButton';
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript required for this control
@@ -379,7 +345,6 @@ class SwatButton extends SwatInputControl
 		return $javascript;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatByteCellRenderer.php
+++ b/Swat/SwatByteCellRenderer.php
@@ -12,7 +12,6 @@
  */
 class SwatByteCellRenderer extends SwatCellRenderer
 {
-	// {{{ public properties
 
 	/**
 	 * Value in bytes
@@ -20,9 +19,6 @@ class SwatByteCellRenderer extends SwatCellRenderer
 	 * @var float
 	 */
 	public $value;
-
-	// }}}
-	// {{{ public function render()
 
 	/**
 	 * Renders the contents of this cell
@@ -40,7 +36,6 @@ class SwatByteCellRenderer extends SwatCellRenderer
 			SwatString::byteFormat($this->value));
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCalendar.php
+++ b/Swat/SwatCalendar.php
@@ -12,7 +12,6 @@
  */
 class SwatCalendar extends SwatControl
 {
-	// {{{ public properties
 
 	/**
 	 * Start date of the valid range (inclusive).
@@ -27,9 +26,6 @@ class SwatCalendar extends SwatControl
 	 * @var SwatDate
 	 */
 	public $valid_range_end;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new calendar
@@ -53,9 +49,6 @@ class SwatCalendar extends SwatControl
 			'packages/swat/javascript/swat-z-index-manager.js'
 		);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this calendar widget
@@ -93,9 +86,6 @@ class SwatCalendar extends SwatControl
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this calendar widget
 	 *
@@ -108,9 +98,6 @@ class SwatCalendar extends SwatControl
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets inline calendar JavaScript
@@ -151,9 +138,6 @@ class SwatCalendar extends SwatControl
 
 		return $javascript;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScriptTranslations()
 
 	/**
 	 * Gets translatable string resources for the JavaScript object for
@@ -209,7 +193,6 @@ class SwatCalendar extends SwatControl
 			"SwatCalendar.close_toggle_text = '{$close_toggle_text}';\n";
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCascadeFlydown.php
+++ b/Swat/SwatCascadeFlydown.php
@@ -14,7 +14,6 @@
  */
 class SwatCascadeFlydown extends SwatFlydown
 {
-	// {{{ public properties
 
 	/**
 	 * Flydown options
@@ -42,9 +41,6 @@ class SwatCascadeFlydown extends SwatFlydown
 	 */
 	public $cascade_from = null;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new calendar
 	 *
@@ -64,9 +60,6 @@ class SwatCascadeFlydown extends SwatFlydown
 		$this->addJavaScript('packages/swat/javascript/swat-cascade.js');
 	}
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this cascading flydown
 	 *
@@ -80,9 +73,6 @@ class SwatCascadeFlydown extends SwatFlydown
 		parent::display();
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
-
-	// }}}
-	// {{{ public function addOption()
 
 	/**
 	 * Adds an option to this option control
@@ -115,9 +105,6 @@ class SwatCascadeFlydown extends SwatFlydown
 		$this->options[$parent][] = $option;
 	}
 
-	// }}}
-	// {{{ public function addOptionsByArray()
-
 	/**
 	 * Adds options to this option control using an associative array
 	 *
@@ -137,9 +124,6 @@ class SwatCascadeFlydown extends SwatFlydown
 				$this->addOption($parent, $value, $title, $content_type);
 		}
 	}
-
-	// }}}
-	// {{{ protected function getOptions()
 
 	/**
 	 * Gets the options of this flydown as a flat array
@@ -188,17 +172,11 @@ class SwatCascadeFlydown extends SwatFlydown
 		return $options;
 	}
 
-	// }}}
-	// {{{ protected function getParentValue()
-
 	protected function getParentValue()
 	{
 		return ($this->cascade_from instanceof SwatFlydown) ?
 			$this->cascade_from->value : null;
 	}
-
-	// }}}
-	// {{{ protected function getParentOptions()
 
 	protected function getParentOptions()
 	{
@@ -206,25 +184,16 @@ class SwatCascadeFlydown extends SwatFlydown
 			$this->cascade_from->getOptions() : array();
 	}
 
-	// }}}
-	// {{{ protected function hasEmptyParent()
-
 	protected function hasEmptyParent()
 	{
 		return (count($this->getParentOptions()) === 0);
 	}
-
-	// }}}
-	// {{{ protected function hasSingleParent()
 
 	protected function hasSingleParent()
 	{
 		return ((count($this->getParentOptions()) === 1) &&
 			$this->cascade_from->show_blank == false);
 	}
-
-	// }}}
-	// {{{ protected function getBlankOption()
 
 	protected function getBlankOption()
 	{
@@ -233,9 +202,6 @@ class SwatCascadeFlydown extends SwatFlydown
 
 		return new SwatFlydownBlankOption(null, $blank_title);
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript that makes this control work
@@ -316,7 +282,6 @@ class SwatCascadeFlydown extends SwatFlydown
 		return $javascript;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCellRenderer.php
+++ b/Swat/SwatCellRenderer.php
@@ -11,7 +11,6 @@
  */
 abstract class SwatCellRenderer extends SwatUIObject
 {
-	// {{{ public properties
 
 	/**
 	 * A non-visible unique id for this cell renderer, or null
@@ -31,9 +30,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 	 * @var boolean
 	 */
 	public $sensitive = true;
-
-	// }}}
-	// {{{ private properties
 
 	/**
 	 * An array containing the static properties of this cell renderer
@@ -69,9 +65,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 	 */
 	private $composite_renderers_created = false;
 
-	// }}}
-	// {{{ public function render()
-
 	/**
 	 * Renders this cell
 	 *
@@ -85,9 +78,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 		$this->render_count++;
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Called during the init phase
 	 *
@@ -100,9 +90,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 		}
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Called during processing phase
 	 *
@@ -114,9 +101,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 			$renderer->process();
 		}
 	}
-
-	// }}}
-	// {{{ public function getMessages()
 
 	/**
 	 * Gathers all messages from this cell renderer
@@ -131,9 +115,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 		return array();
 	}
 
-	// }}}
-	// {{{ public function hasMessage()
-
 	/**
 	 * Gets whether or not this cell renderer has messages
 	 *
@@ -147,9 +128,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 	{
 		return false;
 	}
-
-	// }}}
-	// {{{ public function getPropertyNameToMap()
 
 	/**
 	 * Get a property name to use for mapping
@@ -174,9 +152,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 		return $name;
 	}
 
-	// }}}
-	// {{{ public function getInlineJavaScript()
-
 	/**
 	 * Gets ths inline JavaScript required by this cell renderer
 	 *
@@ -186,9 +161,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 	{
 		return '';
 	}
-
-	// }}}
-	// {{{ public function getBaseCSSClassNames()
 
 	/**
 	 * Gets the base CSS class names for this cell renderer
@@ -203,9 +175,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 		return array();
 	}
 
-	// }}}
-	// {{{ public function getDataSpecificCSSClassNames()
-
 	/**
 	 * Gets the data specific CSS class names for this cell renderer
 	 *
@@ -219,9 +188,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 	{
 		return array();
 	}
-
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this cell renderer
@@ -243,9 +209,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this cell
 	 * renderer
@@ -257,9 +220,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 	{
 		return new SwatHtmlHeadEntrySet($this->html_head_entry_set);
 	}
-
-	// }}}
-	// {{{ public function isPropertyStatic()
 
 	/**
 	 * Checks if a public property is static (can not be data-mapped)
@@ -278,9 +238,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 	{
 		return (in_array($property_name, $this->static_properties));
 	}
-
-	// }}}
-	// {{{ public final function getInheritanceCSSClassNames()
 
 	/**
 	 * Gets the CSS class names of this cell renderer based on the inheritance
@@ -331,9 +288,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 		return $css_class_names;
 	}
 
-	// }}}
-	// {{{ protected function createCompositeRenderers()
-
 	/**
 	 * Creates and adds composite renderers of this renderer
 	 *
@@ -343,9 +297,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 	protected function createCompositeRenderers()
 	{
 	}
-
-	// }}}
-	// {{{ protected final function addCompositeRenderer()
 
 	/**
 	 * Adds a composite a renderer to this renderer
@@ -378,9 +329,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 		$renderer->parent = $this;
 	}
 
-	// }}}
-	// {{{ protected final function getCompositeRenderer()
-
 	/**
 	 * Gets a composite renderer of this renderer by the composite renderer's
 	 * key
@@ -409,9 +357,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 
 		return $this->composite_renderers[$key];
 	}
-
-	// }}}
-	// {{{ protected final function getCompositeRenderers()
 
 	/**
 	 * Gets all composite renderers added to this renderer
@@ -445,9 +390,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 		return $out;
 	}
 
-	// }}}
-	// {{{ protected final function confirmCompositeRenderers()
-
 	/**
 	 * Confirms composite renderers have been created
 	 *
@@ -468,9 +410,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 			$this->composite_renderers_created = true;
 		}
 	}
-
-	// }}}
-	// {{{ protected final function makePropertyStatic()
 
 	/**
 	 * Make a public property static
@@ -507,7 +446,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCellRendererContainer.php
+++ b/Swat/SwatCellRendererContainer.php
@@ -10,7 +10,6 @@
 abstract class SwatCellRendererContainer extends SwatUIObject implements
 	SwatUIParent
 {
-	// {{{ protected properties
 
 	/**
 	 * The set of SwatCellRenderer objects contained in this container
@@ -18,9 +17,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 	 * @var SwatCellRendererSet
 	 */
 	protected $renderers = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new cell renderer container
@@ -30,9 +26,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 		parent::__construct();
 		$this->renderers = new SwatCellRendererSet();
 	}
-
-	// }}}
-	// {{{ public function addMappingToRenderer()
 
 	/**
 	 * Links a data-field to a cell renderer property of a cell renderer
@@ -72,9 +65,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 		return $mapping;
 	}
 
-	// }}}
-	// {{{ public function addRenderer()
-
 	/**
 	 * Adds a cell renderer to this container's set of renderers
 	 *
@@ -85,9 +75,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 		$this->renderers->addRenderer($renderer);
 		$renderer->parent = $this;
 	}
-
-	// }}}
-	// {{{ public function getRenderers()
 
 	/**
 	 * Gets the cell renderers of this container
@@ -103,9 +90,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 
 		return $out;
 	}
-
-	// }}}
-	// {{{ public function getRenderer()
 
 	/**
 	 * Gets a cell renderer of this container by its unique identifier
@@ -124,9 +108,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 		return $this->renderers->getRenderer($renderer_id);
 	}
 
-	// }}}
-	// {{{ public function getRendererByPosition()
-
 	/**
 	 * Gets a cell renderer in this container based on its ordinal position
 	 *
@@ -144,9 +125,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 		return $this->renderers->getRendererByPosition($position);
 	}
 
-	// }}}
-	// {{{ public function getFirstRenderer()
-
 	/**
 	 * Gets the first cell renderer in this container
 	 *
@@ -158,9 +136,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 	{
 		return $this->renderers->getFirst();
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Add a child object to this object
@@ -181,9 +156,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 				'Only SwatCellRender objects may be nested within '.
 				get_class($this).' objects.', 0, $child);
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -222,9 +194,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -258,9 +227,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -280,9 +246,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -298,9 +261,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this cell renderer
@@ -323,9 +283,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this cell
 	 * renderer container
@@ -346,9 +303,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getRendererInlineJavaScript()
-
 	/**
 	 * Gets inline JavaScript used by all cell renderers within this cell
 	 * renderer container
@@ -368,9 +322,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 
 		return $javascript;
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -405,7 +356,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements
 		return $copy;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCellRendererMapping.php
+++ b/Swat/SwatCellRendererMapping.php
@@ -9,7 +9,6 @@
  */
 class SwatCellRendererMapping extends SwatObject
 {
-	// {{{ public properties
 
 	/**
 	 * The name of the property.
@@ -39,9 +38,6 @@ class SwatCellRendererMapping extends SwatObject
 	 */
 	public $array_key = null;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Create a new mapping object
 	 *
@@ -54,7 +50,6 @@ class SwatCellRendererMapping extends SwatObject
 		$this->field = $field;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCellRendererSet.php
+++ b/Swat/SwatCellRendererSet.php
@@ -9,7 +9,6 @@
  */
 class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 {
-	// {{{ private properties
 
 	/**
 	 * Cell renderers of this set indexed numerically
@@ -50,9 +49,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 	 */
 	private $mappings_applied = false;
 
-	// }}}
-	// {{{ public function addRenderer()
-
 	/**
 	 * Adds a cell renderer to this set
 	 *
@@ -72,9 +68,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 			$this->renderers_by_id[$renderer->id] = $renderer;
 	}
 
-	// }}}
-	// {{{ public function addRendererWithMappings()
-
 	/**
 	 * Adds a cell renderer to this set with a predefined set of
 	 * datafield-property mappings
@@ -92,9 +85,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 		$this->addRenderer($renderer);
 		$this->addMappingsToRenderer($renderer, $mappings);
 	}
-
-	// }}}
-	// {{{ public function addMappingsToRenderer()
 
 	/**
 	 * Adds a set of datafield-property mappings to a cell renderer already in
@@ -123,9 +113,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 		}
 	}
 
-	// }}}
-	// {{{ public function addMappingToRenderer()
-
 	/**
 	 * Adds a single property-datafield mapping to a cell renderer already in
 	 * this set
@@ -148,9 +135,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 		$renderer_key = spl_object_hash($renderer);
 		$this->mappings[$renderer_key][] = $mapping;
 	}
-
-	// }}}
-	// {{{ public function applyMappingsToRenderer()
 
 	/**
 	 * Applies the property-datafield mappings to a cell renderer already in
@@ -209,9 +193,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 		$this->mappings_applied = true;
 	}
 
-	// }}}
-	// {{{ public function getRendererByPosition()
-
 	/**
 	 * Gets a cell renderer in this set by its ordinal position
 	 *
@@ -232,9 +213,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 			'Set does not contain that many renderers.',
 			0, $position);
 	}
-
-	// }}}
-	// {{{ public function getRenderer()
 
 	/**
 	 * Gets a renderer in this set by its id
@@ -258,9 +236,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 			0, $renderer_id);
 	}
 
-	// }}}
-	// {{{ public function getMappingsByRenderer()
-
 	/**
 	 * Gets the mappings of a cell renderer already in this set
 	 *
@@ -276,9 +251,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 		return $this->mappings[$renderer_key];
 	}
 
-	// }}}
-	// {{{ public function mappingsApplied()
-
 	/**
 	 * Whether or not mappings have been applied to this cell-renderer set
 	 *
@@ -293,9 +265,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 		return $this->mappings_applied;
 	}
 
-	// }}}
-	// {{{ public function current()
-
 	/**
 	 * Returns the current renderer
 	 *
@@ -305,9 +274,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 	{
 		return $this->renderers[$this->current_index];
 	}
-
-	// }}}
-	// {{{ public function key()
 
 	/**
 	 * Returns the key of the current renderer
@@ -319,9 +285,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 		return $this->current_index;
 	}
 
-	// }}}
-	// {{{ public function next()
-
 	/**
 	 * Moves forward to the next renderer
 	 */
@@ -330,9 +293,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 		$this->current_index++;
 	}
 
-	// }}}
-	// {{{ public function rewind()
-
 	/**
 	 * Rewinds this iterator to the first renderer
 	 */
@@ -340,9 +300,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 	{
 		$this->current_index = 0;
 	}
-
-	// }}}
-	// {{{ public function valid()
 
 	/**
 	 * Checks is there is a current renderer after calls to rewind() and next()
@@ -354,9 +311,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 	{
 		return array_key_exists($this->current_index, $this->renderers);
 	}
-
-	// }}}
-	// {{{ public function getFirst()
 
 	/**
 	 * Gets the first renderer in this set
@@ -374,9 +328,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 		return $first;
 	}
 
-	// }}}
-	// {{{ public function getCount()
-
 	/**
 	 * Gets the number of renderers in this set
 	 *
@@ -390,9 +341,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 		return count($this);
 	}
 
-	// }}}
-	// {{{ public function count()
-
 	/**
 	 * Gets the number of cell renderers in this set
 	 *
@@ -405,7 +353,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 		return count($this->renderers);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatChangeOrder.php
+++ b/Swat/SwatChangeOrder.php
@@ -15,7 +15,6 @@
  */
 class SwatChangeOrder extends SwatOptionControl implements SwatState
 {
-	// {{{ public properties
 
 	/**
 	 * Value ordered array
@@ -41,9 +40,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
 	 */
 	public $height = '180px';
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new change-order widget
 	 *
@@ -65,9 +61,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
 			'packages/swat/javascript/swat-z-index-manager.js'
 		);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this change-order control
@@ -131,9 +124,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	public function process()
 	{
 		parent::process();
@@ -152,9 +142,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
 		}
 	}
 
-	// }}}
-	// {{{ public function getNote()
-
 	/**
 	 * Gets a note letting the user know drag-and-drop is available for
 	 * ordering items
@@ -172,9 +159,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
 		return new SwatMessage($message);
 	}
 
-	// }}}
-	// {{{ public function getState()
-
 	public function getState()
 	{
 		if ($this->values === null)
@@ -183,16 +167,10 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
 			return $this->values;
 	}
 
-	// }}}
-	// {{{ public function setState()
-
 	public function setState($state)
 	{
 		$this->values = $state;
 	}
-
-	// }}}
-	// {{{ public function getOrderedOptions()
 
 	/**
 	 * Gets the options of this change-order control ordered by the
@@ -230,9 +208,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
 		return $ordered_options;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this change-order
 	 * widget
@@ -248,9 +223,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets the inline JavaScript required by this change-order control
 	 *
@@ -264,9 +236,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
 			$this->id,
 			$this->isSensitive() ? 'true' : 'false');
 	}
-
-	// }}}
-	// {{{ private function displayButtons()
 
 	private function displayButtons()
 	{
@@ -312,7 +281,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
 		$buttons_div->close();
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCheckAll.php
+++ b/Swat/SwatCheckAll.php
@@ -9,7 +9,6 @@
  */
 class SwatCheckAll extends SwatCheckbox
 {
-	// {{{ public properties
 
 	/**
 	 * Optional checkbox label title
@@ -57,9 +56,6 @@ class SwatCheckAll extends SwatCheckbox
 	 */
 	public $unit;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new check-all widget
 	 *
@@ -78,9 +74,6 @@ class SwatCheckAll extends SwatCheckbox
 		$this->addJavaScript('packages/swat/javascript/swat-check-all.js');
 	}
 
-	// }}}
-	// {{{ public function isExtendedSelected()
-
 	/**
 	 * Whether or not the extended-checkbox was checked
 	 *
@@ -90,9 +83,6 @@ class SwatCheckAll extends SwatCheckbox
 	{
 		return $this->getCompositeWidget('extended_checkbox')->value;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this check-all widget
@@ -137,9 +127,6 @@ class SwatCheckAll extends SwatCheckbox
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ protected function getExtendedTitle()
-
 	protected function getExtendedTitle()
 	{
 		$locale = SwatI18NLocale::get();
@@ -168,9 +155,6 @@ class SwatCheckAll extends SwatCheckbox
 			$checkbox_display);
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this check-all widget
 	 *
@@ -184,9 +168,6 @@ class SwatCheckAll extends SwatCheckbox
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets the inline JavaScript for this check-all widget
 	 *
@@ -199,16 +180,12 @@ class SwatCheckAll extends SwatCheckbox
 
 	}
 
-	// }}}
-	// {{{ protected function createCompositeWidgets()
-
 	protected function createCompositeWidgets()
 	{
 		$extended_checkbox = new SwatCheckbox();
 		$this->addCompositeWidget($extended_checkbox, 'extended_checkbox');
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCheckbox.php
+++ b/Swat/SwatCheckbox.php
@@ -9,7 +9,6 @@
  */
 class SwatCheckbox extends SwatInputControl implements SwatState
 {
-	// {{{ public properties
 
 	/**
 	 * Checkbox value
@@ -40,9 +39,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
 	 */
 	public $tab_index;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new checkbox
 	 *
@@ -55,9 +51,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
 		parent::__construct($id);
 		$this->requires_id = true;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this checkbox
@@ -94,9 +87,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
 		echo '</span>';
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this checkbox
 	 *
@@ -113,9 +103,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
 		$this->value = array_key_exists($this->id, $data);
 	}
 
-	// }}}
-	// {{{ public function getState()
-
 	/**
 	 * Gets the current state of this checkbox
 	 *
@@ -128,9 +115,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
 		return $this->value;
 	}
 
-	// }}}
-	// {{{ public function setState()
-
 	/**
 	 * Sets the current state of this checkbox
 	 *
@@ -142,9 +126,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
 	{
 		$this->value = $state;
 	}
-
-	// }}}
-	// {{{ public function getFocusableHtmlId()
 
 	/**
 	 * Gets the id attribute of the XHTML element displayed by this widget
@@ -161,9 +142,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
 		return ($this->visible) ? $this->id : null;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this checkbox
 	 *
@@ -177,7 +155,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCheckboxCellRenderer.php
+++ b/Swat/SwatCheckboxCellRenderer.php
@@ -11,7 +11,6 @@
 class SwatCheckboxCellRenderer extends SwatCellRenderer
 	implements SwatViewSelector
 {
-	// {{{ public properties
 
 	/**
 	 * Identifier of this checkbox cell renderer
@@ -64,9 +63,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer
 	 */
 	public $tab_index;
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * Array of selected values populated during the processing of this cell
 	 * renderer
@@ -77,9 +73,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer
 	 * @var array
 	 */
 	private $selected_values = array();
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new checkbox cell renderer
@@ -100,9 +93,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer
 		$this->id = $this->getUniqueId();
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this checkbox cell renderer
 	 */
@@ -122,9 +112,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer
 			}
 		}
 	}
-
-	// }}}
-	// {{{ public function render()
 
 	/**
 	 * Renders this checkbox cell renderer
@@ -171,9 +158,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer
 		}
 	}
 
-	// }}}
-	// {{{ public function getId()
-
 	/**
 	 * Gets the identifier of this checkbox cell renderer
 	 *
@@ -185,9 +169,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer
 	{
 		return $this->id;
 	}
-
-	// }}}
-	// {{{ public function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript required by this checkbox cell renderer
@@ -208,9 +189,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer
 
 		return $javascript;
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -233,9 +211,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer
 		return $copy;
 	}
 
-	// }}}
-	// {{{ private function getForm()
-
 	/**
 	 * Gets the form this checkbox cell renderer is contained in
 	 *
@@ -255,7 +230,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer
 		return $form;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCheckboxEntryList.php
+++ b/Swat/SwatCheckboxEntryList.php
@@ -19,7 +19,6 @@
  */
 class SwatCheckboxEntryList extends SwatCheckboxList
 {
-	// {{{ public properties
 
 	/**
 	 * The size of all the embedded entry widgets
@@ -42,9 +41,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 	 */
 	public $entry_maxlength = null;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * The entry widgets used by this checkbox entry list
 	 *
@@ -53,9 +49,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 	 * @var array
 	 */
 	protected $entry_widgets = array();
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new checkbox entry list
@@ -79,9 +72,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 			'packages/swat/styles/swat-checkbox-entry-list.css'
 		);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this checkbox list
@@ -164,9 +154,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this checkbox entry list
 	 *
@@ -185,9 +172,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 		foreach ($this->values as $option_value)
 			$this->getEntryWidget($option_value)->process();
 	}
-
-	// }}}
-	// {{{ public function getMessages()
 
 	/**
 	 * Gets all messages
@@ -208,9 +192,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 
 		return $messages;
 	}
-
-	// }}}
-	// {{{ public function hasMessage()
 
 	/**
 	 * Checks for the presence of messages
@@ -237,9 +218,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 		return $has_message;
 	}
 
-	// }}}
-	// {{{ public function getEntryValue()
-
 	/**
 	 * Gets the value of an entry widget in this checkbox entry list
 	 *
@@ -259,9 +237,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 
 		return $entry_value;
 	}
-
-	// }}}
-	// {{{ public function setEntryValue()
 
 	/**
 	 * Sets the value of an entry widget in this checkbox entry list
@@ -291,9 +266,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 		$this->getEntryWidget($option_value)->getFirst()->value = $entry_value;
 	}
 
-	// }}}
-	// {{{ public function setEntryValuesByArray()
-
 	/**
 	 * Sets the values of multiple entry widgets
 	 *
@@ -316,9 +288,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 			$this->setEntryValue($option_value, $entry_value);
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets the inline JavaScript for this checkbox entry list
 	 *
@@ -338,9 +307,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 		return $javascript;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this checkbox entry
 	 * list
@@ -355,9 +321,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function hasEntryWidget()
-
 	/**
 	 * Checks if this checkbox entry list has an entry widget for a given
 	 * option value
@@ -371,9 +334,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 	{
 		return isset($this->entry_widgets[$option_value]);
 	}
-
-	// }}}
-	// {{{ protected function getEntryWidget()
 
 	/**
 	 * Gets a widget tree for the entry widget of this checkbox entry list
@@ -401,9 +361,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 		return $this->entry_widgets[$option_value];
 	}
 
-	// }}}
-	// {{{ protected function createEntryWidget()
-
 	/**
 	 * Creates an entry widget of this checkbox entry list
 	 *
@@ -422,7 +379,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 		return $widget;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCheckboxList.php
+++ b/Swat/SwatCheckboxList.php
@@ -9,7 +9,6 @@
  */
 class SwatCheckboxList extends SwatOptionControl implements SwatState
 {
-	// {{{ private properties
 
 	/**
 	 * Used for displaying checkbox labels
@@ -17,9 +16,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 	 * @var SwatHtmlTag
 	 */
 	private $label_tag;
-
-	// }}}
-	// {{{ public properties
 
 	/**
 	 * List values
@@ -52,9 +48,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 	 */
 	public $columns = 1;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new checkbox list
 	 *
@@ -71,9 +64,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 		$this->addJavaScript('packages/swat/javascript/swat-checkbox-list.js');
 		$this->addStyleSheet('packages/swat/styles/swat.css');
 	}
-
-	// }}}
-	// {{{ public function init()
 
 	/**
 	 * Initializes this checkbox list
@@ -95,9 +85,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 					'found in %s', $this->id));
 		}
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this checkbox list
@@ -174,9 +161,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this checkbox list widget
 	 */
@@ -195,9 +179,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 		}
 	}
 
-	// }}}
-	// {{{ public function reset()
-
 	/**
 	 * Reset this checkbox list.
 	 *
@@ -208,9 +189,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 	{
 		$this->values = array();
 	}
-
-	// }}}
-	// {{{ public function setState()
 
 	/**
 	 * Sets the current state of this checkbox list
@@ -224,9 +202,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 		$this->values = $state;
 	}
 
-	// }}}
-	// {{{ public function getState()
-
 	/**
 	 * Gets the current state of this checkbox list
 	 *
@@ -238,9 +213,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 	{
 		return $this->values;
 	}
-
-	// }}}
-	// {{{ protected function processValues()
 
 	/**
 	 * Processes the values of this checkbox list from raw form data
@@ -262,9 +234,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 			$this->values = array();
 		}
 	}
-
-	// }}}
-	// {{{ protected function displayOption()
 
 	/**
 	 * Helper method to display a single option of this checkbox list
@@ -299,9 +268,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 		$li_tag->close();
 	}
 
-	// }}}
-	// {{{ protected function displayOptionLabel()
-
 	/**
 	 * Displays an option in the checkbox list
 	 *
@@ -320,9 +286,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 		$this->label_tag->setContent($option->title, $option->content_type);
 		$this->label_tag->display();
 	}
-
-	// }}}
-	// {{{ protected function getLiTag()
 
 	protected function getLiTag(SwatOption $option)
 	{
@@ -347,9 +310,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 
 		return $tag;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript for this checkbox list
@@ -376,9 +336,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 		return $javascript;
 	}
 
-	// }}}
-	// {{{ protected function getJavaScriptClassName()
-
 	/**
 	 * Get the name of the JavaScript class for this widget
 	 *
@@ -388,9 +345,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 	{
 		return 'SwatCheckboxList';
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this checkbox list
@@ -405,9 +359,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function createCompositeWidgets()
-
 	/**
 	 * Creates and adds composite widgets of this widget
 	 *
@@ -419,7 +370,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 		$this->addCompositeWidget(new SwatCheckAll(), 'check_all');
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCheckboxTree.php
+++ b/Swat/SwatCheckboxTree.php
@@ -9,7 +9,6 @@
  */
 class SwatCheckboxTree extends SwatCheckboxList implements SwatState
 {
-	// {{{ protected properties
 
 	/**
 	 * Checkbox tree structure
@@ -39,9 +38,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
 	 */
 	protected $input_tag = null;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new checkbox list
 	 *
@@ -54,9 +50,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
 		parent::__construct($id);
 		$this->setTree(new SwatDataTreeNode(null, 'root'));
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	public function display()
 	{
@@ -95,9 +88,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function setTree()
-
 	/**
 	 * Sets the tree to use for display
 	 *
@@ -107,9 +97,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
 	{
 		$this->tree = $tree;
 	}
-
-	// }}}
-	// {{{ public function getTree()
 
 	/**
 	 * Gets the tree collection of {@link SwatTreeNode} objects for this
@@ -121,9 +108,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
 	{
 		return $this->tree;
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this checkbox tree
@@ -137,9 +121,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ private function displayNode()
 
 	/**
 	 * Displays a node in a tree as a checkbox input
@@ -211,7 +192,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
 		return $nodes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatColorEntry.php
+++ b/Swat/SwatColorEntry.php
@@ -15,7 +15,6 @@
  */
 class SwatColorEntry extends SwatInputControl implements SwatState
 {
-	// {{{ public properties
 
 	/**
 	 * Selected color of this widget in hexidecimal representation
@@ -32,9 +31,6 @@ class SwatColorEntry extends SwatInputControl implements SwatState
 	 * @var string
 	 */
 	public $access_key = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new color entry widget
@@ -55,9 +51,6 @@ class SwatColorEntry extends SwatInputControl implements SwatState
 			'packages/swat/javascript/swat-z-index-manager.js'
 		);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this color selection widget
@@ -108,9 +101,6 @@ class SwatColorEntry extends SwatInputControl implements SwatState
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this color entry widget
 	 *
@@ -141,9 +131,6 @@ class SwatColorEntry extends SwatInputControl implements SwatState
 		}
 	}
 
-	// }}}
-	// {{{ public function getState()
-
 	/**
 	 * Gets the current state of this color selector
 	 *
@@ -159,9 +146,6 @@ class SwatColorEntry extends SwatInputControl implements SwatState
 			return $this->value;
 	}
 
-	// }}}
-	// {{{ public function setState()
-
 	/**
 	 * Sets the current state of this color selector
 	 *
@@ -175,9 +159,6 @@ class SwatColorEntry extends SwatInputControl implements SwatState
 		if (preg_match($hex_color, $state) === 1)
 			$this->value = $state;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript required for this control to function
@@ -193,9 +174,6 @@ class SwatColorEntry extends SwatInputControl implements SwatState
 		return "var {$this->id}_obj = new SwatColorEntry('{$this->id}');";
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this color entry
 	 * widget
@@ -209,9 +187,6 @@ class SwatColorEntry extends SwatInputControl implements SwatState
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ private function displayPalette()
 
 	/**
 	 * Displays the color palette XHTML
@@ -304,7 +279,6 @@ class SwatColorEntry extends SwatInputControl implements SwatState
 		$wrapper_div->close();
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatCommentHtmlHeadEntry.php
+++ b/Swat/SwatCommentHtmlHeadEntry.php
@@ -9,12 +9,8 @@
  */
 class SwatCommentHtmlHeadEntry extends SwatHtmlHeadEntry
 {
-	// {{{ protected properties
 
 	protected $comment;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new HTML head entry
@@ -27,9 +23,6 @@ class SwatCommentHtmlHeadEntry extends SwatHtmlHeadEntry
 		$this->comment = $comment;
 	}
 
-	// }}}
-	// {{{ protected function displayInternal()
-
 	protected function displayInternal($uri_prefix = '', $tag = null)
 	{
 		// double dashes are not allowed in XML comments
@@ -37,15 +30,11 @@ class SwatCommentHtmlHeadEntry extends SwatHtmlHeadEntry
 		printf('<!-- %s -->', $comment);
 	}
 
-	// }}}
-	// {{{ protected function displayInlineInternal()
-
 	protected function displayInlineInternal($path)
 	{
 		$this->displayInternal();
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatConfirmEmailEntry.php
+++ b/Swat/SwatConfirmEmailEntry.php
@@ -12,7 +12,6 @@
  */
 class SwatConfirmEmailEntry extends SwatEmailEntry
 {
-	// {{{ public properties
 
 	/**
 	 * A reference to the matching email entry widget
@@ -20,9 +19,6 @@ class SwatConfirmEmailEntry extends SwatEmailEntry
 	 * @var SwatEmailEntry
 	 */
 	public $email_widget = null;
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Checks to make sure email addresses match
@@ -54,9 +50,6 @@ class SwatConfirmEmailEntry extends SwatEmailEntry
 		}
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
 	 *
@@ -70,7 +63,6 @@ class SwatConfirmEmailEntry extends SwatEmailEntry
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatConfirmPasswordEntry.php
+++ b/Swat/SwatConfirmPasswordEntry.php
@@ -12,7 +12,6 @@
  */
 class SwatConfirmPasswordEntry extends SwatPasswordEntry
 {
-	// {{{ public properties
 
 	/**
 	 * A reference to the matching password widget
@@ -20,9 +19,6 @@ class SwatConfirmPasswordEntry extends SwatPasswordEntry
 	 * @var SwatPasswordEntry
 	 */
 	public $password_widget = null;
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Checks to make sure passwords match
@@ -51,9 +47,6 @@ class SwatConfirmPasswordEntry extends SwatPasswordEntry
 		}
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
 	 *
@@ -67,7 +60,6 @@ class SwatConfirmPasswordEntry extends SwatPasswordEntry
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatConfirmationButton.php
+++ b/Swat/SwatConfirmationButton.php
@@ -14,7 +14,6 @@
  */
 class SwatConfirmationButton extends SwatButton
 {
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new confirmation button widget
@@ -29,7 +28,6 @@ class SwatConfirmationButton extends SwatButton
 			Swat::_('Are you sure you wish to continue?');
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatContainer.php
+++ b/Swat/SwatContainer.php
@@ -11,7 +11,6 @@
  */
 class SwatContainer extends SwatWidget implements SwatUIParent
 {
-	// {{{ protected properties
 
 	/**
 	 * Children widgets
@@ -32,9 +31,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 	 */
 	protected $children_by_id = array();
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this widget
 	 *
@@ -50,9 +46,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 			$child_widget->init();
 	}
 
-	// }}}
-	// {{{ public function add()
-
 	/**
 	 * Adds a widget
 	 *
@@ -66,9 +59,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 	{
 		$this->packEnd($widget);
 	}
-
-	// }}}
-	// {{{ public function replace()
 
 	/**
 	 * Replace a widget
@@ -102,9 +92,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		return null;
 	}
 
-	// }}}
-	// {{{ public function remove()
-
 	/**
 	 * Removes a widget
 	 *
@@ -134,9 +121,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		return null;
 	}
 
-	// }}}
-	// {{{ public function packStart()
-
 	/**
 	 * Adds a widget to start
 	 *
@@ -158,9 +142,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
 		$this->sendAddNotifySignal($widget);
 	}
-
-	// }}}
-	// {{{ public function insertBefore()
 
 	/**
 	 * Adds a widget to this container before another widget
@@ -198,9 +179,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		$this->sendAddNotifySignal($widget);
 	}
 
-	// }}}
-	// {{{ public function packEnd()
-
 	/**
 	 * Adds a widget to end
 	 *
@@ -223,9 +201,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		$this->sendAddNotifySignal($widget);
 	}
 
-	// }}}
-	// {{{ public function getChild()
-
 	/**
 	 * Gets a child widget
 	 *
@@ -243,9 +218,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		else
 			return null;
 	}
-
-	// }}}
-	// {{{ public function getFirst()
 
 	/**
 	 * Gets the first child widget
@@ -265,9 +237,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 			return null;
 		}
 	}
-
-	// }}}
-	// {{{ public function getChildren()
 
 	/**
 	 * Gets all child widgets
@@ -293,9 +262,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
 		return $out;
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -334,9 +300,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -370,9 +333,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -392,9 +352,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -411,9 +368,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 				$object->setState($states[$id]);
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this container by calling {@link SwatWidget::process()} on all
 	 * children
@@ -428,9 +382,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this container by calling {@link SwatWidget::display()} on all
 	 * children
@@ -444,9 +395,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
 		$this->displayChildren();
 	}
-
-	// }}}
-	// {{{ public function getMessages()
 
 	/**
 	 * Gets all messages
@@ -464,9 +412,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
 		return $messages;
 	}
-
-	// }}}
-	// {{{ public function hasMessage()
 
 	/**
 	 * Checks for the presence of messages
@@ -492,9 +437,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		return $has_message;
 	}
 
-	// }}}
-	// {{{ public function addChild()
-
 	/**
 	 * Adds a child object
 	 *
@@ -519,9 +461,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this container
 	 *
@@ -541,9 +480,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this container
 	 *
@@ -562,9 +498,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function getFocusableHtmlId()
 
 	/**
 	 * Gets the id attribute of the XHTML element displayed by this widget
@@ -592,9 +525,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		return $focus_id;
 	}
 
-	// }}}
-	// {{{ public function printWidgetTree()
-
 	public function printWidgetTree()
 	{
 		echo get_class($this), ' ', $this->id;
@@ -610,9 +540,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 			echo '</ul>';
 		}
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -642,9 +569,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 		return $copy;
 	}
 
-	// }}}
-	// {{{ protected function displayChildren()
-
 	/**
 	 * Displays the child widgets of this container
 	 *
@@ -657,9 +581,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 			$child->display();
 	}
 
-	// }}}
-	// {{{ protected function notifyOfAdd()
-
 	/**
 	 * Notifies this widget that a widget was added
 	 *
@@ -671,9 +592,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 	protected function notifyOfAdd($widget)
 	{
 	}
-
-	// }}}
-	// {{{ protected function sendAddNotifySignal()
 
 	/**
 	 * Sends the notification signal up the widget tree
@@ -691,7 +609,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 			$this->parent->sendAddNotifySignal($widget);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatContentBlock.php
+++ b/Swat/SwatContentBlock.php
@@ -9,7 +9,6 @@
  */
 class SwatContentBlock extends SwatControl
 {
-	// {{{ public properties
 
 	/**
 	 * User visible textual content of this widget
@@ -26,9 +25,6 @@ class SwatContentBlock extends SwatControl
 	 * @var string
 	 */
 	public $content_type = 'text/plain';
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this content
@@ -48,7 +44,6 @@ class SwatContentBlock extends SwatControl
 			echo $this->content;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatControl.php
+++ b/Swat/SwatControl.php
@@ -9,7 +9,6 @@
  */
 abstract class SwatControl extends SwatWidget
 {
-	// {{{ public function addMessage()
 
 	/**
 	 * Adds a message to this control
@@ -54,16 +53,10 @@ abstract class SwatControl extends SwatWidget
 		parent::addMessage($message);
 	}
 
-	// }}}
-	// {{{ public function printWidgetTree()
-
 	public function printWidgetTree()
 	{
 		echo get_class($this), ' ', $this->id;
 	}
-
-	// }}}
-	// {{{ public function getNote()
 
 	/**
 	 * Gets an informative note of how to use this control
@@ -78,7 +71,6 @@ abstract class SwatControl extends SwatWidget
 		return null;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatDataTreeNode.php
+++ b/Swat/SwatDataTreeNode.php
@@ -9,7 +9,6 @@
  */
 class SwatDataTreeNode extends SwatTreeNode
 {
-	// {{{ public properties
 
 	/**
 	 * The value of this node
@@ -29,9 +28,6 @@ class SwatDataTreeNode extends SwatTreeNode
 	 */
 	public $title;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new data node
 	 *
@@ -45,7 +41,6 @@ class SwatDataTreeNode extends SwatTreeNode
 		$this->title = $title;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatDate.php
+++ b/Swat/SwatDate.php
@@ -14,7 +14,6 @@
  */
 class SwatDate extends DateTime implements Serializable
 {
-	// {{{ time zone format constants
 
 	/**
 	 * America/Halifax
@@ -61,9 +60,6 @@ class SwatDate extends DateTime implements Serializable
 	 * @deprecated
 	 */
 	const TZ_CURRENT_LONG           = 8;
-
-	// }}}
-	// {{{ date format constants
 
 	/**
 	 * 07/02/02
@@ -150,9 +146,6 @@ class SwatDate extends DateTime implements Serializable
 	 */
 	const DF_RFC_2822               = 17;
 
-	// }}}
-	// {{{ ISO 8601 option constants
-
 	/**
 	 * Value to use for no options.
 	 *
@@ -184,9 +177,6 @@ class SwatDate extends DateTime implements Serializable
 	 */
 	const ISO_TIME_ZONE = 4;
 
-	// }}}
-	// {{{ date interval part constants
-
 	/**
 	 * A set of bitwise contants to control which parts of the interval we want
 	 * when returning a DateInterval.
@@ -200,9 +190,6 @@ class SwatDate extends DateTime implements Serializable
 	const DI_HOURS   = 16;
 	const DI_MINUTES = 32;
 	const DI_SECONDS = 64;
-
-	// }}}
-	// {{{ protected properties
 
 	static protected $tz_abbreviations = null;
 	static protected $valid_tz_abbreviations = array(
@@ -333,9 +320,6 @@ class SwatDate extends DateTime implements Serializable
 		'yekt'  => true,
 	);
 
-	// }}}
-	// {{{ public function format()
-
 	/**
 	 * Formats this date given either a format string or a format id
 	 *
@@ -362,9 +346,6 @@ class SwatDate extends DateTime implements Serializable
 
 		return $out;
 	}
-
-	// }}}
-	// {{{ public function formatLikeStrftime()
 
 	/**
 	 * Formats this date like strftime() given either a format string or a
@@ -406,9 +387,6 @@ class SwatDate extends DateTime implements Serializable
 
 		return $out;
 	}
-
-	// }}}
-	// {{{ public function formatLikeIntl()
 
 	/**
 	 * Formats this date using the ICU IntlDateFormater given either a format
@@ -458,9 +436,6 @@ class SwatDate extends DateTime implements Serializable
 
 		return $out;
 	}
-
-	// }}}
-	// {{{ public function formatTZ()
 
 	/**
 	 * Formats the time zone part of this date
@@ -525,9 +500,6 @@ class SwatDate extends DateTime implements Serializable
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function clearTime() - deprecated
-
 	/**
 	 * Clears the time portion of the date object
 	 *
@@ -538,16 +510,10 @@ class SwatDate extends DateTime implements Serializable
 		$this->setTime(0, 0, 0);
 	}
 
-	// }}}
-	// {{{ public function __toString()
-
 	public function __toString()
 	{
 		return $this->format('Y-m-d\TH:i:s');
 	}
-
-	// }}}
-	// {{{ public function getHumanReadableDateDiff()
 
 	/**
 	 * Get a human-readable string representing the difference between
@@ -573,9 +539,6 @@ class SwatDate extends DateTime implements Serializable
 		$seconds = $compare_date->getTime() - $this->getTime();
 		return SwatString::toHumanReadableTimePeriod($seconds, true);
 	}
-
-	// }}}
-	// {{{ public function getHumanReadableDateDiffWithWeeks()
 
 	/**
 	 * Get a human-readable string representing the difference between
@@ -603,9 +566,6 @@ class SwatDate extends DateTime implements Serializable
 		return SwatString::toHumanReadableTimePeriodWithWeeks($seconds, true);
 	}
 
-	// }}}
-	// {{{ public function getHumanReadableDateDiffWithWeeksAndDays()
-
 	/**
 	 * Get a human-readable string representing the difference between
 	 * two dates
@@ -631,9 +591,6 @@ class SwatDate extends DateTime implements Serializable
 		$seconds = $compare_date->getTime() - $this->getTime();
 		return SwatString::toHumanReadableTimePeriodWithWeeksAndDays($seconds);
 	}
-
-	// }}}
-	// {{{ public static function getFormatById()
 
 	/**
 	 * Gets a date format string by id
@@ -689,9 +646,6 @@ class SwatDate extends DateTime implements Serializable
 		}
 	}
 
-	// }}}
-	// {{{ public static function getFormatLikeStrftimeById()
-
 	/**
 	 * Gets a strftime() date format string by id
 	 *
@@ -742,9 +696,6 @@ class SwatDate extends DateTime implements Serializable
 			throw new Exception("Unknown date format id '$id'.");
 		}
 	}
-
-	// }}}
-	// {{{ public static function getFormatLikeIntlById()
 
 	/**
 	 * Gets a strftime() date format string by id
@@ -797,9 +748,6 @@ class SwatDate extends DateTime implements Serializable
 		}
 	}
 
-	// }}}
-	// {{{ public static function getTimeZoneAbbreviations()
-
 	/**
 	 * Gets a mapping of time zone names to time zone abbreviations
 	 *
@@ -845,9 +793,6 @@ class SwatDate extends DateTime implements Serializable
 		return self::$tz_abbreviations;
 	}
 
-	// }}}
-	// {{{ public static function getTimeZoneAbbreviation()
-
 	/**
 	 * Gets an array of time zone abbreviations for a specific time zone
 	 *
@@ -868,9 +813,6 @@ class SwatDate extends DateTime implements Serializable
 
 		return $abbreviation;
 	}
-
-	// }}}
-	// {{{ public static function compare()
 
 	/**
 	 * Compares two SwatDates
@@ -903,9 +845,6 @@ class SwatDate extends DateTime implements Serializable
 
 		return 0;
 	}
-
-	// }}}
-	// {{{ public static function getIntervalFromSeconds()
 
 	/**
 	 * Gets a date interval with appropriate values for the specified
@@ -972,9 +911,6 @@ class SwatDate extends DateTime implements Serializable
 		return new DateInterval($interval_spec);
 	}
 
-	// }}}
-	// {{{ public function getYear()
-
 	/**
 	 * Gets the year of this date
 	 *
@@ -986,9 +922,6 @@ class SwatDate extends DateTime implements Serializable
 	{
 		return (integer)$this->format('Y');
 	}
-
-	// }}}
-	// {{{ public function getMonth()
 
 	/**
 	 * Gets the month of this date as a number from 1-12
@@ -1002,9 +935,6 @@ class SwatDate extends DateTime implements Serializable
 		return (integer)$this->format('n');
 	}
 
-	// }}}
-	// {{{ public function getDay()
-
 	/**
 	 * Gets the day of this date as a number from 1-31
 	 *
@@ -1016,9 +946,6 @@ class SwatDate extends DateTime implements Serializable
 	{
 		return (integer)$this->format('j');
 	}
-
-	// }}}
-	// {{{ public function getHour()
 
 	/**
 	 * Gets the hour of this date as a number from 0-23
@@ -1032,9 +959,6 @@ class SwatDate extends DateTime implements Serializable
 		return (integer)ltrim($this->format('H'), '0');
 	}
 
-	// }}}
-	// {{{ public function getMinute()
-
 	/**
 	 * Gets the minute of this date as a number from 0-59
 	 *
@@ -1047,9 +971,6 @@ class SwatDate extends DateTime implements Serializable
 		return (integer)ltrim($this->format('i'), '0');
 	}
 
-	// }}}
-	// {{{ public function getSecond()
-
 	/**
 	 * Gets the second of this date as a number from 0-59
 	 *
@@ -1061,9 +982,6 @@ class SwatDate extends DateTime implements Serializable
 	{
 		return (integer)ltrim($this->format('s'), '0');
 	}
-
-	// }}}
-	// {{{ public function getISO8601()
 
 	/**
 	 * Gets this date formatted as an ISO 8601 timestamp
@@ -1103,9 +1021,6 @@ class SwatDate extends DateTime implements Serializable
 		return $date;
 	}
 
-	// }}}
-	// {{{ public function getRFC2822()
-
 	/**
 	 * Gets this date formatted as required by RFC 2822
 	 *
@@ -1117,9 +1032,6 @@ class SwatDate extends DateTime implements Serializable
 	{
 		return $this->format(self::DF_RFC_2822);
 	}
-
-	// }}}
-	// {{{ public function getFormattedOffsetById()
 
 	/**
 	 * Returns this date's timezone offset from GMT using a format id.
@@ -1156,9 +1068,6 @@ class SwatDate extends DateTime implements Serializable
 		}
 	}
 
-	// }}}
-	// {{{ public function getDaysInMonth()
-
 	/**
 	 * Gets the number of days in the current month as a number from 28-21
 	 *
@@ -1170,9 +1079,6 @@ class SwatDate extends DateTime implements Serializable
 	{
 		return (integer)$this->format('t');
 	}
-
-	// }}}
-	// {{{ public function getDayOfWeek()
 
 	/**
 	 * Gets the day of the current week as a number from 0 to 6
@@ -1187,9 +1093,6 @@ class SwatDate extends DateTime implements Serializable
 		return (integer)$this->format('w');
 	}
 
-	// }}}
-	// {{{ public function getDayOfYear()
-
 	/**
 	 * Gets the day of the year as a number from 1 to 365
 	 *
@@ -1202,9 +1105,6 @@ class SwatDate extends DateTime implements Serializable
 		$day = (integer)$this->format('z');
 		return $day + 1; // the "z" format starts at 0
 	}
-
-	// }}}
-	// {{{ public function getNextDay()
 
 	/**
 	 * Gets a new date a day after this date
@@ -1220,9 +1120,6 @@ class SwatDate extends DateTime implements Serializable
 		return $date;
 	}
 
-	// }}}
-	// {{{ public function getPrevDay()
-
 	/**
 	 * Gets a new date a day before this date
 	 *
@@ -1236,9 +1133,6 @@ class SwatDate extends DateTime implements Serializable
 		$date->subtractDays(1);
 		return $date;
 	}
-
-	// }}}
-	// {{{ public function getDate() - deprecated
 
 	/**
 	 * Gets a PEAR-conanical formatted date
@@ -1259,9 +1153,6 @@ class SwatDate extends DateTime implements Serializable
 		return $this->format('Y-m-d H:i:s');
 	}
 
-	// }}}
-	// {{{ public function getTime() - deprecated
-
 	/**
 	 * Gets the number of seconds since the UNIX epoch for this date
 	 *
@@ -1275,9 +1166,6 @@ class SwatDate extends DateTime implements Serializable
 	{
 		return $this->getTimestamp();
 	}
-
-	// }}}
-	// {{{ public function convertTZ() - deprecated
 
 	/**
 	 * Sets the time zone for this date
@@ -1296,9 +1184,6 @@ class SwatDate extends DateTime implements Serializable
 		return $this->setTimezone($time_zone);
 	}
 
-	// }}}
-	// {{{ public function convertTZById() - deprecated
-
 	/**
 	 * Sets the time zone for this date
 	 *
@@ -1315,9 +1200,6 @@ class SwatDate extends DateTime implements Serializable
 	{
 		return $this->setTimezone(new DateTimeZone($time_zone_name));
 	}
-
-	// }}}
-	// {{{ public function setTZ()
 
 	/**
 	 * Sets the time zone for this date and updates this date's time so the
@@ -1336,9 +1218,6 @@ class SwatDate extends DateTime implements Serializable
 		return $result;
 	}
 
-	// }}}
-	// {{{ public function setTZById()
-
 	/**
 	 * Sets the time zone for this date and updates this date's time so the
 	 * hours are the same as with the old time zone
@@ -1353,9 +1232,6 @@ class SwatDate extends DateTime implements Serializable
 		$this->setTZ(new DateTimeZone($time_zone_name));
 	}
 
-	// }}}
-	// {{{ public function toUTC()
-
 	/**
 	 * Sets the time zone of this date to UTC
 	 *
@@ -1366,9 +1242,6 @@ class SwatDate extends DateTime implements Serializable
 	{
 		return $this->setTimezone(new DateTimeZone('UTC'));
 	}
-
-	// }}}
-	// {{{ public function getMonthName()
 
 	/**
 	 * Gets the full name of the current month of this date
@@ -1382,9 +1255,6 @@ class SwatDate extends DateTime implements Serializable
 	{
 		return $this->formatLikeIntl('LLLL');
 	}
-
-	// }}}
-	// {{{ public function addYears()
 
 	/**
 	 * Adds the specified number of years to this date
@@ -1405,9 +1275,6 @@ class SwatDate extends DateTime implements Serializable
 		return $this->add($interval);
 	}
 
-	// }}}
-	// {{{ public function subtractYears()
-
 	/**
 	 * Subtracts the specified number of years from this date
 	 *
@@ -1421,9 +1288,6 @@ class SwatDate extends DateTime implements Serializable
 		$years = -$years;
 		return $this->addYears($years);
 	}
-
-	// }}}
-	// {{{ public function addMonths()
 
 	/**
 	 * Adds the specified number of months to this date
@@ -1444,9 +1308,6 @@ class SwatDate extends DateTime implements Serializable
 		return $this->add($interval);
 	}
 
-	// }}}
-	// {{{ public function subtractMonths()
-
 	/**
 	 * Subtracts the specified number of months from this date
 	 *
@@ -1460,9 +1321,6 @@ class SwatDate extends DateTime implements Serializable
 		$months = -$months;
 		return $this->addMonths($months);
 	}
-
-	// }}}
-	// {{{ public function addDays()
 
 	/**
 	 * Adds the specified number of days to this date
@@ -1483,9 +1341,6 @@ class SwatDate extends DateTime implements Serializable
 		return $this->add($interval);
 	}
 
-	// }}}
-	// {{{ public function subtractDays()
-
 	/**
 	 * Subtracts the specified number of days from this date
 	 *
@@ -1499,9 +1354,6 @@ class SwatDate extends DateTime implements Serializable
 		$days = -$days;
 		return $this->addDays($days);
 	}
-
-	// }}}
-	// {{{ public function addHours()
 
 	/**
 	 * Adds the specified number of hours to this date
@@ -1522,9 +1374,6 @@ class SwatDate extends DateTime implements Serializable
 		return $this->add($interval);
 	}
 
-	// }}}
-	// {{{ public function subtractHours()
-
 	/**
 	 * Subtracts the specified number of hours from this date
 	 *
@@ -1538,9 +1387,6 @@ class SwatDate extends DateTime implements Serializable
 		$hours = -$hours;
 		return $this->addHours($hours);
 	}
-
-	// }}}
-	// {{{ public function addMinutes()
 
 	/**
 	 * Adds the specified number of minutes to this date
@@ -1561,9 +1407,6 @@ class SwatDate extends DateTime implements Serializable
 		return $this->add($interval);
 	}
 
-	// }}}
-	// {{{ public function subtractMinutes()
-
 	/**
 	 * Subtracts the specified number of minutes from this date
 	 *
@@ -1577,9 +1420,6 @@ class SwatDate extends DateTime implements Serializable
 		$minutes = -$minutes;
 		return $this->addMinutes($minutes);
 	}
-
-	// }}}
-	// {{{ public function addSeconds()
 
 	/**
 	 * Adds the specified number of seconds to this date
@@ -1600,9 +1440,6 @@ class SwatDate extends DateTime implements Serializable
 		return $this->add($interval);
 	}
 
-	// }}}
-	// {{{ public function subtractSeconds()
-
 	/**
 	 * Subtracts the specified number of seconds from this date
 	 *
@@ -1616,9 +1453,6 @@ class SwatDate extends DateTime implements Serializable
 		$seconds = -$seconds;
 		return $this->addSeconds($seconds);
 	}
-
-	// }}}
-	// {{{ public function setDate()
 
 	/**
 	 * Sets the date fields for this date
@@ -1642,9 +1476,6 @@ class SwatDate extends DateTime implements Serializable
 		return parent::setDate($year, $month, $day);
 	}
 
-	// }}}
-	// {{{ public function setYear()
-
 	/**
 	 * Sets the year of this date without affecting the other date parts
 	 *
@@ -1665,9 +1496,6 @@ class SwatDate extends DateTime implements Serializable
 			$this->getDay()
 		);
 	}
-
-	// }}}
-	// {{{ public function setMonth()
 
 	/**
 	 * Sets the month of this date without affecting the other date parts
@@ -1690,9 +1518,6 @@ class SwatDate extends DateTime implements Serializable
 		);
 	}
 
-	// }}}
-	// {{{ public function setDay()
-
 	/**
 	 * Sets the day of this date without affecting the other date parts
 	 *
@@ -1713,9 +1538,6 @@ class SwatDate extends DateTime implements Serializable
 		);
 	}
 
-	// }}}
-	// {{{ public function setHour()
-
 	/**
 	 * Sets the hour of this date without affecting the other date parts
 	 *
@@ -1735,9 +1557,6 @@ class SwatDate extends DateTime implements Serializable
 			$this->getSecond()
 		);
 	}
-
-	// }}}
-	// {{{ public function setMinute()
 
 	/**
 	 * Sets the minute of this date without affecting the other date parts
@@ -1760,9 +1579,6 @@ class SwatDate extends DateTime implements Serializable
 		);
 	}
 
-	// }}}
-	// {{{ public function setSecond()
-
 	/**
 	 * Sets the second of this date without affecting the other date parts
 	 *
@@ -1784,9 +1600,6 @@ class SwatDate extends DateTime implements Serializable
 		);
 	}
 
-	// }}}
-	// {{{ public function before()
-
 	/**
 	 * Gets whether or not this date is before the specified date
 	 *
@@ -1801,9 +1614,6 @@ class SwatDate extends DateTime implements Serializable
 	{
 		return (self::compare($this, $when) == -1);
 	}
-
-	// }}}
-	// {{{ public function after()
 
 	/**
 	 * Gets whether or not this date is after the specified date
@@ -1820,9 +1630,6 @@ class SwatDate extends DateTime implements Serializable
 		return (self::compare($this, $when) == 1);
 	}
 
-	// }}}
-	// {{{ public function equals()
-
 	/**
 	 * Gets whether or not this date is equivalent to the specified date
 	 *
@@ -1837,9 +1644,6 @@ class SwatDate extends DateTime implements Serializable
 	{
 		return (self::compare($this, $when) == 0);
 	}
-
-	// }}}
-	// {{{ public function addStrictMonths()
 
 	/**
 	 * Adds months to this date without affecting the day of the month
@@ -1896,9 +1700,6 @@ class SwatDate extends DateTime implements Serializable
 		return $this;
 	}
 
-	// }}}
-	// {{{ public function subtractStrictMonths()
-
 	/**
 	 * Subtracts months to this date without affecting the day of the month
 	 *
@@ -1922,9 +1723,6 @@ class SwatDate extends DateTime implements Serializable
 		return $this->addStrictMonths(-$months);
 	}
 
-	// }}}
-	// {{{ public function serialize()
-
 	/**
 	 * Serializes this date
 	 *
@@ -1941,9 +1739,6 @@ class SwatDate extends DateTime implements Serializable
 
 		return serialize($data);
 	}
-
-	// }}}
-	// {{{ public function unserialize()
 
 	/**
 	 * Unserializes this date
@@ -1964,7 +1759,6 @@ class SwatDate extends DateTime implements Serializable
 		$this->setTimezone(new DateTimeZone($data[1]));
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatDateCellRenderer.php
+++ b/Swat/SwatDateCellRenderer.php
@@ -9,7 +9,6 @@
  */
 class SwatDateCellRenderer extends SwatCellRenderer
 {
-	// {{{ public properties
 
 	/**
 	 * Date to render
@@ -52,9 +51,6 @@ class SwatDateCellRenderer extends SwatCellRenderer
 	 */
 	public $display_time_zone = null;
 
-	// }}}
-	// {{{ public function render()
-
 	/**
 	 * Renders the contents of this cell
 	 *
@@ -95,7 +91,6 @@ class SwatDateCellRenderer extends SwatCellRenderer
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatDateEntry.php
+++ b/Swat/SwatDateEntry.php
@@ -9,16 +9,12 @@
  */
 class SwatDateEntry extends SwatInputControl implements SwatState
 {
-	// {{{ class constants
 
 	const YEAR     = 1;
 	const MONTH    = 2;
 	const DAY      = 4;
 	const TIME     = 8;
 	const CALENDAR = 16;
-
-	// }}}
-	// {{{ public properties
 
 	/**
 	 * Date of this date entry widget
@@ -104,9 +100,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 	 */
 	public $show_blank_titles = true;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new date entry widget
 	 *
@@ -134,9 +127,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		$this->addJavaScript('packages/swat/javascript/swat-date-entry.js');
 	}
 
-	// }}}
-	// {{{ public function __clone()
-
 	/**
 	 * Clones the valid date range of this date entry
 	 */
@@ -145,9 +135,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		$this->valid_range_start = clone $this->valid_range_start;
 		$this->valid_range_end = clone $this->valid_range_end;
 	}
-
-	// }}}
-	// {{{ public function setValidRange()
 
 	/**
 	 * Set the valid date range
@@ -178,9 +165,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		$this->valid_range_start->setYear($year + $start_offset);
 		$this->valid_range_end->setYear($year + $end_offset + 1);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this date entry
@@ -259,9 +243,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 
 		$div_tag->close();
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this date entry
@@ -394,9 +375,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		}
 	}
 
-	// }}}
-	// {{{ public function getState()
-
 	/**
 	 * Gets the current state of this date entry widget
 	 *
@@ -412,9 +390,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 			return $this->value->getDate();
 	}
 
-	// }}}
-	// {{{ public function setState()
-
 	/**
 	 * Sets the current state of this date entry widget
 	 *
@@ -427,9 +402,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		$this->value = new SwatDate($state);
 	}
 
-	// }}}
-	// {{{ public function isValid()
-
 	/**
 	 * Checks if the entered date is within the valid range
 	 *
@@ -440,9 +412,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 	{
 		return ($this->isStartDateValid() && $this->isEndDateValid());
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript required for this control
@@ -506,9 +475,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		return $javascript;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this date entry widget
 	 *
@@ -521,9 +487,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function isStartDateValid()
 
 	/**
 	 * Checks if the entered date is valid with respect to the valid start
@@ -540,9 +503,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 			$this->value, $this->valid_range_start, true) >= 0);
 	}
 
-	// }}}
-	// {{{ protected function isEndDateValid()
-
 	/**
 	 * Checks if the entered date is valid with respect to the valid end date
 	 *
@@ -556,9 +516,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		return (SwatDate::compare(
 			$this->value, $this->valid_range_end, true) < 0);
 	}
-
-	// }}}
-	// {{{ protected function validateRanges()
 
 	/**
 	 * Makes sure the date the user entered is within the valid range
@@ -583,9 +540,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 			$this->addMessage(new SwatMessage($message, 'error'));
 		}
 	}
-
-	// }}}
-	// {{{ protected function createCompositeWidgets()
 
 	/**
 	 * Creates the composite widgets used by this date entry
@@ -630,9 +584,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		}
 	}
 
-	// }}}
-	// {{{ protected function createYearFlydown()
-
 	/**
 	 * Creates the year flydown for this date entry
 	 *
@@ -662,9 +613,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		return $flydown;
 	}
 
-	// }}}
-	// {{{ protected function getYearBlankValueTitle()
-
 	/**
 	 * Gets the blank value to use for the year flydown option
 	 *
@@ -674,9 +622,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 	{
 		return Swat::_('Year');
 	}
-
-	// }}}
-	// {{{ protected function createMonthFlydown()
 
 	/**
 	 * Creates the month flydown for this date entry
@@ -719,9 +664,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		return $flydown;
 	}
 
-	// }}}
-	// {{{ protected function getMonthBlankValueTitle()
-
 	/**
 	 * Gets the blank value to use for the month flydown option
 	 *
@@ -731,9 +673,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 	{
 		return Swat::_('Month');
 	}
-
-	// }}}
-	// {{{ protected function getMonthOptionText()
 
 	/**
 	 * Gets the title of a month flydown option
@@ -755,9 +694,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 
 		return $text;
 	}
-
-	// }}}
-	// {{{ protected function createDayFlydown()
 
 	/**
 	 * Creates the day flydown for this date entry
@@ -812,9 +748,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		return $flydown;
 	}
 
-	// }}}
-	// {{{ protected function getDayBlankValueTitle()
-
 	/**
 	 * Gets the blank value to use for the day flydown option
 	 *
@@ -824,9 +757,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 	{
 		return Swat::_('Day');
 	}
-
-	// }}}
-	// {{{ protected function createTimeEntry()
 
 	/**
 	 * Creates the time entry widget for this date entry
@@ -839,9 +769,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		$time_entry->classes = array('swat-date-entry-time');
 		return $time_entry;
 	}
-
-	// }}}
-	// {{{ protected function createCalendar()
 
 	/**
 	 * Creates the calendar widget for this date entry
@@ -856,9 +783,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		$calendar->valid_range_end   = $this->valid_range_end;
 		return $calendar;
 	}
-
-	// }}}
-	// {{{ private function getFormattedDate()
 
 	/**
 	 * Formats a date for this date entry
@@ -899,9 +823,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 
 		return $date->formatLikeIntl($format);
 	}
-
-	// }}}
-	// {{{ private function getDatePartOrder()
 
 	/**
 	 * Gets the order of date parts for the current locale
@@ -954,7 +875,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 		return $order;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatDetailsStore.php
+++ b/Swat/SwatDetailsStore.php
@@ -13,7 +13,6 @@
  */
 class SwatDetailsStore extends SwatObject
 {
-	// {{{ private properties
 
 	/**
 	 * The base object for this details store
@@ -32,9 +31,6 @@ class SwatDetailsStore extends SwatObject
 	 */
 	private $data = array();
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new details store
 	 *
@@ -49,9 +45,6 @@ class SwatDetailsStore extends SwatObject
 		if ($base_object !== null && is_object($base_object))
 			$this->base_object = $base_object;
 	}
-
-	// }}}
-	// {{{ public function __get()
 
 	/**
 	 * Gets a property of this details store
@@ -94,9 +87,6 @@ class SwatDetailsStore extends SwatObject
 			0, $this, $name);
 	}
 
-	// }}}
-	// {{{ public function __set()
-
 	/**
 	 * Manually sets a property of this details store
 	 *
@@ -111,9 +101,6 @@ class SwatDetailsStore extends SwatObject
 	{
 		$this->data[$name] = $value;
 	}
-
-	// }}}
-	// {{{ public function __isset()
 
 	/**
 	 * Gets whether or not a property is set for this details store
@@ -136,9 +123,6 @@ class SwatDetailsStore extends SwatObject
 		return $is_set;
 	}
 
-	// }}}
-	// {{{ private function parsePath()
-
 	private function parsePath($object, $path)
 	{
 		$pos = mb_strpos($path, '.');
@@ -154,7 +138,6 @@ class SwatDetailsStore extends SwatObject
 			return $this->parsePath($sub_object, $rest);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatDetailsView.php
+++ b/Swat/SwatDetailsView.php
@@ -9,7 +9,6 @@
  */
 class SwatDetailsView extends SwatControl implements SwatUIParent
 {
-	// {{{ public properties
 
 	/**
 	 * An object containing values to display
@@ -24,9 +23,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 	 * @see SwatDetailsViewField
 	 */
 	public $data = null;
-
-	// }}}
-	// {{{ private properties
 
 	/**
 	 * An array of fields to be displayed by this details view
@@ -48,9 +44,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 	 */
 	private $fields_by_id = array();
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new details view
 	 *
@@ -64,9 +57,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 
 		$this->addStyleSheet('packages/swat/styles/swat-details-view.css');
 	}
-
-	// }}}
-	// {{{ public function init()
 
 	/**
 	 * Initializes this details-view
@@ -83,9 +73,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 			$field->init();
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this details-view
 	 */
@@ -96,9 +83,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		foreach ($this->fields as $field)
 			$field->process();
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this details view
@@ -123,9 +107,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function appendField()
-
 	/**
 	 * Appends a field to this details view
 	 *
@@ -140,9 +121,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 	{
 		$this->insertField($field);
 	}
-
-	// }}}
-	// {{{ public function insertFieldBefore()
 
 	/**
 	 * Inserts a field before an existing field in this details-view
@@ -163,9 +141,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		$this->insertField($field, $reference_field, false);
 	}
 
-	// }}}
-	// {{{ public function insertFieldAfter()
-
 	/**
 	 * Inserts a field after an existing field in this details-view
 	 *
@@ -185,9 +160,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		$this->insertField($field, $reference_field, true);
 	}
 
-	// }}}
-	// {{{ public function getFieldCount()
-
 	/**
 	 * Gets the number of fields of this details-view
 	 *
@@ -198,9 +170,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		return count($this->fields);
 	}
 
-	// }}}
-	// {{{ public function getFields()
-
 	/**
 	 * Get the fields of this details-view
 	 *
@@ -210,9 +179,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 	{
 		return $this->fields;
 	}
-
-	// }}}
-	// {{{ public function getField()
 
 	/**
 	 * Gets a field in this details view by the field's id
@@ -234,9 +200,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		return $this->fields_by_id[$id];
 	}
 
-	// }}}
-	// {{{ public function hasField()
-
 	/**
 	 * Whether a field exists in this details view
 	 *
@@ -248,9 +211,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 	{
 		return array_key_exists($id, $this->fields_by_id);
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child object to this object
@@ -276,9 +236,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this details-view
 	 *
@@ -297,9 +254,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this
@@ -320,9 +274,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -360,9 +311,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -396,9 +344,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -418,9 +363,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -436,9 +378,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -468,9 +407,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		return $copy;
 	}
 
-	// }}}
-	// {{{ protected function validateField()
-
 	/**
 	 * Ensures a field added to this details-view is valid for this
 	 * details-view
@@ -492,9 +428,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 					0, $field->id);
 		}
 	}
-
-	// }}}
-	// {{{ protected function insertField()
 
 	/**
 	 * Helper method to insert fields into this details-view
@@ -571,9 +504,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		$field->parent = $this;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this details view
 	 *
@@ -586,9 +516,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript needed by this details view as well as any
@@ -615,9 +542,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		return $javascript;
 	}
 
-	// }}}
-	// {{{ protected function displayContent()
-
 	/**
 	 * Displays each field of this view
 	 *
@@ -641,7 +565,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatDetailsViewField.php
+++ b/Swat/SwatDetailsViewField.php
@@ -9,7 +9,6 @@
  */
 class SwatDetailsViewField extends SwatCellRendererContainer
 {
-	// {{{ public properties
 
 	/**
 	 * The unique identifier of this field
@@ -67,18 +66,12 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 	 */
 	public $show_renderer_classes = true;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * Whether or not this field is odd or even in its parent details view
 	 *
 	 * @var boolean
 	 */
 	protected $odd = false;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new details view field
@@ -92,9 +85,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 		parent::__construct();
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this field
 	 *
@@ -106,17 +96,11 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 			$renderer->init();
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	public function process()
 	{
 		foreach ($this->renderers as $renderer)
 			$renderer->process();
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this details view field using a data object
@@ -143,9 +127,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 		$tr_tag->close();
 	}
 
-	// }}}
-	// {{{ public function displayHeader()
-
 	/**
 	 * Displays the header for this details view field
 	 */
@@ -164,9 +145,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 
 		$th_tag->display();
 	}
-
-	// }}}
-	// {{{ public function displayValue()
 
 	/**
 	 * Displays the value of this details view field
@@ -193,9 +171,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 		$this->displayRenderers($data);
 	}
 
-	// }}}
-	// {{{ public function getTdAttributes()
-
 	/**
 	 * Gets the TD tag attributes for this column
 	 *
@@ -209,9 +184,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 			'class' => $this->getCSSClassString(),
 		);
 	}
-
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this field
@@ -233,9 +205,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this
 	 * details-view field
@@ -256,9 +225,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ protected function getHeaderTitle()
 
 	/**
 	 * Gets the title to use for the header of this details view field.
@@ -283,9 +249,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 		return $header_title;
 	}
 
-	// }}}
-	// {{{ protected function displayRenderers()
-
 	/**
 	 * Renders each cell renderer in this details-view field
 	 *
@@ -309,9 +272,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 
 		$td_tag->close();
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this details-view
@@ -376,9 +336,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function getBaseCSSClassNames()
-
 	/**
 	 * Gets the base CSS class names of this details-view field
 	 *
@@ -393,7 +350,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 		return array('swat-details-view-field');
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatDetailsViewVerticalField.php
+++ b/Swat/SwatDetailsViewVerticalField.php
@@ -10,7 +10,6 @@
  */
 class SwatDetailsViewVerticalField extends SwatDetailsViewField
 {
-	// {{{ public function display()
 
 	/**
 	 * Displays this details view field using a data object
@@ -44,9 +43,6 @@ class SwatDetailsViewVerticalField extends SwatDetailsViewField
 		$tr_tag->close();
 	}
 
-	// }}}
-	// {{{ public function displayHeader()
-
 	/**
 	 * Displays the header for this details view field
 	 *
@@ -65,9 +61,6 @@ class SwatDetailsViewVerticalField extends SwatDetailsViewField
 			$div_tag->display();
 		}
 	}
-
-	// }}}
-	// {{{ protected function displayRenderers()
 
 	/**
 	 * Renders each cell renderer in this details-view field
@@ -90,9 +83,6 @@ class SwatDetailsViewVerticalField extends SwatDetailsViewField
 		$div_tag->close();
 	}
 
-	// }}}
-	// {{{ protected function getBaseCSSClassNames()
-
 	/**
 	 * Gets the base CSS class names of this details-view field
 	 *
@@ -104,7 +94,6 @@ class SwatDetailsViewVerticalField extends SwatDetailsViewField
 		return array('swat-details-view-vertical-field');
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatDisclosure.php
+++ b/Swat/SwatDisclosure.php
@@ -9,7 +9,6 @@
  */
 class SwatDisclosure extends SwatDisplayableContainer
 {
-	// {{{ public properties
 
 	/**
 	 * A visible title for the label shown beside the disclosure triangle
@@ -24,9 +23,6 @@ class SwatDisclosure extends SwatDisplayableContainer
 	 * @var boolean
 	 */
 	public $open = true;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new disclosure container
@@ -46,9 +42,6 @@ class SwatDisclosure extends SwatDisplayableContainer
 		$this->addJavaScript('packages/swat/javascript/swat-disclosure.js');
 		$this->addStyleSheet('packages/swat/styles/swat-disclosure.css');
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this disclosure container
@@ -91,9 +84,6 @@ class SwatDisclosure extends SwatDisplayableContainer
 		$control_div->close();
 	}
 
-	// }}}
-	// {{{ protected function getControlDivTag()
-
 	protected function getControlDivTag()
 	{
 		$div = new SwatHtmlTag('div');
@@ -103,9 +93,6 @@ class SwatDisclosure extends SwatDisplayableContainer
 		return $div;
 	}
 
-	// }}}
-	// {{{ protected function getContainerDivTag()
-
 	protected function getContainerDivTag()
 	{
 		$div = new SwatHtmlTag('div');
@@ -114,18 +101,12 @@ class SwatDisclosure extends SwatDisplayableContainer
 		return $div;
 	}
 
-	// }}}
-	// {{{ protected function getAnimateDivTag()
-
 	protected function getAnimateDivTag()
 	{
 		$div = new SwatHtmlTag('div');
 
 		return $div;
 	}
-
-	// }}}
-	// {{{ protected function getPaddingDivTag()
 
 	protected function getPaddingDivTag()
 	{
@@ -134,9 +115,6 @@ class SwatDisclosure extends SwatDisplayableContainer
 
 		return $div;
 	}
-
-	// }}}
-	// {{{ protected function getInputTag()
 
 	protected function getInputTag()
 	{
@@ -149,9 +127,6 @@ class SwatDisclosure extends SwatDisplayableContainer
 		return $input;
 	}
 
-	// }}}
-	// {{{ protected function getSpanTag()
-
 	protected function getSpanTag()
 	{
 		$title = strval($this->title);
@@ -162,9 +137,6 @@ class SwatDisclosure extends SwatDisplayableContainer
 
 		return $span;
 	}
-
-	// }}}
-	// {{{ protected function getJavaScriptClass()
 
 	/**
 	 * Gets the name of the JavaScript class to instantiate for this disclosure
@@ -180,9 +152,6 @@ class SwatDisclosure extends SwatDisplayableContainer
 		return 'SwatDisclosure';
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets disclosure specific inline JavaScript
 	 *
@@ -194,9 +163,6 @@ class SwatDisclosure extends SwatDisplayableContainer
 		return sprintf("var %s_obj = new %s('%s', %s);",
 			$this->id, $this->getJavaScriptClass(), $this->id, $open);
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this disclosure
@@ -216,7 +182,6 @@ class SwatDisclosure extends SwatDisplayableContainer
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatDisplayableContainer.php
+++ b/Swat/SwatDisplayableContainer.php
@@ -9,7 +9,6 @@
  */
 class SwatDisplayableContainer extends SwatContainer
 {
-	// {{{ public function display()
 
 	/**
 	 * Displays this container
@@ -30,9 +29,6 @@ class SwatDisplayableContainer extends SwatContainer
 		$div->close();
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this displayable
 	 * container
@@ -47,7 +43,6 @@ class SwatDisplayableContainer extends SwatContainer
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatEmailEntry.php
+++ b/Swat/SwatEmailEntry.php
@@ -12,7 +12,6 @@
  */
 class SwatEmailEntry extends SwatEntry
 {
-	// {{{ public function process()
 
 	/**
 	 * Processes this email entry
@@ -37,9 +36,6 @@ class SwatEmailEntry extends SwatEntry
 		}
 	}
 
-	// }}}
-	// {{{ protected function validateEmailAddress()
-
 	/**
 	 * Validates the email address value of this entry
 	 *
@@ -50,9 +46,6 @@ class SwatEmailEntry extends SwatEntry
 	{
 		return SwatString::validateEmailAddress($this->value);
 	}
-
-	// }}}
-	// {{{ protected function getValidationMessage()
 
 	/**
 	 * Gets a validation message for this email entry
@@ -80,9 +73,6 @@ class SwatEmailEntry extends SwatEntry
 		return $message;
 	}
 
-	// }}}
-	// {{{ protected function getInputTag()
-
 	/**
 	 * Get the input tag to display
 	 *
@@ -94,9 +84,6 @@ class SwatEmailEntry extends SwatEntry
 		$tag->type = 'email';
 		return $tag;
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
@@ -111,7 +98,6 @@ class SwatEmailEntry extends SwatEntry
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatEntry.php
+++ b/Swat/SwatEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatEntry extends SwatInputControl implements SwatState
 {
-	// {{{ public properties
 
 	/**
 	 * Entry value
@@ -101,9 +100,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 	 */
 	public $select_on_focus = false;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * If autocomplete is turned off, this nonce is used to obfuscate the
 	 * name of the XHTML input tag.
@@ -121,9 +117,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 	 * @var boolean
 	 */
 	public $auto_trim = true;
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this entry widget
@@ -148,9 +141,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 			$nonce_tag->display();
 		}
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this entry widget
@@ -200,9 +190,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 		}
 	}
 
-	// }}}
-	// {{{ public function getState()
-
 	/**
 	 * Gets the current state of this entry widget
 	 *
@@ -215,9 +202,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 		return $this->value;
 	}
 
-	// }}}
-	// {{{ public function setState()
-
 	/**
 	 * Sets the current state of this entry widget
 	 *
@@ -229,9 +213,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 	{
 		$this->value = $state;
 	}
-
-	// }}}
-	// {{{ public function getFocusableHtmlId()
 
 	/**
 	 * Gets the id attribute of the XHTML element displayed by this widget
@@ -250,9 +231,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 		else
 			return null;
 	}
-
-	// }}}
-	// {{{ protected function getValidationMessage()
 
 	/**
 	 * Gets a validation message for this entry
@@ -279,9 +257,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 		$message = new SwatMessage($text, 'error');
 		return $message;
 	}
-
-	// }}}
-	// {{{ protected function getInputTag()
 
 	/**
 	 * Get the input tag to display
@@ -335,9 +310,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 		return $tag;
 	}
 
-	// }}}
-	// {{{ protected function getDisplayValue()
-
 	/**
 	 * Formats a value to display
 	 *
@@ -352,9 +324,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 		return $value;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this entry widget
 	 *
@@ -368,9 +337,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function getNonce()
-
 	protected function getNonce()
 	{
 		if ($this->nonce === null)
@@ -378,9 +344,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 
 		return $this->nonce;
 	}
-
-	// }}}
-	// {{{ protected function getRawValue()
 
 	/**
 	 * Gets the raw value entered by the user before processing
@@ -412,9 +375,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 
 		return $value;
 	}
-
-	// }}}
-	// {{{ protected function hasRawValue()
 
 	/**
 	 * Gets whether or not a value was submitted by the user for this entry
@@ -450,7 +410,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 		return $has_value;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatError.php
+++ b/Swat/SwatError.php
@@ -17,7 +17,6 @@
  */
 class SwatError
 {
-	// {{{ protected properties
 
 	/**
 	 * The message of this error
@@ -83,9 +82,6 @@ class SwatError
 	 */
 	protected static $fatal_severity = E_USER_ERROR;
 
-	// }}}
-	// {{{ public static function setLogger()
-
 	/**
 	 * Sets the object that logs SwatError objects when they are processed
 	 *
@@ -100,9 +96,6 @@ class SwatError
 	{
 		self::$loggers = array($logger);
 	}
-
-	// }}}
-	// {{{ public static function addLogger()
 
 	/**
 	 * Adds an object to the array of objects that log SwatError objects
@@ -121,9 +114,6 @@ class SwatError
 		self::$loggers[] = $logger;
 	}
 
-	// }}}
-	// {{{ public static function setDisplayer()
-
 	/**
 	 * Sets the object that displays SwatError objects when they are
 	 * processed
@@ -141,9 +131,6 @@ class SwatError
 		self::$displayer = $displayer;
 	}
 
-	// }}}
-	// {{{ public static function setFatalSeverity()
-
 	/**
 	 * Sets the severity of SwatError that should be fatal
 	 *
@@ -154,9 +141,6 @@ class SwatError
 	{
 		self::$fatal_severity = $severity;
 	}
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new error object
@@ -187,9 +171,6 @@ class SwatError
 		$this->backtrace = &$backtrace;
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this error
 	 *
@@ -211,9 +192,6 @@ class SwatError
 			exit(1);
 	}
 
-	// }}}
-	// {{{ public function getMessage()
-
 	/**
 	 * Gets the original message string of this error
 	 *
@@ -223,9 +201,6 @@ class SwatError
 	{
 		return $this->message;
 	}
-
-	// }}}
-	// {{{ public function getSeverity()
 
 	/**
 	 * Gets the severity of this error
@@ -237,9 +212,6 @@ class SwatError
 		return $this->severity;
 	}
 
-	// }}}
-	// {{{ public function getFile()
-
 	/**
 	 * Gets the file location where the error occurred
 	 *
@@ -250,9 +222,6 @@ class SwatError
 		return $this->file;
 	}
 
-	// }}}
-	// {{{ public function getLine()
-
 	/**
 	 * Gets the line number where the error occurred
 	 *
@@ -262,9 +231,6 @@ class SwatError
 	{
 		return $this->line;
 	}
-
-	// }}}
-	// {{{ public function log()
 
 	/**
 	 * Logs this error
@@ -282,9 +248,6 @@ class SwatError
 		}
 	}
 
-	// }}}
-	// {{{ public function display()
-
 	public function display()
 	{
 		if (self::$displayer === null) {
@@ -297,9 +260,6 @@ class SwatError
 			$displayer->display($this);
 		}
 	}
-
-	// }}}
-	// {{{ public function getSummary()
 
 	/**
 	 * Gets a one-line short text summary of this error
@@ -319,9 +279,6 @@ class SwatError
 
 		return ob_get_clean();
 	}
-
-	// }}}
-	// {{{ public function toString()
 
 	/**
 	 * Gets this error as a nicely formatted text block
@@ -372,9 +329,6 @@ class SwatError
 
 		return ob_get_clean();
 	}
-
-	// }}}
-	// {{{ public function toXHTML()
 
 	/**
 	 * Gets this error as a nicely formatted XHTML fragment
@@ -435,9 +389,6 @@ class SwatError
 		return ob_get_clean();
 	}
 
-	// }}}
-	// {{{ public static function handle()
-
 	/**
 	 * Handles an error
 	 *
@@ -456,9 +407,6 @@ class SwatError
 			$error->process();
 		}
 	}
-
-	// }}}
-	// {{{ protected function getArguments()
 
 	/**
 	 * Formats a method call's arguments
@@ -513,9 +461,6 @@ class SwatError
 		return implode(', ', $formatted_values);
 	}
 
-	// }}}
-	// {{{ protected function formatSensitiveParam()
-
 	/**
 	 * Removes sensitive information from a parameter value and formats
 	 * the parameter as a string
@@ -535,9 +480,6 @@ class SwatError
 	{
 		return '[$'.$name.' FILTERED]';
 	}
-
-	// }}}
-	// {{{ protected function formatValue()
 
 	/**
 	 * Formats a parameter value for display in a stack trace
@@ -596,9 +538,6 @@ class SwatError
 		return $formatted_value;
 	}
 
-	// }}}
-	// {{{ protected function displayStyleSheet()
-
 	/**
 	 * Displays styles required to show XHTML error messages
 	 *
@@ -630,9 +569,6 @@ class SwatError
 		}
 	}
 
-	// }}}
-	// {{{ protected function getSeverityString()
-
 	/**
 	 * Gets a string representation of this error's severity
 	 *
@@ -655,9 +591,6 @@ class SwatError
 
 		return $out;
 	}
-
-	// }}}
-	// {{{ protected function isSensitiveParameter()
 
 	/**
 	 * Detects whether or not a parameter is sensitive from the method-level
@@ -703,9 +636,6 @@ class SwatError
 		return $sensitive;
 	}
 
-	// }}}
-	// {{{ public static function setupHandler()
-
 	/**
 	 * Set the PHP error handler to use SwatError
 	 */
@@ -718,7 +648,6 @@ class SwatError
 		set_error_handler(array('SwatError', 'handle'), error_reporting());
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatErrorDisplayer.php
+++ b/Swat/SwatErrorDisplayer.php
@@ -14,7 +14,6 @@
  */
 abstract class SwatErrorDisplayer
 {
-	// {{{ public abstract function display()
 
 	/**
 	 * Displays a SwatError
@@ -23,7 +22,6 @@ abstract class SwatErrorDisplayer
 	 */
 	public abstract function display(SwatError $e);
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatErrorLogger.php
+++ b/Swat/SwatErrorLogger.php
@@ -14,7 +14,6 @@
  */
 abstract class SwatErrorLogger
 {
-	// {{{ public abstract function log()
 
 	/**
 	 * Logs a SwatError
@@ -23,7 +22,6 @@ abstract class SwatErrorLogger
 	 */
 	public abstract function log(SwatError $e);
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatExceptionDisplayer.php
+++ b/Swat/SwatExceptionDisplayer.php
@@ -15,7 +15,6 @@
  */
 abstract class SwatExceptionDisplayer
 {
-	// {{{ public abstract function display()
 
 	/**
 	 * Displays a SwatException
@@ -24,7 +23,6 @@ abstract class SwatExceptionDisplayer
 	 */
 	public abstract function display(SwatException $e);
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatExceptionLogger.php
+++ b/Swat/SwatExceptionLogger.php
@@ -14,7 +14,6 @@
  */
 abstract class SwatExceptionLogger
 {
-	// {{{ public abstract function log()
 
 	/**
 	 * Logs a SwatException
@@ -23,7 +22,6 @@ abstract class SwatExceptionLogger
 	 */
 	public abstract function log(SwatException $e);
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatExpandableCheckboxTree.php
+++ b/Swat/SwatExpandableCheckboxTree.php
@@ -10,7 +10,6 @@
  */
 class SwatExpandableCheckboxTree extends SwatCheckboxTree
 {
-	// {{{ class constants
 
 	/**
 	 * All branches are open
@@ -26,9 +25,6 @@ class SwatExpandableCheckboxTree extends SwatCheckboxTree
 	 * Branches with checked options are open (default)
 	 */
 	const BRANCH_STATE_AUTO   = 3;
-
-	// }}}
-	// {{{ public properties
 
 	/**
 	 * The initial branch state of the tree
@@ -67,13 +63,7 @@ class SwatExpandableCheckboxTree extends SwatCheckboxTree
 	 */
 	public $dependent_boxes = true;
 
-	// }}}
-	// {{{ protected properties
-
 	protected $checked_parents = array();
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new expandable checkbox tree
@@ -92,9 +82,6 @@ class SwatExpandableCheckboxTree extends SwatCheckboxTree
 			'packages/swat/javascript/swat-expandable-checkbox-tree.js'
 		);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this expandable checkbox tree
@@ -132,9 +119,6 @@ class SwatExpandableCheckboxTree extends SwatCheckboxTree
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this expandable
 	 * checkbox tree
@@ -148,9 +132,6 @@ class SwatExpandableCheckboxTree extends SwatCheckboxTree
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript for this expandable checkbox tree
@@ -189,9 +170,6 @@ class SwatExpandableCheckboxTree extends SwatCheckboxTree
 
 		return $javascript;
 	}
-
-	// }}}
-	// {{{ private function displayNode()
 
 	/**
 	 * Displays a node in a tree as a checkbox input
@@ -303,9 +281,6 @@ class SwatExpandableCheckboxTree extends SwatCheckboxTree
 		return $nodes;
 	}
 
-	// }}}
-	// {{{ private function nodeIsChecked()
-
 	/**
 	 * Check whether the checkbox should be checked
 	 *
@@ -334,9 +309,6 @@ class SwatExpandableCheckboxTree extends SwatCheckboxTree
 
 		return $checked;
 	}
-
-	// }}}
-	// {{{ private function getExpandableNodeIds()
 
 	/**
 	 * Gets the node XHTML ids of all expandable nodes in this expandable
@@ -378,7 +350,6 @@ class SwatExpandableCheckboxTree extends SwatCheckboxTree
 		return $expandable_ids;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatFieldset.php
+++ b/Swat/SwatFieldset.php
@@ -11,7 +11,6 @@
  */
 class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
 {
-	// {{{ public properties
 
 	/**
 	 * Fieldset title
@@ -40,9 +39,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
 	 */
 	public $access_key = null;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new fieldset
 	 *
@@ -62,9 +58,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
 		$this->addJavaScript('packages/swat/javascript/swat-fieldset.js');
 	}
 
-	// }}}
-	// {{{ public function getTitle()
-
 	/**
 	 * Gets the title of this fieldset
 	 *
@@ -77,9 +70,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
 		return $this->title;
 	}
 
-	// }}}
-	// {{{ public function getTitleContentType()
-
 	/**
 	 * Gets the title content-type of this fieldset
 	 *
@@ -91,9 +81,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
 	{
 		return $this->title_content_type;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	public function display()
 	{
@@ -124,9 +111,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
 		$fieldset_tag->close();
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets fieldset specific inline JavaScript
 	 *
@@ -137,9 +121,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
 		return sprintf("var %s_obj = new SwatFieldset('%s');",
 			$this->id, $this->id);
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this fieldset
@@ -153,7 +134,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatFileEntry.php
+++ b/Swat/SwatFileEntry.php
@@ -16,7 +16,6 @@
  */
 class SwatFileEntry extends SwatInputControl
 {
-	// {{{ public properties
 
 	/**
 	 * The size in characters of the XHTML form input, or null if no width is
@@ -83,9 +82,6 @@ class SwatFileEntry extends SwatInputControl
 	 */
 	public $display_maximum_upload_size = false;
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * Stores the relevant part of the $_FILES array for this widget after
 	 * the widget's parent is processed
@@ -105,9 +101,6 @@ class SwatFileEntry extends SwatInputControl
 	 * @var string
 	 */
 	private $mime_type;
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this entry widget
@@ -148,9 +141,6 @@ class SwatFileEntry extends SwatInputControl
 		}
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this file entry widget
 	 *
@@ -189,9 +179,6 @@ class SwatFileEntry extends SwatInputControl
 		}
 	}
 
-	// }}}
-	// {{{ public function getNote()
-
 	/**
 	 * Gets a note specifying the mime types this file entry accepts
 	 *
@@ -228,9 +215,6 @@ class SwatFileEntry extends SwatInputControl
 		return $message;
 	}
 
-	// }}}
-	// {{{ public function isUploaded()
-
 	/**
 	 * Is file uploaded
 	 *
@@ -240,9 +224,6 @@ class SwatFileEntry extends SwatInputControl
 	{
 		return ($this->file !== null);
 	}
-
-	// }}}
-	// {{{ public function getFileName()
 
 	/**
 	 * Gets the original file name of the uploaded file
@@ -256,9 +237,6 @@ class SwatFileEntry extends SwatInputControl
 	{
 		return ($this->isUploaded()) ? $this->file['name'] : null;
 	}
-
-	// }}}
-	// {{{ public function getUniqueFileName()
 
 	/**
 	 * Gets a unique file name for the uploaded file for the given path.
@@ -281,9 +259,6 @@ class SwatFileEntry extends SwatInputControl
 				'directory or does not exist.');
 	}
 
-	// }}}
-	// {{{ public function getTempFileName()
-
 	/**
 	 * Gets the temporary name of the uploaded file
 	 *
@@ -297,9 +272,6 @@ class SwatFileEntry extends SwatInputControl
 		return ($this->isUploaded()) ? $this->file['tmp_name'] : null;
 	}
 
-	// }}}
-	// {{{ public function getSize()
-
 	/**
 	 * Gets the size of the uploaded file in bytes
 	 *
@@ -310,9 +282,6 @@ class SwatFileEntry extends SwatInputControl
 	{
 		return ($this->isUploaded()) ? $this->file['size'] : null;
 	}
-
-	// }}}
-	// {{{ public function getMimeType()
 
 	/**
 	 * Gets the mime type of the uploaded file
@@ -354,9 +323,6 @@ class SwatFileEntry extends SwatInputControl
 		return $this->mime_type;
 	}
 
-	// }}}
-	// {{{ public function saveFile()
-
 	/**
 	 * Saves the uploaded file to the server
 	 *
@@ -387,9 +353,6 @@ class SwatFileEntry extends SwatInputControl
 				'directory or does not exist.');
 	}
 
-	// }}}
-	// {{{ public function getFocusableHtmlId()
-
 	/**
 	 * Gets the id attribute of the XHTML element displayed by this widget
 	 * that should receive focus
@@ -404,9 +367,6 @@ class SwatFileEntry extends SwatInputControl
 	{
 		return ($this->visible) ? $this->id : null;
 	}
-
-	// }}}
-	// {{{ public static function getMaximumFileUploadSize()
 
 	/**
 	 * Returns the size (in bytes) of the upload size limit of the PHP
@@ -424,9 +384,6 @@ class SwatFileEntry extends SwatInputControl
 		return min(self::parseFileUploadSize(ini_get('post_max_size')),
 			self::parseFileUploadSize(ini_get('upload_max_filesize')));
 	}
-
-	// }}}
-	// {{{ protected function getValidationMessage()
 
 	/**
 	 * Gets a validation message for this file entry
@@ -504,9 +461,6 @@ class SwatFileEntry extends SwatInputControl
 		return $message;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this file entry widget
 	 *
@@ -519,9 +473,6 @@ class SwatFileEntry extends SwatInputControl
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function hasValidMimeType()
 
 	/**
 	 * Whether or not the uploaded file's mime type is valid
@@ -560,17 +511,11 @@ class SwatFileEntry extends SwatInputControl
 		return $valid;
 	}
 
-	// }}}
-	// {{{ protected function getMaximumUploadSizeText()
-
 	protected function getMaximumUploadSizeText()
 	{
 		return sprintf(Swat::_('Maximum file size %s.'),
 			SwatString::byteFormat(self::getMaximumFileUploadSize()));
 	}
-
-	// }}}
-	// {{{ protected function getFinfo()
 
 	/**
 	 * Gets a new finfo resource
@@ -588,9 +533,6 @@ class SwatFileEntry extends SwatInputControl
 
 		return new finfo($mime_constant);
 	}
-
-	// }}}
-	// {{{ protected function getDisplayableTypes()
 
 	/**
 	 * Gets a unique array of acceptable human-readable file and mime types for
@@ -618,9 +560,6 @@ class SwatFileEntry extends SwatInputControl
 		return $displayable_types;
 	}
 
-	// }}}
-	// {{{ private function generateUniqueFileName()
-
 	private function generateUniqueFileName($path, $count = 0)
 	{
 		if (mb_strpos($this->getFileName(), '.') === false) {
@@ -642,9 +581,6 @@ class SwatFileEntry extends SwatInputControl
 		else
 			return $file_name;
 	}
-
-	// }}}
-	// {{{ private static function parseFileUploadSize()
 
 	private static function parseFileUploadSize($ini_value)
 	{
@@ -671,7 +607,6 @@ class SwatFileEntry extends SwatInputControl
 		return $value;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatFloatEntry.php
+++ b/Swat/SwatFloatEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatFloatEntry extends SwatNumericEntry
 {
-	// {{{ public function process()
 
 	/**
 	 * Checks to make sure value is a number
@@ -31,9 +30,6 @@ class SwatFloatEntry extends SwatNumericEntry
 		else
 			$this->value = $float_value;
 	}
-
-	// }}}
-	// {{{ protected function getDisplayValue()
 
 	/**
 	 * Formats a float value to display
@@ -58,9 +54,6 @@ class SwatFloatEntry extends SwatNumericEntry
 		return $value;
 	}
 
-	// }}}
-	// {{{ protected function getNumericValue()
-
 	/**
 	 * Gets the float value of this widget
 	 *
@@ -77,9 +70,6 @@ class SwatFloatEntry extends SwatNumericEntry
 		$locale = SwatI18NLocale::get();
 		return $locale->parseFloat($value);
 	}
-
-	// }}}
-	// {{{ protected function getValidationMessage()
 
 	/**
 	 * Gets a validation message for this float entry
@@ -109,9 +99,6 @@ class SwatFloatEntry extends SwatNumericEntry
 		return $message;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
 	 *
@@ -125,7 +112,6 @@ class SwatFloatEntry extends SwatNumericEntry
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatFlydown.php
+++ b/Swat/SwatFlydown.php
@@ -9,7 +9,6 @@
  */
 class SwatFlydown extends SwatOptionControl implements SwatState
 {
-	// {{{ public properties
 
 	/**
 	 * Flydown value
@@ -38,9 +37,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 	 * @var string
 	 */
 	public $blank_title = '';
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this flydown
@@ -148,9 +144,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 		$wrapper->close();
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Figures out what option was selected
 	 *
@@ -177,9 +170,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 		}
 	}
 
-	// }}}
-	// {{{ public function addDivider()
-
 	/**
 	 * Adds a divider to this flydown
 	 *
@@ -195,9 +185,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 		$this->options[] = new SwatFlydownDivider(null, $title, $content_type);
 	}
 
-	// }}}
-	// {{{ public function reset()
-
 	/**
 	 * Resets this flydown
 	 *
@@ -209,9 +196,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 		reset($this->options);
 		$this->value = null;
 	}
-
-	// }}}
-	// {{{ public function getState()
 
 	/**
 	 * Gets the current state of this flydown
@@ -225,9 +209,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 		return $this->value;
 	}
 
-	// }}}
-	// {{{ public function setState()
-
 	/**
 	 * Sets the current state of this flydown
 	 *
@@ -239,9 +220,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 	{
 		$this->value = $state;
 	}
-
-	// }}}
-	// {{{ public function getFocusableHtmlId()
 
 	/**
 	 * Gets the id attribute of the XHTML element displayed by this widget
@@ -269,9 +247,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 		return $focusable_id;
 	}
 
-	// }}}
-	// {{{ protected function processValue()
-
 	/**
 	 * Processes the value of this flydown from user-submitted form data
 	 *
@@ -295,9 +270,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 
 		return true;
 	}
-
-	// }}}
-	// {{{ protected function displaySingle()
 
 	/**
 	 * Displays this flydown if there is only a single option
@@ -326,9 +298,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 		$span_tag->display();
 	}
 
-	// }}}
-	// {{{ protected function getBlankOption()
-
 	/**
 	 * Gets the the blank option for this flydown.
 	 *
@@ -338,9 +307,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 	{
 		return new SwatFlydownBlankOption(null, $this->blank_title);
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this flydown
@@ -354,7 +320,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatFlydownDivider.php
+++ b/Swat/SwatFlydownDivider.php
@@ -12,7 +12,6 @@
  */
 class SwatFlydownDivider extends SwatOption
 {
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a flydown option
@@ -34,7 +33,6 @@ class SwatFlydownDivider extends SwatOption
 		parent::__construct($value, $title, $content_type);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatFooterFormField.php
+++ b/Swat/SwatFooterFormField.php
@@ -11,7 +11,6 @@
  */
 class SwatFooterFormField extends SwatFormField
 {
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this footer form field
@@ -26,7 +25,6 @@ class SwatFooterFormField extends SwatFormField
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatForm.php
+++ b/Swat/SwatForm.php
@@ -15,7 +15,6 @@
  */
 class SwatForm extends SwatDisplayableContainer
 {
-	// {{{ constants
 
 	const METHOD_POST = 'post';
 	const METHOD_GET  = 'get';
@@ -29,9 +28,6 @@ class SwatForm extends SwatDisplayableContainer
 	const ENCODING_ENTITY_VALUE = '&auml;&trade;&reg;';
 	const ENCODING_UTF8_VALUE   = "\xc3\xa4\xe2\x84\xa2\xc2\xae";
 	const ENCODING_8BIT_VALUE   = "\xe4\x99\xae";
-
-	// }}}
-	// {{{ public properties
 
 	/**
 	 * The action attribute of the HTML form tag
@@ -122,9 +118,6 @@ class SwatForm extends SwatDisplayableContainer
 	 */
 	public static $default_salt = null;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * Hidden form fields
 	 *
@@ -203,9 +196,6 @@ class SwatForm extends SwatDisplayableContainer
 	 */
 	protected $connection_close_uri = null;
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * The method to use for this form
 	 *
@@ -228,9 +218,6 @@ class SwatForm extends SwatDisplayableContainer
 	 * @see SwatForm::isAuthenticated()
 	 */
 	private static $authentication_token = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new form
@@ -260,9 +247,6 @@ class SwatForm extends SwatDisplayableContainer
 		$this->addJavaScript('packages/swat/javascript/swat-form.js');
 	}
 
-	// }}}
-	// {{{ public function setMethod()
-
 	/**
 	 * Sets the HTTP method this form uses to send data
 	 *
@@ -281,9 +265,6 @@ class SwatForm extends SwatDisplayableContainer
 		$this->method = $method;
 	}
 
-	// }}}
-	// {{{ public function getMethod()
-
 	/**
 	 * Gets the HTTP method this form uses to send data
 	 *
@@ -293,9 +274,6 @@ class SwatForm extends SwatDisplayableContainer
 	{
 		return $this->method;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this form
@@ -332,9 +310,6 @@ class SwatForm extends SwatDisplayableContainer
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this form
 	 *
@@ -360,9 +335,6 @@ class SwatForm extends SwatDisplayableContainer
 					$child->process();
 		}
 	}
-
-	// }}}
-	// {{{ public function addHiddenField()
 
 	/**
 	 * Adds a hidden form field
@@ -393,9 +365,6 @@ class SwatForm extends SwatDisplayableContainer
 
 		$this->hidden_fields[$name] = $value;
 	}
-
-	// }}}
-	// {{{ public function getHiddenField()
 
 	/**
 	 * Gets the value of a hidden form field
@@ -434,9 +403,6 @@ class SwatForm extends SwatDisplayableContainer
 		return $data;
 	}
 
-	// }}}
-	// {{{ public function clearHiddenFields()
-
 	/**
 	 * Clears all hidden fields
 	 */
@@ -444,9 +410,6 @@ class SwatForm extends SwatDisplayableContainer
 	{
 		$this->hidden_fields = array();
 	}
-
-	// }}}
-	// {{{ public function addWithField()
 
 	/**
 	 * Adds a widget within a new SwatFormField
@@ -466,9 +429,6 @@ class SwatForm extends SwatDisplayableContainer
 		$field->title = $title;
 		$this->add($field);
 	}
-
-	// }}}
-	// {{{ public function &getFormData()
 
 	/**
 	 * Returns the super-global array with this form's data
@@ -495,9 +455,6 @@ class SwatForm extends SwatDisplayableContainer
 		return $data;
 	}
 
-	// }}}
-	// {{{ public function isSubmitted()
-
 	/**
 	 * Whether or not this form was submitted on the previous page request
 	 *
@@ -515,9 +472,6 @@ class SwatForm extends SwatDisplayableContainer
 		return (isset($raw_data[self::PROCESS_FIELD]) &&
 			$raw_data[self::PROCESS_FIELD] == $this->id);
 	}
-
-	// }}}
-	// {{{ public function isAuthenticated()
 
 	/**
 	 * Whether or not this form is authenticated
@@ -557,9 +511,6 @@ class SwatForm extends SwatDisplayableContainer
 			self::$authentication_token === $token);
 	}
 
-	// }}}
-	// {{{ public function setSalt()
-
 	/**
 	 * Sets the salt value to use when salting signature data
 	 *
@@ -569,9 +520,6 @@ class SwatForm extends SwatDisplayableContainer
 	{
 		$this->salt = (string)$salt;
 	}
-
-	// }}}
-	// {{{ public function getSalt()
 
 	/**
 	 * Gets the salt value to use when salting signature data
@@ -590,9 +538,6 @@ class SwatForm extends SwatDisplayableContainer
 		return $this->salt;
 	}
 
-	// }}}
-	// {{{ public function set8BitEncoding()
-
 	/**
 	 * Sets the encoding to assume for 8-bit content submitted from clients
 	 *
@@ -608,9 +553,6 @@ class SwatForm extends SwatDisplayableContainer
 	{
 		$this->_8bit_encoding = $encoding;
 	}
-
-	// }}}
-	// {{{ public function setConnectionCloseUri()
 
 	/**
 	 * Sets the URI at which a Connection: close header may be sent to the
@@ -630,9 +572,6 @@ class SwatForm extends SwatDisplayableContainer
 		$this->connection_close_uri = $connection_close_uri;
 	}
 
-	// }}}
-	// {{{ public static function setDefault8BitEncoding()
-
 	/**
 	 * Sets the default encoding to assume for 8-bit content submitted from
 	 * clients
@@ -649,9 +588,6 @@ class SwatForm extends SwatDisplayableContainer
 	{
 		self::$default_8bit_encoding = $encoding;
 	}
-
-	// }}}
-	// {{{ public static function setDefaultConnectionCloseUri()
 
 	/**
 	 * Sets the default URI at which a Connection: close header may be sent to
@@ -672,9 +608,6 @@ class SwatForm extends SwatDisplayableContainer
 		self::$default_connection_close_uri = $connection_close_uri;
 	}
 
-	// }}}
-	// {{{ public static function setAuthenticationToken()
-
 	/**
 	 * Sets the token value used to prevent cross-site request forgeries
 	 *
@@ -694,9 +627,6 @@ class SwatForm extends SwatDisplayableContainer
 		self::$authentication_token = (string)$token;
 	}
 
-	// }}}
-	// {{{ public static function clearAuthenticationToken()
-
 	/**
 	 * Clears the token value used to prevent cross-site request forgeries
 	 *
@@ -709,9 +639,6 @@ class SwatForm extends SwatDisplayableContainer
 	{
 		self::$authentication_token = null;
 	}
-
-	// }}}
-	// {{{ protected function processHiddenFields()
 
 	/**
 	 * Checks submitted form data for hidden fields
@@ -743,9 +670,6 @@ class SwatForm extends SwatDisplayableContainer
 			}
 		}
 	}
-
-	// }}}
-	// {{{ protected function processEncoding()
 
 	/**
 	 * Detects 8-bit character encoding in form data and converts data to UTF-8
@@ -831,9 +755,6 @@ class SwatForm extends SwatDisplayableContainer
 		}
 	}
 
-	// }}}
-	// {{{ protected function notifyOfAdd()
-
 	/**
 	 * Notifies this widget that a widget was added
 	 *
@@ -861,9 +782,6 @@ class SwatForm extends SwatDisplayableContainer
 			}
 		}
 	}
-
-	// }}}
-	// {{{ protected function displayHiddenFields()
 
 	/**
 	 * Displays hidden form fields
@@ -951,9 +869,6 @@ class SwatForm extends SwatDisplayableContainer
 		echo '</div>';
 	}
 
-	// }}}
-	// {{{ protected fucntion getFormTag()
-
 	/**
 	 * Gets the XHTML form tag used to display this form
 	 *
@@ -981,9 +896,6 @@ class SwatForm extends SwatDisplayableContainer
 		return $form_tag;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this form
 	 *
@@ -995,9 +907,6 @@ class SwatForm extends SwatDisplayableContainer
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets inline JavaScript required for this form
@@ -1046,9 +955,6 @@ class SwatForm extends SwatDisplayableContainer
 		return $javascript;
 	}
 
-	// }}}
-	// {{{ protected function getJavaScriptClass()
-
 	/**
 	 * Gets the name of the JavaScript class to instantiate for this form
 	 *
@@ -1062,9 +968,6 @@ class SwatForm extends SwatDisplayableContainer
 	{
 		return 'SwatForm';
 	}
-
-	// }}}
-	// {{{ protected function serializeHiddenField()
 
 	/**
 	 * Serializes a hidden field value into a string safe for including in
@@ -1088,9 +991,6 @@ class SwatForm extends SwatDisplayableContainer
 
 		return $value;
 	}
-
-	// }}}
-	// {{{ protected function unserializeHiddenField()
 
 	/**
 	 * Unserializes a hidden field value that was serialized using
@@ -1117,7 +1017,6 @@ class SwatForm extends SwatDisplayableContainer
 		return $value;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatFormField.php
+++ b/Swat/SwatFormField.php
@@ -11,7 +11,6 @@
  */
 class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 {
-	// {{{ constants
 
 	/**
 	 * Indicates the required status display should highlight no fields.
@@ -27,9 +26,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 	 * Indicates the required status display should highlight optional fields.
 	 */
 	const SHOW_OPTIONAL = 2;
-
-	// }}}
-	// {{{ public properties
 
 	/**
 	 * The visible name for this field, or null
@@ -154,9 +150,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 	 */
 	public $show_title = true;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * Container tag to use
 	 *
@@ -184,9 +177,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 	 */
 	protected $widget_class;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new form field
 	 *
@@ -201,9 +191,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 		$this->addStyleSheet('packages/swat/styles/swat-message.css');
 	}
 
-	// }}}
-	// {{{ public function getTitle()
-
 	/**
 	 * Gets the title of this form field
 	 *
@@ -216,9 +203,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 		return $this->title;
 	}
 
-	// }}}
-	// {{{ public function getTitleContentType()
-
 	/**
 	 * Gets the title content-type of this form field
 	 *
@@ -230,9 +214,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 	{
 		return $this->title_content_type;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this form field
@@ -334,9 +315,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 		$container_tag->close();
 	}
 
-	// }}}
-	// {{{ protected function displayTitle()
-
 	protected function displayTitle()
 	{
 		if (!$this->show_title ||
@@ -350,9 +328,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 		$this->displayRequiredStatus();
 		$title_tag->close();
 	}
-
-	// }}}
-	// {{{ protected function displayRequiredStatus()
 
 	/**
 	 * Highlights required and/or optional fields according to the required
@@ -380,9 +355,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 		}
 	}
 
-	// }}}
-	// {{{ protected function displayContent()
-
 	protected function displayContent()
 	{
 		$contents_tag = new SwatHtmlTag($this->contents_tag);
@@ -392,9 +364,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 		$this->displayChildren();
 		$contents_tag->close();
 	}
-
-	// }}}
-	// {{{ protected function displayMessages()
 
 	protected function displayMessages()
 	{
@@ -431,9 +400,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 
 		$message_ul->close();
 	}
-
-	// }}}
-	// {{{ protected function displayNotes()
 
 	protected function displayNotes()
 	{
@@ -475,9 +441,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 		}
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this form field
 	 *
@@ -500,9 +463,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getTitleTag()
 
 	/**
 	 * Get a SwatHtmlTag to display the title
@@ -528,9 +488,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 
 		return $label_tag;
 	}
-
-	// }}}
-	// {{{ protected function notifyOfAdd()
 
 	/**
 	 * Notifies this widget that a widget was added
@@ -559,10 +516,7 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 		}
 	}
 
-	// }}}
-
 	// deprecated
-	// {{{ protected function displayRequired()
 
 	/**
 	 * @deprecated use the displayRequiredStatus() method instead
@@ -577,7 +531,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatFrame.php
+++ b/Swat/SwatFrame.php
@@ -9,7 +9,6 @@
  */
 class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
 {
-	// {{{ public properties
 
 	/**
 	 * A visible title for this frame, or null
@@ -51,9 +50,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
 	 */
 	public $header_level;
 
-	// }}}
-	// {{{ public function getTitle()
-
 	/**
 	 * Gets the title of this frame
 	 *
@@ -72,9 +68,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
 		return $this->title.': '.$this->subtitle;
 	}
 
-	// }}}
-	// {{{ public function getTitleContentType()
-
 	/**
 	 * Gets the title content-type of this frame
 	 *
@@ -86,9 +79,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
 	{
 		return $this->title_content_type;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this frame
@@ -109,9 +99,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
 		$this->displayContent();
 		$outer_div->close();
 	}
-
-	// }}}
-	// {{{ protected function displayTitle()
 
 	/**
 	 * Displays this frame's title
@@ -141,9 +128,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
 		}
 	}
 
-	// }}}
-	// {{{ protected function displayContent()
-
 	/**
 	 * Displays this frame's content
 	 */
@@ -156,9 +140,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
 		$inner_div->close();
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this frame
 	 *
@@ -170,9 +151,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getHeaderLevel()
 
 	protected function getHeaderLevel()
 	{
@@ -199,7 +177,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
 		return $level;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatFrameDisclosure.php
+++ b/Swat/SwatFrameDisclosure.php
@@ -9,7 +9,6 @@
  */
 class SwatFrameDisclosure extends SwatDisclosure
 {
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new frame disclosure container
@@ -24,9 +23,6 @@ class SwatFrameDisclosure extends SwatDisclosure
 
 		$this->addStyleSheet('packages/swat/styles/swat-frame-disclosure.css');
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this frame disclosure container
@@ -87,9 +83,6 @@ class SwatFrameDisclosure extends SwatDisclosure
 		$control_div->close();
 	}
 
-	// }}}
-	// {{{ protected function getContainerDivTag()
-
 	protected function getContainerDivTag()
 	{
 		$div = new SwatHtmlTag('div');
@@ -99,18 +92,12 @@ class SwatFrameDisclosure extends SwatDisclosure
 		return $div;
 	}
 
-	// }}}
-	// {{{ protected function getSpanTag()
-
 	protected function getSpanTag()
 	{
 		$span_tag = parent::getSpanTag();
 		$span_tag->class = null;
 		return $span_tag;
 	}
-
-	// }}}
-	// {{{ protected function getJavaScriptClass()
 
 	/**
 	 * Gets the name of the JavaScript class to instantiate for this disclosure
@@ -125,9 +112,6 @@ class SwatFrameDisclosure extends SwatDisclosure
 	{
 		return 'SwatFrameDisclosure';
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this disclosure
@@ -146,7 +130,6 @@ class SwatFrameDisclosure extends SwatDisclosure
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatGroupedFlydown.php
+++ b/Swat/SwatGroupedFlydown.php
@@ -12,7 +12,6 @@
  */
 class SwatGroupedFlydown extends SwatTreeFlydown
 {
-	// {{{ public function setTree()
 
 	/**
 	 * Sets the tree to use for display
@@ -29,9 +28,6 @@ class SwatGroupedFlydown extends SwatTreeFlydown
 		$this->checkTree($tree);
 		parent::setTree($tree);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this grouped flydown
@@ -78,9 +74,6 @@ class SwatGroupedFlydown extends SwatTreeFlydown
 		}
 	}
 
-	// }}}
-	// {{{ protected function checkTree()
-
 	/**
 	 * Checks a tree to ensure it is valid for a grouped flydown
 	 *
@@ -97,9 +90,6 @@ class SwatGroupedFlydown extends SwatTreeFlydown
 		foreach ($tree->getChildren() as $child)
 			$this->checkTree($child, $level + 1);
 	}
-
-	// }}}
-	// {{{ protected function displayNode()
 
 	/**
 	 * Displays a grouped tree flydown node and its child nodes
@@ -170,9 +160,6 @@ class SwatGroupedFlydown extends SwatTreeFlydown
 		}
 	}
 
-	// }}}
-	// {{{ protected function buildDisplayTree()
-
 	/**
 	 * Builds this grouped flydown's display tree by copying nodes from this
 	 * grouped flydown's tree
@@ -195,9 +182,6 @@ class SwatGroupedFlydown extends SwatTreeFlydown
 		foreach ($tree->getChildren() as $child)
 			$this->buildDisplayTree($child, $new_node, $path);
 	}
-
-	// }}}
-	// {{{ protected function getDisplayTree()
 
 	/**
 	 * Gets the display tree of this grouped flydown
@@ -224,7 +208,6 @@ class SwatGroupedFlydown extends SwatTreeFlydown
 		return $display_tree;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatGroupedMenu.php
+++ b/Swat/SwatGroupedMenu.php
@@ -11,7 +11,6 @@
  */
 class SwatGroupedMenu extends SwatAbstractMenu implements SwatUIParent
 {
-	// {{{ protected properties
 
 	/**
 	 * The set of SwatMenuGroup objects contained in this grouped menu
@@ -19,9 +18,6 @@ class SwatGroupedMenu extends SwatAbstractMenu implements SwatUIParent
 	 * @var array
 	 */
 	protected $groups = array();
-
-	// }}}
-	// {{{ public function addGroup()
 
 	/**
 	 * Adds a group to this grouped menu
@@ -33,9 +29,6 @@ class SwatGroupedMenu extends SwatAbstractMenu implements SwatUIParent
 		$this->groups[] = $group;
 		$group->parent = $this;
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child object
@@ -62,9 +55,6 @@ class SwatGroupedMenu extends SwatAbstractMenu implements SwatUIParent
 				'SwatGroupedMenu object.', 0, $child);
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this grouped menu
 	 */
@@ -74,9 +64,6 @@ class SwatGroupedMenu extends SwatAbstractMenu implements SwatUIParent
 		foreach ($this->groups as $group)
 			$group->init();
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this grouped menu
@@ -115,9 +102,6 @@ class SwatGroupedMenu extends SwatAbstractMenu implements SwatUIParent
 			Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function getDescendants()
-
 	/**
 	 * Gets descendant UI-objects
 	 *
@@ -154,9 +138,6 @@ class SwatGroupedMenu extends SwatAbstractMenu implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -190,9 +171,6 @@ class SwatGroupedMenu extends SwatAbstractMenu implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -212,9 +190,6 @@ class SwatGroupedMenu extends SwatAbstractMenu implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -230,9 +205,6 @@ class SwatGroupedMenu extends SwatAbstractMenu implements SwatUIParent
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -258,7 +230,6 @@ class SwatGroupedMenu extends SwatAbstractMenu implements SwatUIParent
 		return $copy;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatGroupingFormField.php
+++ b/Swat/SwatGroupingFormField.php
@@ -12,7 +12,6 @@
  */
 class SwatGroupingFormField extends SwatFormField
 {
-	// {{{ protected function getTitleTag()
 
 	/**
 	 * Get a SwatHtmlTag to display the title.
@@ -28,9 +27,6 @@ class SwatGroupingFormField extends SwatFormField
 
 		return $legend_tag;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this form field
@@ -64,9 +60,6 @@ class SwatGroupingFormField extends SwatFormField
 		$container_tag->close();
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this footer form field
 	 *
@@ -80,7 +73,6 @@ class SwatGroupingFormField extends SwatFormField
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatHeaderFormField.php
+++ b/Swat/SwatHeaderFormField.php
@@ -11,7 +11,6 @@
  */
 class SwatHeaderFormField extends SwatFormField
 {
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this header form field
@@ -26,7 +25,6 @@ class SwatHeaderFormField extends SwatFormField
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatHtmlHeadEntry.php
+++ b/Swat/SwatHtmlHeadEntry.php
@@ -12,7 +12,6 @@
  */
 abstract class SwatHtmlHeadEntry extends SwatObject
 {
-	// {{{ protected properties
 
 	/**
 	 * The uri of this head entry
@@ -35,9 +34,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
 	 */
 	protected $ie_condition = '';
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new HTML head entry
 	 *
@@ -47,9 +43,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
 	{
 		$this->uri = $uri;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this html head entry
@@ -68,9 +61,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
 		$this->closeIECondition();
 	}
 
-	// }}}
-	// {{{ public function displayInline()
-
 	/**
 	 * Displays the resource referenced by this html head entry inline
 	 *
@@ -85,9 +75,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
 		$this->closeIECondition();
 	}
 
-	// }}}
-	// {{{ public function getUri()
-
 	/**
 	 * Gets the URI of this HTML head entry
 	 *
@@ -98,9 +85,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
 		return $this->uri;
 	}
 
-	// }}}
-	// {{{ public function getType()
-
 	/**
 	 * Gets the type of this HTML head entry
 	 *
@@ -110,9 +94,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
 	{
 		return get_class($this);
 	}
-
-	// }}}
-	// {{{ public function getIECondition()
 
 	/**
 	 * Gets the conditional expression used to limit display for Internet
@@ -126,9 +107,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
 	{
 		return $this->ie_conditional;
 	}
-
-	// }}}
-	// {{{ public function setIECondition()
 
 	/**
 	 * Sets the conditional expression used to limit display for Internet
@@ -147,9 +125,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
 		$this->ie_condition = (string)$condition;
 	}
 
-	// }}}
-	// {{{ protected abstract function displayInternal()
-
 	/**
 	 * Displays this html head entry
 	 *
@@ -162,9 +137,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
 	 */
 	protected abstract function displayInternal($uri_prefix = '', $tag = null);
 
-	// }}}
-	// {{{ protected abstract function displayInlineInternal()
-
 	/**
 	 * Displays the resource referenced by this html head entry inline
 	 *
@@ -173,9 +145,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
 	 * @param string $path the path containing the resource files.
 	 */
 	protected abstract function displayInlineInternal($path);
-
-	// }}}
-	// {{{ protected function openIECondition()
 
 	/**
 	 * Renders the opening tag for the IE condditional if an IE conditional
@@ -196,9 +165,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ protected function closeIECondition()
-
 	/**
 	 * Renders the closing tag for the IE condditional if an IE conditional
 	 * is set
@@ -213,7 +179,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatHtmlHeadEntrySet.php
+++ b/Swat/SwatHtmlHeadEntrySet.php
@@ -12,7 +12,6 @@
  */
 class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 {
-	// {{{ protected properties
 
 	/**
 	 * HTML head entries managed by this collection
@@ -35,9 +34,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 		'/\.less$/' => 'SwatLessStyleSheetHtmlHeadEntry',
 	);
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new HTML head entry collection
 	 *
@@ -50,9 +46,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 			$this->addEntrySet($set);
 		}
 	}
-
-	// }}}
-	// {{{ public function addEntry()
 
 	/**
 	 * Adds a HTML head entry to this set
@@ -85,9 +78,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 		}
 	}
 
-	// }}}
-	// {{{ public function addEntrySet()
-
 	/**
 	 * Adds a set of HTML head entries to this set
 	 *
@@ -98,16 +88,10 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 		$this->entries = array_merge($this->entries, $set->entries);
 	}
 
-	// }}}
-	// {{{ public function toArray()
-
 	public function toArray()
 	{
 		return $this->entries;
 	}
-
-	// }}}
-	// {{{ public function count()
 
 	/**
 	 * Gets the number of entries in this set
@@ -120,9 +104,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 	{
 		return count($this->entries);
 	}
-
-	// }}}
-	// {{{ public function getIterator()
 
 	/**
 	 * Gets an iterator over the entries in this set
@@ -137,9 +118,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 		// interface.
 		return $this->entries;
 	}
-
-	// }}}
-	// {{{ public function addTypeMapping()
 
 	public function setTypeMapping($type, $class = null)
 	{
@@ -165,9 +143,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 		$this->type_map = array_merge($this->type_map, $type);
 	}
 
-	// }}}
-	// {{{ public function getByType()
-
 	/**
 	 * Gets a subset of this set by the entry type
 	 *
@@ -190,9 +165,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 		return $set;
 	}
 
-	// }}}
-	// {{{ protected function getClassFromType()
-
 	protected function getClassFromType($entry)
 	{
 		$class = null;
@@ -207,7 +179,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 		return $class;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatHtmlHeadEntrySetDisplayer.php
+++ b/Swat/SwatHtmlHeadEntrySetDisplayer.php
@@ -12,15 +12,11 @@
  */
 class SwatHtmlHeadEntrySetDisplayer extends SwatObject
 {
-	// {{{ protected properties
 
 	/**
 	 * @var Concentrate_Concentrator
 	 */
 	protected $concentrator;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new HTML head entry collection
@@ -31,9 +27,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
 	{
 		$this->concentrator = $concentrator;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays a set of HTML head entries
@@ -124,9 +117,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
 		echo "\n";
 	}
 
-	// }}}
-	// {{{ public function displayInline()
-
 	/**
 	 * Displays the contents of the set of HTML head entries inline
 	 */
@@ -157,9 +147,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
 
 		echo "\n";
 	}
-
-	// }}}
-	// {{{ protected function getCombinedEntries()
 
 	/**
 	 * Gets the entries of this set accounting for combining
@@ -192,9 +179,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
 			'superset' => $info['superset'],
 		);
 	}
-
-	// }}}
-	// {{{ protected function getSortedEntries()
 
 	/**
 	 * Gets the entries of this set sorted by their correct display order
@@ -231,9 +215,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
 
 		return $sorted_entries;
 	}
-
-	// }}}
-	// {{{ protected function compareEntries()
 
 	/**
 	 * Compares two {@link SwatHtmlHeadEntry} objects to get their display
@@ -300,9 +281,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
 		return 0;
 	}
 
-	// }}}
-	// {{{ protected function getTypeOrder()
-
 	/**
 	 * Gets the order in which HTML head entry types should be displayed
 	 *
@@ -326,9 +304,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
 			'__unknown__'                       => 6,
 		);
 	}
-
-	// }}}
-	// {{{ protected function checkForConflicts()
 
 	/**
 	 * Check for conflicts in a set of HTML head entry URIs
@@ -360,7 +335,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatHtmlTag.php
+++ b/Swat/SwatHtmlTag.php
@@ -9,7 +9,6 @@
  */
 class SwatHtmlTag extends SwatObject
 {
-	// {{{ private properties
 
 	/**
 	 * The name of the HTML tag
@@ -44,9 +43,6 @@ class SwatHtmlTag extends SwatObject
 	 */
 	private $content_type = 'text/plain';
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new HTML tag
 	 *
@@ -61,9 +57,6 @@ class SwatHtmlTag extends SwatObject
 		if (is_array($attributes))
 			$this->attributes = $attributes;
 	}
-
-	// }}}
-	// {{{ public function setContent()
 
 	/**
 	 * Set content for the body of the XHTML tag
@@ -86,9 +79,6 @@ class SwatHtmlTag extends SwatObject
 		$this->content_type = $type;
 	}
 
-	// }}}
-	// {{{ public function addAtributes()
-
 	/**
 	 * Adds an array of attributes to this XHTML tag
 	 *
@@ -105,9 +95,6 @@ class SwatHtmlTag extends SwatObject
 			$this->attributes = array_merge($this->attributes, $attributes);
 	}
 
-	// }}}
-	// {{{ public function removeAttribute()
-
 	/**
 	 * Removes an attribute
 	 *
@@ -120,9 +107,6 @@ class SwatHtmlTag extends SwatObject
 	{
 		unset($this->attributes[$attribute]);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this tag
@@ -147,9 +131,6 @@ class SwatHtmlTag extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ public function displayContent()
-
 	/**
 	 * Displays the content of this tag
 	 *
@@ -167,9 +148,6 @@ class SwatHtmlTag extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ public function open()
-
 	/**
 	 * Opens this tag
 	 *
@@ -184,9 +162,6 @@ class SwatHtmlTag extends SwatObject
 		$this->openInternal(false);
 	}
 
-	// }}}
-	// {{{ public function close()
-
 	/**
 	 * Closes this tag
 	 *
@@ -199,9 +174,6 @@ class SwatHtmlTag extends SwatObject
 	{
 		echo '</', $this->tag_name, '>';
 	}
-
-	// }}}
-	// {{{ public function toString()
 
 	/**
 	 * Gets this tag as a string
@@ -222,9 +194,6 @@ class SwatHtmlTag extends SwatObject
 		return ob_get_clean();
 	}
 
-	// }}}
-	// {{{ public function __get()
-
 	/**
 	 * Magic __get method
 	 *
@@ -244,9 +213,6 @@ class SwatHtmlTag extends SwatObject
 			return null;
 	}
 
-	// }}}
-	// {{{ public function __set()
-
 	/**
 	 * Magic __set method
 	 *
@@ -261,9 +227,6 @@ class SwatHtmlTag extends SwatObject
 		$this->attributes[$attribute] =
 			($value === null) ? null : (string)$value;
 	}
-
-	// }}}
-	// {{{ public function __toString()
 
 	/**
 	 * Gets this tag as a string
@@ -289,9 +252,6 @@ class SwatHtmlTag extends SwatObject
 	{
 		return $this->toString();
 	}
-
-	// }}}
-	// {{{ private function openInternal()
 
 	/**
 	 * Outputs opening tag and all attributes
@@ -319,7 +279,6 @@ class SwatHtmlTag extends SwatObject
 			echo '>';
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatImageButton.php
+++ b/Swat/SwatImageButton.php
@@ -12,7 +12,6 @@
  */
 class SwatImageButton extends SwatButton
 {
-	// {{{ public properties
 
 	/**
 	 * Image
@@ -46,9 +45,6 @@ class SwatImageButton extends SwatButton
 	 */
 	public $alt = null;
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Does button processing
 	 *
@@ -68,9 +64,6 @@ class SwatImageButton extends SwatButton
 			$this->getForm()->button = $this;
 		}
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this image button
@@ -119,9 +112,6 @@ class SwatImageButton extends SwatButton
 		}
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this button
 	 *
@@ -134,7 +124,6 @@ class SwatImageButton extends SwatButton
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatImageCellRenderer.php
+++ b/Swat/SwatImageCellRenderer.php
@@ -9,7 +9,6 @@
  */
 class SwatImageCellRenderer extends SwatCellRenderer
 {
-	// {{{ public properties
 
 	/**
 	 * The relative uri of the image file for this image renderer
@@ -100,9 +99,6 @@ class SwatImageCellRenderer extends SwatCellRenderer
 	 */
 	public $alt = null;
 
-	// }}}
-	// {{{ public function render()
-
 	/**
 	 * Renders the contents of this cell
 	 *
@@ -159,9 +155,6 @@ class SwatImageCellRenderer extends SwatCellRenderer
 		$image_tag->display();
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this cell renderer
 	 *
@@ -174,7 +167,6 @@ class SwatImageCellRenderer extends SwatCellRenderer
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatImageCropper.php
+++ b/Swat/SwatImageCropper.php
@@ -12,7 +12,6 @@
  */
 class SwatImageCropper extends SwatInputControl
 {
-	// {{{ public properties
 
 	/**
 	 * Image URI
@@ -129,9 +128,6 @@ class SwatImageCropper extends SwatInputControl
 	 */
 	public $crop_box_top;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new image cropper
 	 *
@@ -151,9 +147,6 @@ class SwatImageCropper extends SwatInputControl
 		$this->addJavaScript('packages/swat/javascript/swat-image-cropper.js');
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	public function process()
 	{
 		parent::process();
@@ -171,9 +164,6 @@ class SwatImageCropper extends SwatInputControl
 		$this->crop_box_left   = $this->crop_left;
 		$this->crop_box_top    = $this->crop_top;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this image cropper
@@ -228,9 +218,6 @@ class SwatImageCropper extends SwatInputControl
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets the inline JavaScript required by this image cropper
 	 *
@@ -281,9 +268,6 @@ class SwatImageCropper extends SwatInputControl
 		return sprintf("%1\$s_obj = new SwatImageCropper(".
 			"'%1\$s', {%2\$s});", $this->id, $options_string);
 	}
-
-	// }}}
-	// {{{ protected function autoCropBoxDimensions()
 
 	/**
 	 * Automatically sets crop box dimensions if they are not specified and
@@ -382,7 +366,6 @@ class SwatImageCropper extends SwatInputControl
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatImageDisplay.php
+++ b/Swat/SwatImageDisplay.php
@@ -11,7 +11,6 @@
  */
 class SwatImageDisplay extends SwatControl
 {
-	// {{{ public properties
 
 	/**
 	 * Image
@@ -92,9 +91,6 @@ class SwatImageDisplay extends SwatControl
 	 */
 	public $alt = null;
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this image
 	 */
@@ -134,9 +130,6 @@ class SwatImageDisplay extends SwatControl
 		$image_tag->display();
 	}
 
-	// }}}
-	// {{{ public static function getOccupyMargin()
-
 	public static function getOccupyMargin(
 		$width,
 		$height,
@@ -169,9 +162,6 @@ class SwatImageDisplay extends SwatControl
 		return $style;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this image display
 	 *
@@ -185,7 +175,6 @@ class SwatImageDisplay extends SwatControl
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatImageLinkCellRenderer.php
+++ b/Swat/SwatImageLinkCellRenderer.php
@@ -9,7 +9,6 @@
  */
 class SwatImageLinkCellRenderer extends SwatImageCellRenderer
 {
-	// {{{ public properties
 
 	/**
 	 * The href attribute in the XHTML anchor tag
@@ -38,9 +37,6 @@ class SwatImageLinkCellRenderer extends SwatImageCellRenderer
 	 * @see SwatImageLinkCellRenderer::$link
 	 */
 	public $link_value = null;
-
-	// }}}
-	// {{{ public function render()
 
 	/**
 	 * Renders the contents of this cell
@@ -72,7 +68,6 @@ class SwatImageLinkCellRenderer extends SwatImageCellRenderer
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatImagePreviewDisplay.php
+++ b/Swat/SwatImagePreviewDisplay.php
@@ -12,7 +12,6 @@
  */
 class SwatImagePreviewDisplay extends SwatImageDisplay
 {
-	// {{{ public properties
 
 	/**
 	 * Preview Image
@@ -140,9 +139,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
 	 */
 	public $close_text = null;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new image preview display
 	 *
@@ -173,9 +169,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
 
 		$this->title = Swat::_('View Larger Image');
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this image
@@ -218,9 +211,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
 		}
 	}
 
-	// }}}
-	// {{{ protected function isPreviewDisplayable()
-
 	/**
 	 * Checks whether the preview exists, and whether it should be displayed.
 	 *
@@ -243,9 +233,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
 		);
 	}
 
-	// }}}
-	// {{{ protected function getJavaScriptClass()
-
 	/**
 	 * Gets the name of the JavaScript class to instantiate for this image
 	 * preview display
@@ -261,9 +248,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
 	{
 		return 'SwatImagePreviewDisplay';
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets inline JavaScript required by this image preview.
@@ -306,9 +290,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
 		return $javascript;
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScriptTranslations()
-
 	/**
 	 * Gets translatable string resources for the JavaScript object for
 	 * this widget
@@ -325,9 +306,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
 			$close_text);
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this image display
 	 *
@@ -341,7 +319,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatInlineJavaScriptHtmlHeadEntry.php
+++ b/Swat/SwatInlineJavaScriptHtmlHeadEntry.php
@@ -7,15 +7,11 @@
  */
 class SwatInlineJavaScriptHtmlHeadEntry extends SwatHtmlHeadEntry
 {
-	// {{{ protected properties
 
 	/**
 	 * @var string
 	 */
 	protected $script;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new HTML head entry
@@ -28,23 +24,16 @@ class SwatInlineJavaScriptHtmlHeadEntry extends SwatHtmlHeadEntry
 		$this->script = $script;
 	}
 
-	// }}}
-	// {{{ protected function displayInternal()
-
 	protected function displayInternal($uri_prefix = '', $tag = null)
 	{
 		Swat::displayInlineJavaScript($this->script);
 	}
-
-	// }}}
-	// {{{ protected function displayInlineInternal()
 
 	protected function displayInlineInternal($path)
 	{
 		$this->displayInternal();
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatInputCell.php
+++ b/Swat/SwatInputCell.php
@@ -16,7 +16,6 @@
  */
 class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 {
-	// {{{ private properties
 
 	/**
 	 * A lookup array for widgets contained in this cell
@@ -53,18 +52,12 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 	 */
 	private $clones = array();
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * The prototype widget displayed in this cell
 	 *
 	 * @var SwatWidget
 	 */
 	protected $widget = null;
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child object
@@ -92,9 +85,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 				'multiple widgets.');
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this input cell
 	 *
@@ -109,9 +99,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 		if ($this->widget->id === null)
 			$this->widget->id = $this->widget->getUniqueId();
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this input cell given a numeric row identifier
@@ -128,9 +115,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 		$widget->process();
 	}
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this input cell given a numeric row identifier
 	 *
@@ -145,9 +129,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 		$widget = $this->getClonedWidget($row_identifier);
 		$widget->display();
 	}
-
-	// }}}
-	// {{{ public function getTitle()
 
 	/**
 	 * Gets the title of this input cell
@@ -164,9 +145,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 			return $this->parent->title;
 	}
 
-	// }}}
-	// {{{ public function getTitleContentType()
-
 	/**
 	 * Gets the title content-type of this input cell
 	 *
@@ -179,9 +157,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 		return 'text/plain';
 	}
 
-	// }}}
-	// {{{ public function setWidget()
-
 	/**
 	 * Sets the prototype widget of this input cell
 	 *
@@ -192,9 +167,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 		$this->widget = $widget;
 		$widget->parent = $this;
 	}
-
-	// }}}
-	// {{{ public function getPrototypeWidget()
 
 	/**
 	 * Gets the widget of this input cell
@@ -213,9 +185,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 	{
 		return $this->widget;
 	}
-
-	// }}}
-	// {{{ public function getWidget()
 
 	/**
 	 * Gets a particular widget in this input cell
@@ -248,9 +217,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 			'specified row identifier.');
 	}
 
-	// }}}
-	// {{{ public function unsetWidget()
-
 	/**
 	 * Unsets a cloned widget within this cell
 	 *
@@ -270,9 +236,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 			unset($this->clones[$replicator_id]);
 	}
 
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this input cell
 	 *
@@ -288,9 +251,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this input cell
 	 *
@@ -305,9 +265,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 		$set->addEntrySet($this->widget->getAvailableHtmlHeadEntrySet());
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -349,9 +306,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -388,9 +342,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -410,9 +361,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -428,9 +376,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -476,9 +421,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 		return $copy;
 	}
 
-	// }}}
-	// {{{ protected function getInputRow()
-
 	/**
 	 * Gets the input row this cell belongs to
 	 *
@@ -497,9 +439,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 
 		return $row;
 	}
-
-	// }}}
-	// {{{ protected function getClonedWidget()
 
 	/**
 	 * Gets a cloned widget given a unique identifier
@@ -563,7 +502,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 		return $new_widget;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatInputControl.php
+++ b/Swat/SwatInputControl.php
@@ -9,7 +9,6 @@
  */
 abstract class SwatInputControl extends SwatControl
 {
-	// {{{ public properties
 
 	/**
 	 * Whether this entry widget is required or not
@@ -27,9 +26,6 @@ abstract class SwatInputControl extends SwatControl
 	 */
 	public $show_field_title_in_messages = true;
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this widget
 	 *
@@ -44,9 +40,6 @@ abstract class SwatInputControl extends SwatControl
 		if ($this->required && $this->parent instanceof SwatFormField)
 			$this->parent->required = true;
 	}
-
-	// }}}
-	// {{{ public function getForm()
 
 	/**
 	 * Gets the form that this control is contained in
@@ -75,9 +68,6 @@ abstract class SwatInputControl extends SwatControl
 
 		return $form;
 	}
-
-	// }}}
-	// {{{ protected function getValidationMessage()
 
 	/**
 	 * Gets a validation message for this control
@@ -115,7 +105,6 @@ abstract class SwatInputControl extends SwatControl
 		return $message;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatIntegerEntry.php
+++ b/Swat/SwatIntegerEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatIntegerEntry extends SwatNumericEntry
 {
-	// {{{ public function process()
 
 	/**
 	 * Checks to make sure value is an integer
@@ -44,9 +43,6 @@ class SwatIntegerEntry extends SwatNumericEntry
 		}
 	}
 
-	// }}}
-	// {{{ protected function getDisplayValue()
-
 	/**
 	 * Formats an integer value to display
 	 *
@@ -70,9 +66,6 @@ class SwatIntegerEntry extends SwatNumericEntry
 		return $value;
 	}
 
-	// }}}
-	// {{{  protected function getNumericValue()
-
 	/**
 	 * Gets the numeric value of this widget
 	 *
@@ -89,9 +82,6 @@ class SwatIntegerEntry extends SwatNumericEntry
 		$locale = SwatI18NLocale::get();
 		return $locale->parseInteger($value);
 	}
-
-	// }}}
-	// {{{ protected function getValidationMessage()
 
 	/**
 	 * Gets a validation message for this integer entry
@@ -141,9 +131,6 @@ class SwatIntegerEntry extends SwatNumericEntry
 		return $message;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
 	 *
@@ -157,7 +144,6 @@ class SwatIntegerEntry extends SwatNumericEntry
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatJavaScriptHtmlHeadEntry.php
+++ b/Swat/SwatJavaScriptHtmlHeadEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatJavaScriptHtmlHeadEntry extends SwatHtmlHeadEntry
 {
-	// {{{ protected function displayInternal()
 
 	protected function displayInternal($uri_prefix = '', $tag = null)
 	{
@@ -27,9 +26,6 @@ class SwatJavaScriptHtmlHeadEntry extends SwatHtmlHeadEntry
 			$uri);
 	}
 
-	// }}}
-	// {{{ protected function displayInlineInternal()
-
 	protected function displayInlineInternal($path)
 	{
 		echo '<script type="text/javascript">';
@@ -37,7 +33,6 @@ class SwatJavaScriptHtmlHeadEntry extends SwatHtmlHeadEntry
 		echo '</script>';
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatLessStyleSheetHtmlHeadEntry.php
+++ b/Swat/SwatLessStyleSheetHtmlHeadEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatLessStyleSheetHtmlHeadEntry extends SwatStyleSheetHtmlHeadEntry
 {
-	// {{{ protected function displayInternal()
 
 	protected function displayInternal($uri_prefix = '', $tag = null)
 	{
@@ -27,15 +26,11 @@ class SwatLessStyleSheetHtmlHeadEntry extends SwatStyleSheetHtmlHeadEntry
 			$uri);
 	}
 
-	// }}}
-	// {{{ public function getStyleSheetHeadEntry()
-
 	public function getStyleSheetHeadEntry()
 	{
 		return new SwatStyleSheetHtmlHeadEntry($this->uri);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatLinkCellRenderer.php
+++ b/Swat/SwatLinkCellRenderer.php
@@ -9,7 +9,6 @@
  */
 class SwatLinkCellRenderer extends SwatCellRenderer
 {
-	// {{{ public properties
 
 	/**
 	 * The href attribute in the XHTML anchor tag
@@ -73,9 +72,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
 	 */
 	public $link_value = null;
 
-	// }}}
-	// {{{ public function render()
-
 	/**
 	 * Renders the contents of this cell
 	 *
@@ -94,9 +90,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
 			$this->renderInsensitive();
 	}
 
-	// }}}
-	// {{{ protected function isSensitive()
-
 	/**
 	 * Whether or not this link is sensitive
 	 *
@@ -111,9 +104,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
 		return ($this->sensitive && ($this->link !== null));
 	}
 
-	// }}}
-	// {{{ protected function renderSensitive()
-
 	/**
 	 * Renders this link as sensitive
 	 */
@@ -127,9 +117,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
 		$anchor_tag->display();
 	}
 
-	// }}}
-	// {{{ protected function renderInsensitive()
-
 	/**
 	 * Renders this link as not sensitive
 	 */
@@ -142,16 +129,10 @@ class SwatLinkCellRenderer extends SwatCellRenderer
 		$span_tag->display();
 	}
 
-	// }}}
-	// {{{ protected function getTitle()
-
 	protected function getTitle()
 	{
 		return null;
 	}
-
-	// }}}
-	// {{{ protected function getText()
 
 	protected function getText()
 	{
@@ -164,9 +145,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
 
 		return $text;
 	}
-
-	// }}}
-	// {{{ protected function getLink()
 
 	protected function getLink()
 	{
@@ -187,9 +165,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
 		return $link;
 	}
 
-	// }}}
-	// {{{ public function getDataSpecificCSSClassNames()
-
 	/**
 	 * Gets the data specific CSS class names for this cell renderer
 	 *
@@ -205,7 +180,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatLinkHtmlHeadEntry.php
+++ b/Swat/SwatLinkHtmlHeadEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatLinkHtmlHeadEntry extends SwatHtmlHeadEntry
 {
-	// {{{ protected properties
 
 	/**
 	 * The URI linked to by this link
@@ -39,9 +38,6 @@ class SwatLinkHtmlHeadEntry extends SwatHtmlHeadEntry
 	 */
 	protected $type;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new link HTML head entry
 	 *
@@ -67,9 +63,6 @@ class SwatLinkHtmlHeadEntry extends SwatHtmlHeadEntry
 		$this->title = $title;
 	}
 
-	// }}}
-	// {{{ protected function displayInternal()
-
 	protected function displayInternal($uri_prefix = '', $tag = null)
 	{
 		$link = new SwatHtmlTag('link');
@@ -80,15 +73,11 @@ class SwatLinkHtmlHeadEntry extends SwatHtmlHeadEntry
 		$link->display();
 	}
 
-	// }}}
-	// {{{ protected function displayInlineInternal()
-
 	protected function displayInlineInternal($path)
 	{
 		$this->displayInternal();
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatListEntry.php
+++ b/Swat/SwatListEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatListEntry extends SwatEntry
 {
-	// {{{ public properties
 
 	/**
 	 * The values of this list entry
@@ -73,9 +72,6 @@ class SwatListEntry extends SwatEntry
 	 */
 	public $min_entries = 1;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new list entry widget
 	 *
@@ -88,9 +84,6 @@ class SwatListEntry extends SwatEntry
 		parent::__construct($id);
 		$this->minlength = 1;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this list entry
@@ -109,9 +102,6 @@ class SwatListEntry extends SwatEntry
 
 		$this->maxlength = $old_maxlength;
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this list entry widget
@@ -214,9 +204,6 @@ class SwatListEntry extends SwatEntry
 		}
 	}
 
-	// }}}
-	// {{{ public function getState()
-
 	/**
 	 * Gets the current state of this entry widget
 	 *
@@ -228,9 +215,6 @@ class SwatListEntry extends SwatEntry
 	{
 		return $this->values;
 	}
-
-	// }}}
-	// {{{ public function setState()
 
 	/**
 	 * Sets the current state of this list entry widget
@@ -247,9 +231,6 @@ class SwatListEntry extends SwatEntry
 			$this->values = $this->splitValues($values);
 		}
 	}
-
-	// }}}
-	// {{{ public function getDisplayValue()
 
 	/**
 	 * Gets the value displayed in the XHTML input
@@ -269,9 +250,6 @@ class SwatListEntry extends SwatEntry
 			return implode($this->delimiter, $this->values);
 		}
 	}
-
-	// }}}
-	// {{{ public function getNote()
 
 	/**
 	 * Gets a note describing the rules on this list entry
@@ -321,9 +299,6 @@ class SwatListEntry extends SwatEntry
 		return $message;
 	}
 
-	// }}}
-	// {{{ protected function splitValues()
-
 	/**
 	 * Splits a value string with entries separated by delimiters into
 	 * an array
@@ -349,9 +324,6 @@ class SwatListEntry extends SwatEntry
 		return preg_split($expression, $value, -1, PREG_SPLIT_NO_EMPTY);
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
 	 *
@@ -365,7 +337,6 @@ class SwatListEntry extends SwatEntry
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatMenu.php
+++ b/Swat/SwatMenu.php
@@ -11,7 +11,6 @@
  */
 class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 {
-	// {{{ protected properties
 
 	/**
 	 * The set of SwatMenuItem objects contained in this menu
@@ -19,9 +18,6 @@ class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 	 * @var array
 	 */
 	protected $items = array();
-
-	// }}}
-	// {{{ public function addItem()
 
 	/**
 	 * Adds a menu item to this menu
@@ -33,9 +29,6 @@ class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 		$this->items[] = $item;
 		$item->parent = $this;
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child object
@@ -61,9 +54,6 @@ class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 				'SwatMenu object.', 0, $child);
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this menu
 	 */
@@ -73,9 +63,6 @@ class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 		foreach ($this->items as $item)
 			$item->init();
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this menu
@@ -128,9 +115,6 @@ class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 			Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function getDescendants()
-
 	/**
 	 * Gets descendant UI-objects
 	 *
@@ -167,9 +151,6 @@ class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -203,9 +184,6 @@ class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -225,9 +203,6 @@ class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -243,9 +218,6 @@ class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -271,9 +243,6 @@ class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 		return $copy;
 	}
 
-	// }}}
-	// {{{ protected function getMenuItemCSSClassName()
-
 	/**
 	 * Gets the CSS class name to use for menu items in this menu
 	 *
@@ -283,9 +252,6 @@ class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 	{
 		return 'yuimenuitem';
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this menu
@@ -299,7 +265,6 @@ class SwatMenu extends SwatAbstractMenu implements SwatUIParent
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatMenuBar.php
+++ b/Swat/SwatMenuBar.php
@@ -15,7 +15,6 @@
  */
 class SwatMenuBar extends SwatMenu
 {
-	// {{{ protected function getJavaScriptClass()
 
 	/**
 	 * Gets the name of the JavaScript class to instantiate for this menu
@@ -29,9 +28,6 @@ class SwatMenuBar extends SwatMenu
 		return 'YAHOO.widget.MenuBar';
 	}
 
-	// }}}
-	// {{{ protected function getMenuItemCSSClass()
-
 	/**
 	 * Gets the CSS class name to use for menu items in this menu
 	 *
@@ -41,9 +37,6 @@ class SwatMenuBar extends SwatMenu
 	{
 		return 'yuimenubaritem';
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this menu bar
@@ -57,7 +50,6 @@ class SwatMenuBar extends SwatMenu
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatMenuGroup.php
+++ b/Swat/SwatMenuGroup.php
@@ -15,7 +15,6 @@
  */
 class SwatMenuGroup extends SwatControl implements SwatUIParent
 {
-	// {{{ public properties
 
 	/**
 	 * The user-visible title of this group
@@ -24,18 +23,12 @@ class SwatMenuGroup extends SwatControl implements SwatUIParent
 	 */
 	public $title;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * The set of SwatMenuItem objects contained in this group
 	 *
 	 * @var array
 	 */
 	protected $items = array();
-
-	// }}}
-	// {{{ public function addItem()
 
 	/**
 	 * Adds a menu item to this group
@@ -47,9 +40,6 @@ class SwatMenuGroup extends SwatControl implements SwatUIParent
 		$this->items[] = $item;
 		$item->parent = $this;
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child object
@@ -75,9 +65,6 @@ class SwatMenuGroup extends SwatControl implements SwatUIParent
 				'Only SwatMenuItem objects may be nested within a '.
 				'SwatMenuGroup object.', 0, $child);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this menu group
@@ -130,9 +117,6 @@ class SwatMenuGroup extends SwatControl implements SwatUIParent
 		$ul_tag->close();
 	}
 
-	// }}}
-	// {{{ public function setMenuItemValues()
-
 	/**
 	 * Sets the value of all {@link SwatMenuItem} objects within this menu
 	 * group
@@ -148,9 +132,6 @@ class SwatMenuGroup extends SwatControl implements SwatUIParent
 		foreach ($items as $item)
 			$item->value = $value;
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -188,9 +169,6 @@ class SwatMenuGroup extends SwatControl implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -224,9 +202,6 @@ class SwatMenuGroup extends SwatControl implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -246,9 +221,6 @@ class SwatMenuGroup extends SwatControl implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -264,9 +236,6 @@ class SwatMenuGroup extends SwatControl implements SwatUIParent
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -292,7 +261,6 @@ class SwatMenuGroup extends SwatControl implements SwatUIParent
 		return $copy;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatMenuItem.php
+++ b/Swat/SwatMenuItem.php
@@ -15,7 +15,6 @@
  */
 class SwatMenuItem extends SwatControl implements SwatUIParent
 {
-	// {{{ public properties
 
 	/**
 	 * The URI-reference (see RFC2396) linked by this menu item
@@ -67,9 +66,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 	 */
 	public $stock_id = null;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * The sub menu of this menu item
 	 *
@@ -86,9 +82,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 	 */
 	protected $stock_class = null;
 
-	// }}}
-	// {{{ public function setSubMenu()
-
 	/**
 	 * Sets the sub-menu of this menu item
 	 *
@@ -99,9 +92,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 		$this->sub_menu = $menu;
 		$menu->parent = $this;
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child object
@@ -134,9 +124,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this menu item
 	 */
@@ -150,9 +137,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 		if ($this->sub_menu !== null)
 			$this->sub_menu->init();
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this menu item
@@ -190,9 +174,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 
 		$this->displaySubMenu();
 	}
-
-	// }}}
-	// {{{ public function setFromStock()
 
 	/**
 	 * Sets the values of this menu item to a stock type
@@ -275,9 +256,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 		$this->stock_class = $class;
 	}
 
-	// }}}
-	// {{{ public function getDescendants()
-
 	/**
 	 * Gets descendant UI-objects
 	 *
@@ -316,9 +294,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -345,9 +320,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -367,9 +339,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -385,9 +354,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -413,9 +379,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 		return $copy;
 	}
 
-	// }}}
-	// {{{ protected function displaySubMenu()
-
 	/**
 	 * Displays this menu item's sub-menu
 	 */
@@ -424,9 +387,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 		if ($this->sub_menu !== null)
 			$this->sub_menu->display();
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this menu item
@@ -446,7 +406,6 @@ class SwatMenuItem extends SwatControl implements SwatUIParent
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatMessage.php
+++ b/Swat/SwatMessage.php
@@ -26,7 +26,6 @@
  */
 class SwatMessage extends SwatObject
 {
-	// {{{ constants
 
 	/**
 	 * Notification message type
@@ -68,9 +67,6 @@ class SwatMessage extends SwatObject
 	 */
 	const SYSTEM_ERROR = 'system-error';
 
-	// }}}
-	// {{{ public properties
-
 	/**
 	 * Type of message
 	 *
@@ -107,9 +103,6 @@ class SwatMessage extends SwatObject
 	 */
 	public $content_type = 'text/plain';
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new SwatMessage
 	 *
@@ -126,9 +119,6 @@ class SwatMessage extends SwatObject
 		$this->primary_content = $primary_content;
 		$this->type = $type;
 	}
-
-	// }}}
-	// {{{ public function getCSSClassString()
 
 	/**
 	 * Gets the CSS class names of this message as a string
@@ -156,9 +146,6 @@ class SwatMessage extends SwatObject
 		return implode(' ', $classes);
 	}
 
-	// }}}
-	// {{{ public function getCssClass()
-
 	/**
 	 * An alias for SwatMessage::getCSSClassString()
 	 *
@@ -171,7 +158,6 @@ class SwatMessage extends SwatObject
 		return $this->getCSSClassString();
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatMessageDisplay.php
+++ b/Swat/SwatMessageDisplay.php
@@ -9,7 +9,6 @@
  */
 class SwatMessageDisplay extends SwatControl
 {
-	// {{{ class constants
 
 	/**
 	 * Dismiss link for message is on.
@@ -29,9 +28,6 @@ class SwatMessageDisplay extends SwatControl
 	 */
 	const DISMISS_AUTO = 3;
 
-	// }}}
-	// {{{ public properties
-
 	/**
 	 * Text to display for closing the message
 	 *
@@ -40,9 +36,6 @@ class SwatMessageDisplay extends SwatControl
 	 * @var string
 	 */
 	public $close_text = null;
-
-	// }}}
-	// {{{ protected properties
 
 	/**
 	 * The messages to display
@@ -62,9 +55,6 @@ class SwatMessageDisplay extends SwatControl
 	 * @var array
 	 */
 	protected $dismissable_messages = array();
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new message display
@@ -89,9 +79,6 @@ class SwatMessageDisplay extends SwatControl
 		$this->addStyleSheet('packages/swat/styles/swat-message.css');
 		$this->addStyleSheet('packages/swat/styles/swat-message-display.css');
 	}
-
-	// }}}
-	// {{{ public function add()
 
 	/**
 	 * Adds a message
@@ -133,9 +120,6 @@ class SwatMessageDisplay extends SwatControl
 		if ($dismissable == self::DISMISS_ON)
 			$this->dismissable_messages[] = count($this->display_messages) - 1;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays messages in this message display
@@ -182,9 +166,6 @@ class SwatMessageDisplay extends SwatControl
 			Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function isVisible()
-
 	/**
 	 * Gets whether or not this message display is visible
 	 *
@@ -202,9 +183,6 @@ class SwatMessageDisplay extends SwatControl
 		return (($this->getMessageCount() > 0) && parent::isVisible());
 	}
 
-	// }}}
-	// {{{ public function getMessageCount()
-
 	/**
 	 * Gets the number of messages in this message display
 	 *
@@ -214,9 +192,6 @@ class SwatMessageDisplay extends SwatControl
 	{
 		return count($this->display_messages);
 	}
-
-	// }}}
-	// {{{ protected function displayMessage()
 
 	/**
 	 * Display a single message of this message display
@@ -274,9 +249,6 @@ class SwatMessageDisplay extends SwatControl
 		$message_div->close();
 	}
 
-	// }}}
-	// {{{ protected function getDismissableMessageTypes()
-
 	/**
 	 * Gets an array of message types that are dismissable by default
 	 *
@@ -291,9 +263,6 @@ class SwatMessageDisplay extends SwatControl
 		);
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this message display
 	 *
@@ -306,9 +275,6 @@ class SwatMessageDisplay extends SwatControl
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript for hiding messages
@@ -334,9 +300,6 @@ class SwatMessageDisplay extends SwatControl
 		return $javascript;
 	}
 
-	// }}}
-	// {{{ protected function getJavaScriptClass()
-
 	/**
 	 * Gets the name of the JavaScript class to instantiate for this message
 	 * display
@@ -352,9 +315,6 @@ class SwatMessageDisplay extends SwatControl
 		return 'SwatMessageDisplay';
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScriptTranslations()
-
 	/**
 	 * Gets translatable string resources for the JavaScript object for
 	 * this widget
@@ -369,7 +329,6 @@ class SwatMessageDisplay extends SwatControl
 		return "SwatMessageDisplayMessage.close_text = '{$close_text}';\n";
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatMoneyCellRenderer.php
+++ b/Swat/SwatMoneyCellRenderer.php
@@ -9,7 +9,6 @@
  */
 class SwatMoneyCellRenderer extends SwatCellRenderer
 {
-	// {{{ public properties
 
 	/**
 	 * Optional locale for currency format
@@ -75,9 +74,6 @@ class SwatMoneyCellRenderer extends SwatCellRenderer
 	 */
 	public $null_display_value = null;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a money cell renderer
 	 */
@@ -89,9 +85,6 @@ class SwatMoneyCellRenderer extends SwatCellRenderer
 			'packages/swat/styles/swat-money-cell-renderer.css'
 		);
 	}
-
-	// }}}
-	// {{{ public function render()
 
 	/**
 	 * Renders the contents of this cell
@@ -125,9 +118,6 @@ class SwatMoneyCellRenderer extends SwatCellRenderer
 		}
 	}
 
-	// }}}
-	// {{{ protected function getCurrencyFormat()
-
 	/**
 	 * Gets currency format to use when rendering
 	 *
@@ -140,7 +130,6 @@ class SwatMoneyCellRenderer extends SwatCellRenderer
 		return $format;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatMoneyEntry.php
+++ b/Swat/SwatMoneyEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatMoneyEntry extends SwatFloatEntry
 {
-	// {{{ public properties
 
 	/**
 	 * Optional locale for currency format
@@ -42,9 +41,6 @@ class SwatMoneyEntry extends SwatFloatEntry
 	 */
 	public $decimal_places = null;
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this money entry widget
 	 *
@@ -63,9 +59,6 @@ class SwatMoneyEntry extends SwatFloatEntry
 				$locale->getInternationalCurrencySymbol());
 		}
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this money entry widget
@@ -147,9 +140,6 @@ class SwatMoneyEntry extends SwatFloatEntry
 		}
 	}
 
-	// }}}
-	// {{{ protected function getDisplayValue()
-
 	/**
 	 * Formats a monetary value to display
 	 *
@@ -168,9 +158,6 @@ class SwatMoneyEntry extends SwatFloatEntry
 		return $value;
 	}
 
-	// }}}
-	// {{{ protected function getNumericValue()
-
 	/**
 	 * Gets the numeric value of this money entry
 	 *
@@ -183,9 +170,6 @@ class SwatMoneyEntry extends SwatFloatEntry
 	{
 		return SwatI18NLocale::get($this->locale)->parseCurrency($value);
 	}
-
-	// }}}
-	// {{{ protected function getValidationMessage()
 
 	/**
 	 * Gets a validation message for this money entry widget
@@ -238,9 +222,6 @@ class SwatMoneyEntry extends SwatFloatEntry
 		return $message;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
 	 *
@@ -254,7 +235,6 @@ class SwatMoneyEntry extends SwatFloatEntry
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatNavBar.php
+++ b/Swat/SwatNavBar.php
@@ -10,7 +10,6 @@
  */
 class SwatNavBar extends SwatControl implements Countable
 {
-	// {{{ public properties
 
 	/**
 	 * Whether or not to display the last entry in this navbar as a link
@@ -41,9 +40,6 @@ class SwatNavBar extends SwatControl implements Countable
 	 */
 	public $container_tag;
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * Array of SwatNavBarEntry objects displayed in this navbar
 	 *
@@ -52,9 +48,6 @@ class SwatNavBar extends SwatControl implements Countable
 	 * @see SwatNavBarEntry
 	 */
 	private $entries = array();
-
-	// }}}
-	// {{{ public function createEntry()
 
 	/**
 	 * Creates a SwatNavBarEntry and adds it to the end of this navigation bar
@@ -71,9 +64,6 @@ class SwatNavBar extends SwatControl implements Countable
 		$this->addEntry(new SwatNavBarEntry($title, $link, $content_type));
 	}
 
-	// }}}
-	// {{{ public function addEntry()
-
 	/**
 	 * Adds a SwatNavBarEntry to the end of this navigation bar
 	 *
@@ -83,9 +73,6 @@ class SwatNavBar extends SwatControl implements Countable
 	{
 		$this->entries[] = $entry;
 	}
-
-	// }}}
-	// {{{ public function addEntries()
 
 	/**
 	 * Adds an array of SwatNavBarEntry to the end of this navigation bar
@@ -98,9 +85,6 @@ class SwatNavBar extends SwatControl implements Countable
 			$this->entries[] = $entry;
 	}
 
-	// }}}
-	// {{{ public function addEntryToStart()
-
 	/**
 	 * Adds a SwatNavBarEntry to the beginning of this navigation bar
 	 *
@@ -110,9 +94,6 @@ class SwatNavBar extends SwatControl implements Countable
 	{
 		array_unshift($this->entries, $entry);
 	}
-
-	// }}}
-	// {{{ public function replaceEntryByPosition()
 
 	/**
 	 * Replaces an entry in this navigation bar
@@ -146,9 +127,6 @@ class SwatNavBar extends SwatControl implements Countable
 			$position));
 	}
 
-	// }}}
-	// {{{ public function getEntryByPosition()
-
 	/**
 	 * Gets an entry from this navigation bar
 	 *
@@ -178,9 +156,6 @@ class SwatNavBar extends SwatControl implements Countable
 				$position));
 	}
 
-	// }}}
-	// {{{ public function getLastEntry()
-
 	/**
 	 * Gets the last entry from this navigation bar
 	 *
@@ -198,9 +173,6 @@ class SwatNavBar extends SwatControl implements Countable
 		return end($this->entries);
 	}
 
-	// }}}
-	// {{{ public function getCount()
-
 	/**
 	 * Gets the number of entries in this navigational bar
 	 *
@@ -214,9 +186,6 @@ class SwatNavBar extends SwatControl implements Countable
 		return count($this->entries);
 	}
 
-	// }}}
-	// {{{ public function count()
-
 	/**
 	 * Gets the number of entries in this navigational bar
 	 *
@@ -228,9 +197,6 @@ class SwatNavBar extends SwatControl implements Countable
 	{
 		return count($this->entries);
 	}
-
-	// }}}
-	// {{{ public function popEntry()
 
 	/**
 	 * Pops the last entry off the end of this navigational bar
@@ -249,9 +215,6 @@ class SwatNavBar extends SwatControl implements Countable
 		else
 			return array_pop($this->entries);
 	}
-
-	// }}}
-	// {{{ public function popEntries()
 
 	/**
 	 * Pops one or more entries off the end of this navigational bar
@@ -282,9 +245,6 @@ class SwatNavBar extends SwatControl implements Countable
 		}
 	}
 
-	// }}}
-	// {{{ public function clear()
-
 	/**
 	 * Clears all entries from this navigational bar
 	 *
@@ -297,9 +257,6 @@ class SwatNavBar extends SwatControl implements Countable
 		$this->entries = array();
 		return $entries;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this navigational bar
@@ -336,9 +293,6 @@ class SwatNavBar extends SwatControl implements Countable
 		$container_tag->close();
 	}
 
-	// }}}
-	// {{{ protected function displayEntry()
-
 	/**
 	 * Displays an entry in this navigational bar
 	 *
@@ -374,9 +328,6 @@ class SwatNavBar extends SwatControl implements Countable
 		}
 	}
 
-	// }}}
-	// {{{ protected function getLink()
-
 	/**
 	 * Gets the link from an entry.
 	 *
@@ -388,9 +339,6 @@ class SwatNavBar extends SwatControl implements Countable
 	{
 		return $entry->link;
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this navigational bar
@@ -404,9 +352,6 @@ class SwatNavBar extends SwatControl implements Countable
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getContainerTag()
 
 	/**
 	 * Gets the container tag for this navigational bar
@@ -427,7 +372,6 @@ class SwatNavBar extends SwatControl implements Countable
 		return $tag;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatNavBarEntry.php
+++ b/Swat/SwatNavBarEntry.php
@@ -11,7 +11,6 @@
  */
 class SwatNavBarEntry extends SwatObject
 {
-	// {{{ public properties
 
 	/**
 	 * The visible title of this entry
@@ -39,9 +38,6 @@ class SwatNavBarEntry extends SwatObject
 	 */
 	public $content_type = 'text/plain';
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new navbar entry
 	 *
@@ -59,7 +55,6 @@ class SwatNavBarEntry extends SwatObject
 		$this->content_type = $content_type;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatNoteBook.php
+++ b/Swat/SwatNoteBook.php
@@ -10,7 +10,6 @@
  */
 class SwatNoteBook extends SwatWidget implements SwatUIParent
 {
-	// {{{ constants
 
 	/**
 	 * Positions notebook tabs on the top of notebook pages.
@@ -32,9 +31,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 	 */
 	const POSITION_LEFT   = 4;
 
-	// }}}
-	// {{{ public properties
-
 	/**
 	 * Position of tabs for this notebook
 	 *
@@ -52,9 +48,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 	 */
 	public $selected_page;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * Note book child objects initally added to this widget
 	 *
@@ -68,9 +61,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 	 * @var array
 	 */
 	protected $pages = array();
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new notebook
@@ -88,9 +78,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 
 		$this->addStyleSheet('packages/swat/styles/swat-note-book.css');
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a {@link SwatNoteBookChild} to this notebook
@@ -122,9 +109,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ public function addPage()
-
 	/**
 	 * Adds a {@link SwatNoteBookPage} to this notebook
 	 *
@@ -135,9 +119,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 		$this->pages[] = $page;
 		$page->parent = $this;
 	}
-
-	// }}}
-	// {{{ public function getPage()
 
 	/**
 	 * Gets a page in this notebook
@@ -163,9 +144,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 		return $found_page;
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this notebook
 	 */
@@ -185,9 +163,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this notebook
 	 */
@@ -198,9 +173,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 			$page->process();
 		}
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this notebook
@@ -255,9 +227,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function printWidgetTree()
-
 	public function printWidgetTree()
 	{
 		echo get_class($this), ' ', $this->id;
@@ -272,9 +241,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 			echo '</ul>';
 		}
 	}
-
-	// }}}
-	// {{{ public function getMessages()
 
 	/**
 	 * Gets all messaages
@@ -296,9 +262,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 		return $messages;
 	}
 
-	// }}}
-	// {{{ public function hasMessage()
-
 	/**
 	 * Checks for the presence of messages
 	 *
@@ -318,9 +281,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 
 		return $has_message;
 	}
-
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
 
 	/**
 	 * Gets the {@link SwatHtmlHeadEntry} objects needed by this notebook
@@ -342,9 +302,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the {@link SwatHtmlHeadEntry} objects that may be needed by this
 	 * notebook
@@ -365,9 +322,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -406,9 +360,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -442,9 +393,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -464,9 +412,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -482,9 +427,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -509,9 +451,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 
 		return $copy;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript used by this notebook
@@ -541,7 +480,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 				$this->id, $this->id, $position);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatNoteBookChild.php
+++ b/Swat/SwatNoteBookChild.php
@@ -11,7 +11,6 @@
  */
 interface SwatNoteBookChild
 {
-	// {{{ public function getPages()
 
 	/**
 	 * Gets the notebook pages of this child
@@ -22,7 +21,6 @@ interface SwatNoteBookChild
 	 */
 	public function getPages();
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatNoteBookPage.php
+++ b/Swat/SwatNoteBookPage.php
@@ -10,7 +10,6 @@
  */
 class SwatNoteBookPage extends SwatContainer implements SwatNoteBookChild
 {
-	// {{{ public properties
 
 	/**
 	 * The title of this page
@@ -28,9 +27,6 @@ class SwatNoteBookPage extends SwatContainer implements SwatNoteBookChild
 	 */
 	public $title_content_type = 'text/plain';
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new notebook page
 	 *
@@ -42,9 +38,6 @@ class SwatNoteBookPage extends SwatContainer implements SwatNoteBookChild
 
 		$this->requires_id = true;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this notebook page
@@ -65,9 +58,6 @@ class SwatNoteBookPage extends SwatContainer implements SwatNoteBookChild
 		$div_tag->close();
 	}
 
-	// }}}
-	// {{{ public function getPages()
-
 	/**
 	 * Gets the notebook pages of this notebook page
 	 *
@@ -79,9 +69,6 @@ class SwatNoteBookPage extends SwatContainer implements SwatNoteBookChild
 	{
 		return array($this);
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this page
@@ -96,7 +83,6 @@ class SwatNoteBookPage extends SwatContainer implements SwatNoteBookChild
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatNullTextCellRenderer.php
+++ b/Swat/SwatNullTextCellRenderer.php
@@ -10,7 +10,6 @@
  */
 class SwatNullTextCellRenderer extends SwatTextCellRenderer
 {
-	// {{{ public properties
 
 	/**
 	 * The text to display in this cell if the
@@ -29,9 +28,6 @@ class SwatNullTextCellRenderer extends SwatTextCellRenderer
 	 */
 	public $strict = false;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a null text cell renderer
 	 */
@@ -43,9 +39,6 @@ class SwatNullTextCellRenderer extends SwatTextCellRenderer
 			'packages/swat/styles/swat-null-text-cell-renderer.css'
 		);
 	}
-
-	// }}}
-	// {{{ public function render()
 
 	/**
 	 * Renders this cell renderer
@@ -72,7 +65,6 @@ class SwatNullTextCellRenderer extends SwatTextCellRenderer
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatNumber.php
+++ b/Swat/SwatNumber.php
@@ -9,7 +9,6 @@
  */
 class SwatNumber extends SwatObject
 {
-	// {{{ public static function roundUp()
 
 	/**
 	 * Rounds a number to the specified number of fractional digits using the
@@ -30,9 +29,6 @@ class SwatNumber extends SwatObject
 
 		return $value;
 	}
-
-	// }}}
-	// {{{ public static function roundToEven()
 
 	/**
 	 * Rounds a number to the specified number of fractional digits using the
@@ -68,9 +64,6 @@ class SwatNumber extends SwatObject
 
 		return $value;
 	}
-
-	// }}}
-	// {{{ public static function ordinal()
 
 	/**
 	 * Formats an integer as an ordinal number (1st, 2nd, 3rd)
@@ -148,9 +141,6 @@ class SwatNumber extends SwatObject
 		return $ordinal_value;
 	}
 
-	// }}}
-	// {{{ private function __construct()
-
 	/**
 	 * Don't allow instantiation of the SwatNumber object
 	 *
@@ -160,7 +150,6 @@ class SwatNumber extends SwatObject
 	{
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatNumericCellRenderer.php
+++ b/Swat/SwatNumericCellRenderer.php
@@ -9,7 +9,6 @@
  */
 class SwatNumericCellRenderer extends SwatCellRenderer
 {
-	// {{{ public properties
 
 	/**
 	 * Value can be either a float or an integer
@@ -39,9 +38,6 @@ class SwatNumericCellRenderer extends SwatCellRenderer
 	 */
 	public $null_display_value = null;
 
-	// }}}
-	// {{{ public function render()
-
 	/**
 	 * Renders the contents of this cell
 	 *
@@ -62,9 +58,6 @@ class SwatNumericCellRenderer extends SwatCellRenderer
 		}
 	}
 
-	// }}}
-	// {{{ protected function renderNullValue()
-
 	protected function renderNullValue()
 	{
 		$span_tag = new SwatHtmlTag('span');
@@ -72,9 +65,6 @@ class SwatNumericCellRenderer extends SwatCellRenderer
 		$span_tag->setContent($this->null_display_value);
 		$span_tag->display();
 	}
-
-	// }}}
-	// {{{ protected function getDisplayValue()
 
 	public function getDisplayValue()
 	{
@@ -88,7 +78,6 @@ class SwatNumericCellRenderer extends SwatCellRenderer
 		return $value;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatNumericEntry.php
+++ b/Swat/SwatNumericEntry.php
@@ -9,7 +9,6 @@
  */
 abstract class SwatNumericEntry extends SwatEntry
 {
-	// {{{ public properties
 
 	/**
 	 * Show Thousands Seperator
@@ -39,9 +38,6 @@ abstract class SwatNumericEntry extends SwatEntry
 	 */
 	public $maximum_value = null;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new numeric entry widget
 	 *
@@ -57,9 +53,6 @@ abstract class SwatNumericEntry extends SwatEntry
 
 		$this->size = 10;
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Checks the minimum and maximum values of this numeric entry widget
@@ -100,9 +93,6 @@ abstract class SwatNumericEntry extends SwatEntry
 		}
 	}
 
-	// }}}
-	// {{{ protected function getValidationMessage()
-
 	/**
 	 * Gets a validation message for this numeric entry
 	 *
@@ -138,9 +128,6 @@ abstract class SwatNumericEntry extends SwatEntry
 		return $message;
 	}
 
-	// }}}
-	// {{{ abstract protected function getNumericValue()
-
 	/**
 	 * Gets the numeric value of this widget
 	 *
@@ -153,9 +140,6 @@ abstract class SwatNumericEntry extends SwatEntry
 	 *                numeric value is available.
 	 */
 	abstract protected function getNumericValue($value);
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
@@ -170,7 +154,6 @@ abstract class SwatNumericEntry extends SwatEntry
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatObject.php
+++ b/Swat/SwatObject.php
@@ -9,7 +9,6 @@
  */
 class SwatObject
 {
-	// {{{ public function __toString()
 
 	/**
 	 * Gets this object as a string
@@ -31,7 +30,6 @@ class SwatObject
 		return ob_get_clean();
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatOption.php
+++ b/Swat/SwatOption.php
@@ -9,7 +9,6 @@
  */
 class SwatOption extends SwatObject
 {
-	// {{{ public properties
 
 	/**
 	 * Option title
@@ -34,9 +33,6 @@ class SwatOption extends SwatObject
 	 */
 	public $value = null;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates an option
 	 *
@@ -53,7 +49,6 @@ class SwatOption extends SwatObject
 		$this->content_type = $content_type;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatOptionControl.php
+++ b/Swat/SwatOptionControl.php
@@ -9,7 +9,6 @@
  */
 abstract class SwatOptionControl extends SwatInputControl
 {
-	// {{{ public properties
 
 	/**
 	 * Options
@@ -67,9 +66,6 @@ abstract class SwatOptionControl extends SwatInputControl
 	 * @var boolean
 	 */
 	public $serialize_values = true;
-
-	// }}}
-	// {{{ public function addOption()
 
 	/**
 	 * Adds an option to this option control
@@ -136,9 +132,6 @@ abstract class SwatOptionControl extends SwatInputControl
 		}
 	}
 
-	// }}}
-	// {{{ public function addOptionMetadata()
-
 	/**
 	 * Sets the metadata for an option
 	 *
@@ -172,9 +165,6 @@ abstract class SwatOptionControl extends SwatInputControl
 			$this->option_metadata[$key][$metadata] = $value;
 		}
 	}
-
-	// }}}
-	// {{{ public function getOptionMetadata()
 
 	/**
 	 * Gets the metadata for an option
@@ -219,9 +209,6 @@ abstract class SwatOptionControl extends SwatInputControl
 		return $metadata;
 	}
 
-	// }}}
-	// {{{ public function removeOption()
-
 	/**
 	 * Removes an option from this option control
 	 *
@@ -248,9 +235,6 @@ abstract class SwatOptionControl extends SwatInputControl
 
 		return $removed_option;
 	}
-
-	// }}}
-	// {{{ public function removeOptionsByValue()
 
 	/**
 	 * Removes options from this option control by their value
@@ -280,9 +264,6 @@ abstract class SwatOptionControl extends SwatInputControl
 		return $removed_options;
 	}
 
-	// }}}
-	// {{{ public function addOptionsByArray()
-
 	/**
 	 * Adds options to this option control using an associative array
 	 *
@@ -299,9 +280,6 @@ abstract class SwatOptionControl extends SwatInputControl
 		foreach ($options as $value => $title)
 			$this->addOption($value, $title, $content_type);
 	}
-
-	// }}}
-	// {{{ public function getOptionsByValue()
 
 	/**
 	 * Gets options from this option control by their value
@@ -323,9 +301,6 @@ abstract class SwatOptionControl extends SwatInputControl
 		return $options;
 	}
 
-	// }}}
-	// {{{ protected function getOptions()
-
 	/**
 	 * Gets a reference to the array of options
 	 *
@@ -337,9 +312,6 @@ abstract class SwatOptionControl extends SwatInputControl
 	{
 		return $this->options;
 	}
-
-	// }}}
-	// {{{ protected function getOption()
 
 	/**
 	 * Gets an option within this option control
@@ -360,9 +332,6 @@ abstract class SwatOptionControl extends SwatInputControl
 		return $option;
 	}
 
-	// }}}
-	// {{{ protected function getOptionMetadataKey()
-
 	/**
 	 * Gets the key used to load and store metadata for an option
 	 *
@@ -376,7 +345,6 @@ abstract class SwatOptionControl extends SwatInputControl
 		return spl_object_hash($option);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatPagination.php
+++ b/Swat/SwatPagination.php
@@ -11,7 +11,6 @@
  */
 class SwatPagination extends SwatControl
 {
-	// {{{ class constants
 
 	/**
 	 * Display part constant for the displaying 'next' link
@@ -34,9 +33,6 @@ class SwatPagination extends SwatControl
 	 * current page
 	 */
 	const PAGES    = 8;
-
-	// }}}
-	// {{{ public properties
 
 	/**
 	 * The URI linked by this pagination widget
@@ -110,9 +106,6 @@ class SwatPagination extends SwatControl
 	 */
 	public $display_parts;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * The next page to display
 	 *
@@ -143,9 +136,6 @@ class SwatPagination extends SwatControl
 	 */
 	protected $total_pages = 0;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new pagination widget
 	 *
@@ -168,9 +158,6 @@ class SwatPagination extends SwatControl
 
 		$this->addStyleSheet('packages/swat/styles/swat-pagination.css');
 	}
-
-	// }}}
-	// {{{ public function getResultsMessage()
 
 	/**
 	 * Gets a human readable summary of the current state of this pagination
@@ -214,9 +201,6 @@ class SwatPagination extends SwatControl
 		return $message;
 	}
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this pagination widget
 	 */
@@ -251,9 +235,6 @@ class SwatPagination extends SwatControl
 		}
 	}
 
-	// }}}
-	// {{{ public function setCurrentPage()
-
 	/**
 	 * Set the current page that is displayed
 	 *
@@ -268,9 +249,6 @@ class SwatPagination extends SwatControl
 		$this->current_record = ($this->current_page - 1) * $this->page_size;
 	}
 
-	// }}}
-	// {{{ public function getCurrentPage()
-
 	/**
 	 * Get the current page that is displayed
 	 *
@@ -280,9 +258,6 @@ class SwatPagination extends SwatControl
 	{
 		return $this->current_page;
 	}
-
-	// }}}
-	// {{{ protected function displayPrev()
 
 	/**
 	 * Displays the previous page link
@@ -306,9 +281,6 @@ class SwatPagination extends SwatControl
 		}
 	}
 
-	// }}}
-	// {{{ protected function displayPosition()
-
 	/**
 	 * Displays the current page position
 	 *
@@ -324,9 +296,6 @@ class SwatPagination extends SwatControl
 
 		$div->display();
 	}
-
-	// }}}
-	// {{{ protected function displayNext()
 
 	/**
 	 * Displays the next page link
@@ -350,9 +319,6 @@ class SwatPagination extends SwatControl
 			$span->display();
 		}
 	}
-
-	// }}}
-	// {{{ protected function displayPages()
 
 	/**
 	 * Displays a smart list of pages
@@ -412,9 +378,6 @@ class SwatPagination extends SwatControl
 		}
 	}
 
-	// }}}
-	// {{{ protected function getLink()
-
 	/**
 	 * Gets the base link for all page links
 	 *
@@ -424,9 +387,6 @@ class SwatPagination extends SwatControl
 	{
 		return ($this->link === null) ? '%s' : $this->link;
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this pagination
@@ -441,9 +401,6 @@ class SwatPagination extends SwatControl
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function calculatePages()
 
 	/**
 	 * Calculates page totals
@@ -466,7 +423,6 @@ class SwatPagination extends SwatControl
 			$this->prev_page = 0;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatPasswordEntry.php
+++ b/Swat/SwatPasswordEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatPasswordEntry extends SwatEntry
 {
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new password entry and defaults the size to 20
@@ -24,18 +23,12 @@ class SwatPasswordEntry extends SwatEntry
 		$this->size = 20;
 	}
 
-	// }}}
-	// {{{ protected function getInputTag()
-
 	protected function getInputTag()
 	{
 		$tag = parent::getInputTag();
 		$tag->type = 'password';
 		return $tag;
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
@@ -50,7 +43,6 @@ class SwatPasswordEntry extends SwatEntry
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatPercentageCellRenderer.php
+++ b/Swat/SwatPercentageCellRenderer.php
@@ -9,7 +9,6 @@
  */
 class SwatPercentageCellRenderer extends SwatNumericCellRenderer
 {
-	// {{{ public function render()
 
 	/**
 	 * Renders the contents of this cell
@@ -33,7 +32,6 @@ class SwatPercentageCellRenderer extends SwatNumericCellRenderer
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatPercentageEntry.php
+++ b/Swat/SwatPercentageEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatPercentageEntry extends SwatFloatEntry
 {
-	// {{{ protected function getDisplayValue()
 
 	/**
 	 * Returns a value for this widget
@@ -30,9 +29,6 @@ class SwatPercentageEntry extends SwatFloatEntry
 
 		return $value;
 	}
-
-	// }}}
-	// {{{ protected function getNumericValue()
 
 	/**
 	 * Gets the float value of this widget
@@ -55,9 +51,6 @@ class SwatPercentageEntry extends SwatFloatEntry
 		return $value;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
 	 *
@@ -71,7 +64,6 @@ class SwatPercentageEntry extends SwatFloatEntry
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatPhoneEntry.php
+++ b/Swat/SwatPhoneEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatPhoneEntry extends SwatEntry
 {
-	// {{{ protected function getInputTag()
 
 	/**
 	 * Get the input tag to display
@@ -22,9 +21,6 @@ class SwatPhoneEntry extends SwatEntry
 		$tag->type = 'tel';
 		return $tag;
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
@@ -39,7 +35,6 @@ class SwatPhoneEntry extends SwatEntry
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatProgressBar.php
+++ b/Swat/SwatProgressBar.php
@@ -22,7 +22,6 @@
  */
 class SwatProgressBar extends SwatControl
 {
-	// {{{ class constants
 
 	/**
 	 * Progress bar displays horizontally and completes from left to right
@@ -43,9 +42,6 @@ class SwatProgressBar extends SwatControl
 	 * Progress bar displays vertically and completes from top to bottom
 	 */
 	const ORIENTATION_TOP_TO_BOTTOM = 4;
-
-	// }}}
-	// {{{ public properties
 
 	/**
 	 * Orientation of this progress bar
@@ -118,9 +114,6 @@ class SwatProgressBar extends SwatControl
 	 */
 	public $length = '200px';
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new progress bar
 	 *
@@ -140,9 +133,6 @@ class SwatProgressBar extends SwatControl
 		$this->addStyleSheet('packages/swat/styles/swat-progress-bar.css');
 		$this->addJavaScript('packages/swat/javascript/swat-progress-bar.js');
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this progress bar
@@ -170,9 +160,6 @@ class SwatProgressBar extends SwatControl
 
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
-
-	// }}}
-	// {{{ protected function displayBar()
 
 	/**
 	 * Displays the bar part of this progress bar
@@ -249,9 +236,6 @@ class SwatProgressBar extends SwatControl
 		$bar_div_tag->close();
 	}
 
-	// }}}
-	// {{{ protected function displayText()
-
 	/**
 	 * Displays the text part of this progress bar
 	 */
@@ -277,9 +261,6 @@ class SwatProgressBar extends SwatControl
 		$span_tag->display();
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets inline JavaScript for this progress bar
 	 *
@@ -290,9 +271,6 @@ class SwatProgressBar extends SwatControl
 		return sprintf("var %s_obj = new SwatProgressBar('%s', %s, %s);",
 			$this->id, $this->id, $this->orientation, $this->value);
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this progress bar
@@ -307,7 +285,6 @@ class SwatProgressBar extends SwatControl
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatRadioButtonCellRenderer.php
+++ b/Swat/SwatRadioButtonCellRenderer.php
@@ -14,7 +14,6 @@
 class SwatRadioButtonCellRenderer extends SwatCellRenderer
 	implements SwatViewSelector
 {
-	// {{{ public properties
 
 	/**
 	 * Identifier of this radio button cell renderer
@@ -56,9 +55,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer
 	 */
 	public $content_type = 'text/plain';
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * The selected value populated during the processing of this cell
 	 * renderer
@@ -69,9 +65,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer
 	 * @var array
 	 */
 	private $selected_value;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new radio button cell renderer
@@ -91,9 +84,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer
 		// auto-generate an id to use if no id is set
 		$this->id = $this->getUniqueId();
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this radio button cell renderer
@@ -116,9 +106,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer
 			}
 		}
 	}
-
-	// }}}
-	// {{{ public function render()
 
 	/**
 	 * Renders this radio button cell renderer
@@ -163,9 +150,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer
 		}
 	}
 
-	// }}}
-	// {{{ public function getId()
-
 	/**
 	 * Gets the identifier of this checkbox cell renderer
 	 *
@@ -177,9 +161,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer
 	{
 		return $this->id;
 	}
-
-	// }}}
-	// {{{ public function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript required by this radio button cell renderer
@@ -200,9 +181,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer
 
 		return $javascript;
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -225,9 +203,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer
 		return $copy;
 	}
 
-	// }}}
-	// {{{ private function getForm()
-
 	/**
 	 * Gets the form this radio button cell renderer is contained in
 	 *
@@ -248,7 +223,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer
 		return $form;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatRadioList.php
+++ b/Swat/SwatRadioList.php
@@ -9,7 +9,6 @@
  */
 class SwatRadioList extends SwatFlydown
 {
-	// {{{ private properties
 
 	/**
 	 * Used for displaying radio buttons
@@ -24,9 +23,6 @@ class SwatRadioList extends SwatFlydown
 	 * @var SwatHtmlTag
 	 */
 	private $label_tag;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new radiolist
@@ -44,9 +40,6 @@ class SwatRadioList extends SwatFlydown
 
 		$this->addStyleSheet('packages/swat/styles/swat-radio-list.css');
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this radio list
@@ -124,9 +117,6 @@ class SwatRadioList extends SwatFlydown
 		$ul_tag->close();
 	}
 
-	// }}}
-	// {{{ protected function processValue()
-
 	/**
 	 * Processes the value of this radio list from user-submitted form data
 	 *
@@ -156,9 +146,6 @@ class SwatRadioList extends SwatFlydown
 		return true;
 	}
 
-	// }}}
-	// {{{ protected function displayDivider()
-
 	/**
 	 * Displays a divider option in this radio list
 	 *
@@ -176,9 +163,6 @@ class SwatRadioList extends SwatFlydown
 		$span_tag->setContent($option->title, $option->content_type);
 		$span_tag->display();
 	}
-
-	// }}}
-	// {{{ protected function displayOption()
 
 	/**
 	 * Displays an option in the radio list
@@ -230,9 +214,6 @@ class SwatRadioList extends SwatFlydown
 		echo '</span>';
 	}
 
-	// }}}
-	// {{{ protected function displayOptionLabel()
-
 	/**
 	 * Displays an option in the radio list
 	 *
@@ -252,9 +233,6 @@ class SwatRadioList extends SwatFlydown
 		$this->label_tag->display();
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this radio list
 	 *
@@ -268,7 +246,6 @@ class SwatRadioList extends SwatFlydown
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatRadioNoteBook.php
+++ b/Swat/SwatRadioNoteBook.php
@@ -13,7 +13,6 @@
  */
 class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 {
-	// {{{ public properties
 
 	/**
 	 * Selected page
@@ -24,9 +23,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 	 * @var string
 	 */
 	public $selected_page;
-
-	// }}}
-	// {{{ protected properties
 
 	/**
 	 * Note book child objects initally added to this widget
@@ -41,9 +37,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 	 * @var array
 	 */
 	protected $pages = array();
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new notebook
@@ -67,9 +60,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 			'packages/swat/javascript/swat-radio-note-book.js'
 		);
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a {@link SwatNoteBookChild} to this notebook
@@ -101,9 +91,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ public function addPage()
-
 	/**
 	 * Adds a {@link SwatNoteBookPage} to this notebook
 	 *
@@ -114,9 +101,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 		$this->pages[] = $page;
 		$page->parent = $this;
 	}
-
-	// }}}
-	// {{{ public function getPage()
 
 	/**
 	 * Gets a page in this notebook
@@ -142,9 +126,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 		return $found_page;
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this notebook
 	 */
@@ -163,9 +144,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 			$page->init();
 		}
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this notebook
@@ -189,9 +167,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 			}
 		}
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this notebook
@@ -239,9 +214,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ public function printWidgetTree()
-
 	public function printWidgetTree()
 	{
 		echo get_class($this), ' ', $this->id;
@@ -257,9 +229,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 			echo '</ul>';
 		}
 	}
-
-	// }}}
-	// {{{ public function getMessages()
 
 	/**
 	 * Gets all messaages
@@ -281,9 +250,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 		return $messages;
 	}
 
-	// }}}
-	// {{{ public function hasMessage()
-
 	/**
 	 * Checks for the presence of messages
 	 *
@@ -303,9 +269,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 
 		return $has_message;
 	}
-
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
 
 	/**
 	 * Gets the {@link SwatHtmlHeadEntry} objects needed by this notebook
@@ -327,9 +290,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the {@link SwatHtmlHeadEntry} objects that may be needed by this
 	 * notebook
@@ -350,9 +310,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -391,9 +348,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -427,9 +381,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -449,9 +400,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -467,9 +415,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -494,9 +439,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 
 		return $copy;
 	}
-
-	// }}}
-	// {{{ public function processValue()
 
 	/**
 	 * Processes the value of this radio list from user-submitted form data
@@ -528,9 +470,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 
 		return true;
 	}
-
-	// }}}
-	// {{{ protected function displayPage()
 
 	/**
 	 * Displays an individual page in this radio notebook
@@ -589,9 +528,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 		echo '</tr>';
 	}
 
-	// }}}
-	// {{{ protected function displaySinglePage()
-
 	/**
 	 * Displays the only page of this notebook if this notebook contains only
 	 * one page
@@ -621,9 +557,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 		$container->close();
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets the inline JavaScript used by this notebook
 	 *
@@ -638,7 +571,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 		);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatRadioTable.php
+++ b/Swat/SwatRadioTable.php
@@ -9,7 +9,6 @@
  */
 class SwatRadioTable extends SwatRadioList
 {
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new radio table
@@ -24,9 +23,6 @@ class SwatRadioTable extends SwatRadioList
 
 		$this->addStyleSheet('packages/swat/styles/swat-radio-table.css');
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	public function display()
 	{
@@ -57,9 +53,6 @@ class SwatRadioTable extends SwatRadioList
 
 		$table_tag->close();
 	}
-
-	// }}}
-	// {{{ protected function displayRadioTableOption()
 
 	/**
 	 * Displays a single option in this radio table
@@ -101,9 +94,6 @@ class SwatRadioTable extends SwatRadioList
 		$tr_tag->close();
 	}
 
-	// }}}
-	// {{{ protected function getTrTag()
-
 	/**
 	 * Gets the tr tag used to display a single option in this radio table
 	 *
@@ -114,9 +104,6 @@ class SwatRadioTable extends SwatRadioList
 	{
 		return new SwatHtmlTag('tr');
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this radio table
@@ -131,7 +118,6 @@ class SwatRadioTable extends SwatRadioList
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatRating.php
+++ b/Swat/SwatRating.php
@@ -9,7 +9,6 @@
  */
 class SwatRating extends SwatInputControl
 {
-	// {{{ public properties
 
 	/**
 	 * The value of this rating control
@@ -24,9 +23,6 @@ class SwatRating extends SwatInputControl
 	 * @var integer
 	 */
 	public $maximum_value = 5;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new rating control
@@ -47,9 +43,6 @@ class SwatRating extends SwatInputControl
 		$this->addStyleSheet('packages/swat/styles/swat-rating.css');
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this rating control
 	 */
@@ -60,9 +53,6 @@ class SwatRating extends SwatInputControl
 		$flydown = $this->getCompositeWidget('flydown');
 		$flydown->addOptionsByArray($this->getRatings());
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this rating control
@@ -79,7 +69,6 @@ class SwatRating extends SwatInputControl
 		}
 	}
 
-	// }}}
 	//  {{{ public function display()
 
 	/**
@@ -108,9 +97,6 @@ class SwatRating extends SwatInputControl
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ protected function getRatings()
-
 	protected function getRatings()
 	{
 		$ratings = array();
@@ -121,9 +107,6 @@ class SwatRating extends SwatInputControl
 
 		return $ratings;
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this rating control
@@ -138,9 +121,6 @@ class SwatRating extends SwatInputControl
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets the inline JavaScript for this rating control
 	 *
@@ -152,9 +132,6 @@ class SwatRating extends SwatInputControl
 		return sprintf('var %s_obj = new SwatRating(%s, %s);',
 			$this->id, $quoted_string, intval($this->maximum_value));
 	}
-
-	// }}}
-	// {{{ protected function createCompositeWidgets()
 
 	/**
 	 * Creates the composite flydown used by this rating control
@@ -169,7 +146,6 @@ class SwatRating extends SwatInputControl
 		$this->addCompositeWidget($flydown, 'flydown');
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatRatingCellRenderer.php
+++ b/Swat/SwatRatingCellRenderer.php
@@ -9,16 +9,12 @@
  */
 class SwatRatingCellRenderer extends SwatNumericCellRenderer
 {
-	// {{{ constants
 
 	const ROUND_FLOOR = 1;
 	const ROUND_CEIL  = 2;
 	const ROUND_UP    = 3;
 	const ROUND_NONE  = 4;
 	const ROUND_HALF  = 5;
-
-	// }}}
-	// {{{ public properties
 
 	/**
 	 * Maximum value a rating can be.
@@ -37,9 +33,6 @@ class SwatRatingCellRenderer extends SwatNumericCellRenderer
 	 * @var integer
 	 */
 	public $round_mode = self::ROUND_FLOOR;
-
-	// }}}
-	// {{{ public function render()
 
 	/**
 	 * Renders the contents of this cell
@@ -89,9 +82,6 @@ class SwatRatingCellRenderer extends SwatNumericCellRenderer
 		}
 	}
 
-	// }}}
-	// {{{ protected function getDisplayValue()
-
 	public function getDisplayValue()
 	{
 		switch ($this->round_mode) {
@@ -119,7 +109,6 @@ class SwatRatingCellRenderer extends SwatNumericCellRenderer
 		return $value;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatReCaptcha.php
+++ b/Swat/SwatReCaptcha.php
@@ -9,7 +9,6 @@
  */
 class SwatReCaptcha extends SwatInputControl
 {
-	// {{{ public properties
 
 	/**
 	 * Public Key
@@ -39,9 +38,6 @@ class SwatReCaptcha extends SwatInputControl
 	 */
 	public $secure = false;
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this ReCaptcha widget
 	 */
@@ -58,9 +54,6 @@ class SwatReCaptcha extends SwatInputControl
 		 */
 		ReCaptcha::display($this->public_key, null, $this->secure);
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this ReCaptcha Widget
@@ -96,7 +89,6 @@ class SwatReCaptcha extends SwatInputControl
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatRemoveInputCell.php
+++ b/Swat/SwatRemoveInputCell.php
@@ -19,7 +19,6 @@
  */
 class SwatRemoveInputCell extends SwatInputCell
 {
-	// {{{ public function init()
 
 	/**
 	 * Sets the remove widget for this input cell
@@ -62,9 +61,6 @@ class SwatRemoveInputCell extends SwatInputCell
 		$content->parent = $this;
 	}
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this remove input cell given a numeric row identifier
 	 *
@@ -81,9 +77,6 @@ class SwatRemoveInputCell extends SwatInputCell
 		$widget->display();
 	}
 
-	// }}}
-	// {{{ public function setWidget()
-
 	/**
 	 * Sets the widget of this input cell
 	 *
@@ -99,7 +92,6 @@ class SwatRemoveInputCell extends SwatInputCell
 		throw new SwatException('Remove input cells must be empty');
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatReplicable.php
+++ b/Swat/SwatReplicable.php
@@ -9,7 +9,6 @@
  */
 interface SwatReplicable
 {
-	// {{{ public function getWidget()
 
 	/**
 	 * Retrives a reference to a replicated widget
@@ -23,7 +22,6 @@ interface SwatReplicable
 	 */
 	public function getWidget($widget_id, $replicator_id);
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatReplicableContainer.php
+++ b/Swat/SwatReplicableContainer.php
@@ -10,7 +10,6 @@
 class SwatReplicableContainer extends SwatDisplayableContainer
 	implements SwatReplicable
 {
-	// {{{ public properties
 
 	/**
 	 * An array of unique id => title pairs, one for each replication
@@ -34,14 +33,8 @@ class SwatReplicableContainer extends SwatDisplayableContainer
 	 */
 	public $replication_ids = null;
 
-	// }}}
-	// {{{ private properties
-
 	private $widgets = array();
 	private $prototype_widgets = array();
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new replicator container
@@ -55,9 +48,6 @@ class SwatReplicableContainer extends SwatDisplayableContainer
 		parent::__construct($id);
 		$this->requires_id = true;
 	}
-
-	// }}}
-	// {{{ public function init()
 
 	/**
 	 * Initilizes this replicable container
@@ -83,9 +73,6 @@ class SwatReplicableContainer extends SwatDisplayableContainer
 
 		parent::init();
 	}
-
-	// }}}
-	// {{{ public function addReplication()
 
 	public function addReplication($id)
 	{
@@ -117,9 +104,6 @@ class SwatReplicableContainer extends SwatDisplayableContainer
 		}
 	}
 
-	// }}}
-	// {{{ public function getWidget()
-
 	/**
 	 * Retrives a reference to a replicated widget
 	 *
@@ -139,7 +123,6 @@ class SwatReplicableContainer extends SwatDisplayableContainer
 		return $widget;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatReplicableDisclosure.php
+++ b/Swat/SwatReplicableDisclosure.php
@@ -15,7 +15,6 @@
  */
 class SwatReplicableDisclosure extends SwatReplicableContainer
 {
-	// {{{ public function init()
 
 	/**
 	 * Initilizes this replicable disclosure
@@ -43,7 +42,6 @@ class SwatReplicableDisclosure extends SwatReplicableContainer
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatReplicableFieldset.php
+++ b/Swat/SwatReplicableFieldset.php
@@ -15,7 +15,6 @@
  */
 class SwatReplicableFieldset extends SwatReplicableContainer
 {
-	// {{{ public function init()
 
 	/**
 	 * Initilizes this replicable fieldset
@@ -43,7 +42,6 @@ class SwatReplicableFieldset extends SwatReplicableContainer
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatReplicableFormField.php
+++ b/Swat/SwatReplicableFormField.php
@@ -15,7 +15,6 @@
  */
 class SwatReplicableFormField extends SwatReplicableContainer
 {
-	// {{{ public function init()
 
 	/**
 	 * Initilizes this replicable form field
@@ -43,7 +42,6 @@ class SwatReplicableFormField extends SwatReplicableContainer
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatReplicableFrame.php
+++ b/Swat/SwatReplicableFrame.php
@@ -15,7 +15,6 @@
  */
 class SwatReplicableFrame extends SwatReplicableContainer
 {
-	// {{{ public function init()
 
 	/**
 	 * Initilizes this replicable frame
@@ -45,7 +44,6 @@ class SwatReplicableFrame extends SwatReplicableContainer
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatReplicableNoteBookChild.php
+++ b/Swat/SwatReplicableNoteBookChild.php
@@ -10,7 +10,6 @@
 class SwatReplicableNoteBookChild extends SwatReplicableContainer
 	implements SwatNoteBookChild
 {
-	// {{{ public function getPages()
 
 	/**
 	 * Gets the notebook pages of this replicable notebook child
@@ -32,9 +31,6 @@ class SwatReplicableNoteBookChild extends SwatReplicableContainer
 
 		return $pages;
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a {@link SwatNoteBookChild} to this replicable notebook child
@@ -58,7 +54,6 @@ class SwatReplicableNoteBookChild extends SwatReplicableContainer
 		parent::addChild($child);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatReplicableNoteBookPage.php
+++ b/Swat/SwatReplicableNoteBookPage.php
@@ -16,7 +16,6 @@
 class SwatReplicableNoteBookPage extends SwatReplicableContainer
 	implements SwatNoteBookChild
 {
-	// {{{ public function init()
 
 	/**
 	 * Initilizes this replicable notebook page
@@ -53,9 +52,6 @@ class SwatReplicableNoteBookPage extends SwatReplicableContainer
 		$this->add($note_book);
 	}
 
-	// }}}
-	// {{{ public function getPages()
-
 	/**
 	 * Gets the notebook pages of this replicable notebook page
 	 *
@@ -69,7 +65,6 @@ class SwatReplicableNoteBookPage extends SwatReplicableContainer
 		return $this->children;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatSearchEntry.php
+++ b/Swat/SwatSearchEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatSearchEntry extends SwatEntry
 {
-	// {{{ public properties
 
 	/**
 	 * An XHTML name for this search entry widget
@@ -22,9 +21,6 @@ class SwatSearchEntry extends SwatEntry
 	 */
 	public $name;
 
-	// }}}
-	// {{{ public function __construct()
-
 	public function __construct($id = null)
 	{
 		parent::__construct($id);
@@ -36,9 +32,6 @@ class SwatSearchEntry extends SwatEntry
 		$this->addJavaScript('packages/swat/javascript/swat-search-entry.js');
 		$this->addStyleSheet('packages/swat/styles/swat-search-entry.css');
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this search entry
@@ -55,9 +48,6 @@ class SwatSearchEntry extends SwatEntry
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets the inline JavaScript for this entry to function
 	 *
@@ -72,9 +62,6 @@ class SwatSearchEntry extends SwatEntry
 		return "var {$this->id}_obj = new SwatSearchEntry('{$this->id}');";
 	}
 
-	// }}}
-	// {{{ protected function getInputTag()
-
 	protected function getInputTag()
 	{
 		$tag = parent::getInputTag();
@@ -84,9 +71,6 @@ class SwatSearchEntry extends SwatEntry
 
 		return $tag;
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
@@ -100,9 +84,6 @@ class SwatSearchEntry extends SwatEntry
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getRawValue()
 
 	/**
 	 * Gets the raw value entered by the user before processing
@@ -126,9 +107,6 @@ class SwatSearchEntry extends SwatEntry
 
 		return $value;
 	}
-
-	// }}}
-	// {{{ protected function hasRawValue()
 
 	/**
 	 * Gets whether or not a value was submitted by the user for this entry
@@ -156,7 +134,6 @@ class SwatSearchEntry extends SwatEntry
 		return $has_value;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatSelectList.php
+++ b/Swat/SwatSelectList.php
@@ -9,7 +9,6 @@
  */
 class SwatSelectList extends SwatCheckboxList
 {
-	// {{{ public properties
 
 	/**
 	 * Optional number of rows in the select list
@@ -17,9 +16,6 @@ class SwatSelectList extends SwatCheckboxList
 	 * @var integer
 	 */
 	public $size;
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this select list
@@ -59,9 +55,6 @@ class SwatSelectList extends SwatCheckboxList
 		$select_tag->close();
 	}
 
-	// }}}
-	// {{{ public function getNote()
-
 	/**
 	 * Gets a note letting the user know the select list can select multiple
 	 * options
@@ -79,7 +72,6 @@ class SwatSelectList extends SwatCheckboxList
 		return new SwatMessage($message);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatSimpleColorEntry.php
+++ b/Swat/SwatSimpleColorEntry.php
@@ -12,7 +12,6 @@
  */
 class SwatSimpleColorEntry extends SwatAbstractOverlay
 {
-	// {{{ public properties
 
 	/**
 	 * Show "none" option
@@ -50,9 +49,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
 		'ad7fa8', '75507b', '5c3566', 'ef2929', 'cc0000', 'a40000',
 		);
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new simple color selection widget
 	 *
@@ -78,9 +74,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
 
 		$this->addStyleSheet('packages/swat/styles/swat-color-entry.css');
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this color entry
@@ -116,9 +109,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
 		}
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this simple color
 	 * entry widget
@@ -132,9 +122,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets simple color selector inline JavaScript
@@ -163,9 +150,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
 
 		return $javascript;
 	}
-
-	// }}}
-	// {{{ protected function validateColor()
 
 	/**
 	 * Validates a color
@@ -197,9 +181,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
 		return $valid;
 	}
 
-	// }}}
-	// {{{ protected function getJavaScriptClassName()
-
 	/**
 	 * Get the name of the JavaScript class for this widget
 	 *
@@ -210,7 +191,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
 		return 'SwatSimpleColorEntry';
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatState.php
+++ b/Swat/SwatState.php
@@ -9,7 +9,6 @@
  */
 interface SwatState
 {
-	// {{{ public function setState()
 
 	/**
 	 * Set the state of the control
@@ -22,9 +21,6 @@ interface SwatState
 	 * @param mixed $state The state to load into the control.
 	 */
 	public function setState($state);
-
-	// }}}
-	// {{{ public function getState()
 
 	/**
 	 * Get the state of the control
@@ -39,7 +35,6 @@ interface SwatState
 	 */
 	public function getState();
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatString.php
+++ b/Swat/SwatString.php
@@ -9,7 +9,6 @@
  */
 class SwatString extends SwatObject
 {
-	// {{{ public static properties
 
 	/**
 	 * Block level XHTML elements used when filtering strings
@@ -76,9 +75,6 @@ class SwatString extends SwatObject
 	public static $preformatted_elements = array(
 		'script', 'style', 'pre',
 	);
-
-	// }}}
-	// {{{ public static function toXHTML()
 
 	/**
 	 * Intelligently converts a text block to XHTML
@@ -266,9 +262,6 @@ class SwatString extends SwatObject
 		return $text;
 	}
 
-	// }}}
-	// {{{ public static function minimizeEntities()
-
 	/**
 	 * Converts a UTF-8 text string to have the minimal number of entities
 	 * necessary to output it as valid UTF-8 XHTML without ever double-escaping.
@@ -297,9 +290,6 @@ class SwatString extends SwatObject
 
 		return $text;
 	}
-
-	// }}}
-	// {{{ public static function minimizeEntitiesWithTags()
 
 	/**
 	 * Same as {@link SwatString::minimizeEntities()} but also accepts a list
@@ -332,9 +322,6 @@ class SwatString extends SwatObject
 
 		return $output;
 	}
-
-	// }}}
-	// {{{ public static function condense()
 
 	/**
 	 * Takes a block of text and condenses it into a small fragment of XHTML.
@@ -452,9 +439,6 @@ class SwatString extends SwatObject
 		return $text;
 	}
 
-	// }}}
-	// {{{ public static function condenseToName()
-
 	/**
 	 * Condenses a string to a name
 	 *
@@ -567,9 +551,6 @@ class SwatString extends SwatObject
 		return $string_out;
 	}
 
-	// }}}
-	// {{{ public static function ellipsizeRight()
-
 	/**
 	 * Ellipsizes a string to the right
 	 *
@@ -649,9 +630,6 @@ class SwatString extends SwatObject
 		$flag = true;
 		return $string;
 	}
-
-	// }}}
-	// {{{ public static function ellipsizeMiddle()
 
 	/**
 	 * Ellipsizes a string in the middle
@@ -777,9 +755,6 @@ class SwatString extends SwatObject
 		return $string;
 	}
 
-	// }}}
-	// {{{ public static function removeTrailingPunctuation()
-
 	/**
 	 * Removes trailing punctuation from a string
 	 *
@@ -792,9 +767,6 @@ class SwatString extends SwatObject
 		return preg_replace('/\W+$/su', '', $string);
 	}
 
-	// }}}
-	// {{{ public static function removeLeadingPunctuation()
-
 	/**
 	 * Removes leading punctuation from a string
 	 *
@@ -806,9 +778,6 @@ class SwatString extends SwatObject
 	{
 		return preg_replace('/^\W+/su', '', $string);
 	}
-
-	// }}}
-	// {{{ public static function removePunctuation()
 
 	/**
 	 * Removes both leading and trailing punctuation from a string
@@ -823,9 +792,6 @@ class SwatString extends SwatObject
 		$string = self::removeLeadingPunctuation($string);
 		return $string;
 	}
-
-	// }}}
-	// {{{ public static function moneyFormat()
 
 	/**
 	 * Formats a numeric value as currency
@@ -909,9 +875,6 @@ class SwatString extends SwatObject
 		return $output;
 	}
 
-	// }}}
-	// {{{ public static function getInternationalCurrencySymbol()
-
 	/**
 	 * Gets the international currency symbol of a locale
 	 *
@@ -958,9 +921,6 @@ class SwatString extends SwatObject
 
 		return $symbol;
 	}
-
-	// }}}
-	// {{{ public static function numberFormat()
 
 	/**
 	 * Formats a number using locale-based separators
@@ -1027,9 +987,6 @@ class SwatString extends SwatObject
 		return $output;
 	}
 
-	// }}}
-	// {{{ public static function ordinalNumberFormat()
-
 	/**
 	 * Formats an integer as an ordinal number (1st, 2nd, 3rd)
 	 *
@@ -1043,9 +1000,6 @@ class SwatString extends SwatObject
 	{
 		return SwatNumber::ordinal($value);
 	}
-
-	// }}}
-	// {{{ public static function byteFormat()
 
 	/**
 	 * Format bytes in human readible units
@@ -1156,9 +1110,6 @@ class SwatString extends SwatObject
 		return $formatted_value.' '.$units[$unit_magnitude];
 	}
 
-	// }}}
-	// {{{ public static function pad()
-
 	/**
 	 * Pads a string in a UTF-8 safe way.
 	 *
@@ -1219,9 +1170,6 @@ class SwatString extends SwatObject
 		return $output;
 	}
 
-	// }}}
-	// {{{ public static function toInteger()
-
 	/**
 	 * Convert a locale-formatted number and return it as an integer.
 	 *
@@ -1278,9 +1226,6 @@ class SwatString extends SwatObject
 		return $value;
 	}
 
-	// }}}
-	// {{{ public static function toFloat()
-
 	/**
 	 * Convert a locale-formatted number and return it as an float.
 	 *
@@ -1313,9 +1258,6 @@ class SwatString extends SwatObject
 
 		return (is_numeric($value)) ? floatval($value) : null;
 	}
-
-	// }}}
-	// {{{ public static function toList()
 
 	/**
 	 * Convert an iterable object or array into a human-readable, delimited
@@ -1378,9 +1320,6 @@ class SwatString extends SwatObject
 
 		return $list;
 	}
-
-	// }}}
-	// {{{ public static function getTimePeriodParts()
 
 	/**
 	 * Gets the parts representing a time period matching a desired interval
@@ -1503,9 +1442,6 @@ class SwatString extends SwatObject
 		return $parts;
 	}
 
-	// }}}
-	// {{{ public static function getHumanReadableTimePeriodParts()
-
 	/**
 	 * Gets the parts to construct a human-readable string representing a time
 	 * period.
@@ -1602,9 +1538,6 @@ class SwatString extends SwatObject
 		return $parts;
 	}
 
-	// }}}
-	// {{{ public static function toHumanReadableTimePeriod()
-
 	/**
 	 * Gets a human-readable string representing a time period
 	 *
@@ -1629,9 +1562,6 @@ class SwatString extends SwatObject
 		$parts = self::getHumanReadableTimePeriodParts($seconds);
 		return self::toHumanReadableTimePeriodString($parts, $largest_part);
 	}
-
-	// }}}
-	// {{{ public static function toHumanReadableTimePeriodWithWeeks()
 
 	/**
 	 * Gets a human-readable string representing a time period that includes
@@ -1671,9 +1601,6 @@ class SwatString extends SwatObject
 
 		return self::toHumanReadableTimePeriodString($parts, $largest_part);
 	}
-
-	// }}}
-	// {{{ public static function toHumanReadableTimePeriodWithWeeksAndDays()
 
 	/**
 	 * Gets a human-readable string representing a time period that includes
@@ -1720,9 +1647,6 @@ class SwatString extends SwatObject
 		return self::toHumanReadableTimePeriodString($parts, true);
 	}
 
-	// }}}
-	// {{{ public static function hash()
-
 	/**
 	 * Gets a unique hash of a string
 	 *
@@ -1750,9 +1674,6 @@ class SwatString extends SwatObject
 		return $hash;
 	}
 
-	// }}}
-	// {{{ public static function getSalt()
-
 	/**
 	 * Gets a salt value of the specified length
 	 *
@@ -1775,9 +1696,6 @@ class SwatString extends SwatObject
 
 		return $salt;
 	}
-
-	// }}}
-	// {{{ public static function getCryptSalt()
 
 	/**
 	 * Gets a salt value for crypt(3)
@@ -1811,9 +1729,6 @@ class SwatString extends SwatObject
 		return $salt;
 	}
 
-	// }}}
-	// {{{ public static function stripXHTMLTags()
-
 	/**
 	 * Removes all XHTML tags from a string
 	 *
@@ -1832,9 +1747,6 @@ class SwatString extends SwatObject
 		return preg_replace('/<\/?('.$elements.')[^<>]*?>/siu', '', $string);
 	}
 
-	// }}}
-	// {{{ public static function linkify()
-
 	/**
 	 * Replaces all URI's in a string with anchor markup tags
 	 *
@@ -1852,9 +1764,6 @@ class SwatString extends SwatObject
 		return preg_replace ('@(https?://[^\s"\'\[\]]+\.[^\s"\'.\[\]]+)@iu',
 			'<a href="\1">\1</a>', $string);
 	}
-
-	// }}}
-	// {{{ public static function signedSerialize()
 
 	/**
 	 * Serializes and signs a value using a salt
@@ -1878,9 +1787,6 @@ class SwatString extends SwatObject
 
 		return $signature_data.'|'.$serialized_data;
 	}
-
-	// }}}
-	// {{{ public static function signedUnserialize()
 
 	/**
 	 * Unserializes a signed serialized value
@@ -1913,9 +1819,6 @@ class SwatString extends SwatObject
 
 		return unserialize($serialized_data);
 	}
-
-	// }}}
-	// {{{ public static function quoteJavaScriptString()
 
 	/**
 	 * Safely quotes a PHP string into a JavaScript string
@@ -1975,9 +1878,6 @@ class SwatString extends SwatObject
 		return $string;
 	}
 
-	// }}}
-	// {{{ public static function validateUtf8()
-
 	/**
 	 * Checks whether or not a string is valid UTF-8
 	 *
@@ -1989,9 +1889,6 @@ class SwatString extends SwatObject
 	{
 		return (mb_detect_encoding($string, 'UTF-8', true) === 'UTF-8');
 	}
-
-	// }}}
-	// {{{ public static function validateEmailAddress()
 
 	/**
 	 * Validates an email address
@@ -2016,9 +1913,6 @@ class SwatString extends SwatObject
 
 		return $valid;
 	}
-
-	// }}}
-	// {{{ public static function escapeBinary()
 
 	/**
 	 * Escapes a binary string making it safe to display using ASCII encoding
@@ -2058,9 +1952,6 @@ class SwatString extends SwatObject
 		return $escaped;
 	}
 
-	// }}}
-	// {{{ protected static function toHumanReadableTimePeriodString()
-
 	/**
 	 * Gets a human-readable string representing a time period from an array of
 	 * human readable date parts.
@@ -2091,9 +1982,6 @@ class SwatString extends SwatObject
 		return self::toList($parts);
 	}
 
-	// }}}
-	// {{{ private static function stripEntities()
-
 	/**
 	 * Strips entities from a string remembering their positions
 	 *
@@ -2112,9 +2000,6 @@ class SwatString extends SwatObject
 
 		$string = preg_replace($reg_exp, '*', $string);
 	}
-
-	// }}}
-	// {{{ private static function insertEntities()
 
 	/**
 	 * Re-inserts stripped entities into a string in the correct positions
@@ -2174,7 +2059,6 @@ class SwatString extends SwatObject
 		}
 	}
 
-	// }}}
 	//{{{ private static function parseNegativeNotation()
 
 	private static function parseNegativeNotation($string)
@@ -2211,9 +2095,6 @@ class SwatString extends SwatObject
 		return $string;
 	}
 
-	// }}}
-	// {{{ private static function getDecimalPrecision()
-
 	private static function getDecimalPrecision($value)
 	{
 		$lc = localeconv();
@@ -2225,9 +2106,6 @@ class SwatString extends SwatObject
 			: 0;
 	}
 
-	// }}}
-	// {{{ private function __construct()
-
 	/**
 	 * Don't allow instantiation of the SwatString object
 	 *
@@ -2237,7 +2115,6 @@ class SwatString extends SwatObject
 	{
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatStyleSheetHtmlHeadEntry.php
+++ b/Swat/SwatStyleSheetHtmlHeadEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatStyleSheetHtmlHeadEntry extends SwatHtmlHeadEntry
 {
-	// {{{ protected function displayInternal()
 
 	protected function displayInternal($uri_prefix = '', $tag = null)
 	{
@@ -27,9 +26,6 @@ class SwatStyleSheetHtmlHeadEntry extends SwatHtmlHeadEntry
 			$uri);
 	}
 
-	// }}}
-	// {{{ protected function displayInlineInternal()
-
 	protected function displayInlineInternal($path)
 	{
 		echo '<style type="text/css" media="all">';
@@ -37,7 +33,6 @@ class SwatStyleSheetHtmlHeadEntry extends SwatHtmlHeadEntry
 		echo '</style>';
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTableStore.php
+++ b/Swat/SwatTableStore.php
@@ -12,7 +12,6 @@
  */
 class SwatTableStore extends SwatObject implements SwatTableModel
 {
-	// {{{ private properties
 
 	/**
 	 * The indvidual rows for this data structure
@@ -28,9 +27,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 	 */
 	private $current_index = 0;
 
-	// }}}
-	// {{{ public function count()
-
 	/**
 	 * Gets the number of rows
 	 *
@@ -43,9 +39,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 		return count($this->rows);
 	}
 
-	// }}}
-	// {{{ public function current()
-
 	/**
 	 * Returns the current element
 	 *
@@ -55,9 +48,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 	{
 		return $this->rows[$this->current_index];
 	}
-
-	// }}}
-	// {{{ public function key()
 
 	/**
 	 * Returns the key of the current element
@@ -69,9 +59,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 		return $this->current_index;
 	}
 
-	// }}}
-	// {{{ public function next()
-
 	/**
 	 * Moves forward to the next element
 	 */
@@ -79,9 +66,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 	{
 		$this->current_index++;
 	}
-
-	// }}}
-	// {{{ public function prev()
 
 	/**
 	 * Moves forward to the previous element
@@ -91,9 +75,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 		$this->current_index--;
 	}
 
-	// }}}
-	// {{{ public function rewind()
-
 	/**
 	 * Rewinds this iterator to the first element
 	 */
@@ -101,9 +82,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 	{
 		$this->current_index = 0;
 	}
-
-	// }}}
-	// {{{ public function valid()
 
 	/**
 	 * Checks is there is a current element after calls to rewind() and next()
@@ -116,9 +94,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 		return array_key_exists($this->current_index, $this->rows);
 	}
 
-	// }}}
-	// {{{ public function add()
-
 	/**
 	 * Adds a row to this data structure
 	 *
@@ -129,9 +104,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 	{
 		$this->rows[] = $data;
 	}
-
-	// }}}
-	// {{{ public function addToStart()
 
 	/**
 	 * Adds a row to the beginning of this data structure
@@ -145,9 +117,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 		$this->current_index++;
 	}
 
-	// }}}
-	// {{{ public function getRowCount()
-
 	/**
 	 * Gets the number of rows in this data structure
 	 *
@@ -157,9 +126,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 	{
 		return count($this->rows);
 	}
-
-	// }}}
-	// {{{ public function &getRows()
 
 	/**
 	 * Gets the rows of this data structure as an array
@@ -172,9 +138,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 	{
 		return $this->rows;
 	}
-
-	// }}}
-	// {{{ public function addRow()
 
 	/**
 	 * Adds a row to this data structure
@@ -189,7 +152,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 		$this->add($data);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTableView.php
+++ b/Swat/SwatTableView.php
@@ -13,7 +13,6 @@
  */
 class SwatTableView extends SwatView implements SwatUIParent
 {
-	// {{{ public properties
 
 	/**
 	 * The column of this table-view that data in the model is currently being
@@ -84,9 +83,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 	 * @var boolean
 	 */
 	public $use_invalid_tfoot_ordering = false;
-
-	// }}}
-	// {{{ protected properties
 
 	/**
 	 * The columns of this table-view indexed by their unique identifier
@@ -186,10 +182,7 @@ class SwatTableView extends SwatView implements SwatUIParent
 	 */
 	protected $has_input_row = false;
 
-	// }}}
-
 	// general methods
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new table view
@@ -208,9 +201,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		$this->addJavaScript('packages/swat/javascript/swat-table-view.js');
 		$this->addStyleSheet('packages/swat/styles/swat-table-view.css');
 	}
-
-	// }}}
-	// {{{ public function init()
 
 	/**
 	 * Initializes this table-view
@@ -251,9 +241,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 				$this->spanning_columns_by_id[$column->id] = $column;
 		}
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this table-view
@@ -315,9 +302,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this table-view
 	 */
@@ -340,9 +324,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 			$this->checked_items = $items->getItems();
 		}
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child object
@@ -382,9 +363,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 				'objects.', 0, $child);
 	}
 
-	// }}}
-	// {{{ public function getMessages()
-
 	/**
 	 * Gathers all messages from this table-view
 	 *
@@ -420,9 +398,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
 		return $messages;
 	}
-
-	// }}}
-	// {{{ public function hasMessage()
 
 	/**
 	 * Gets whether or not this table-view has any messages
@@ -464,9 +439,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $has_message;
 	}
 
-	// }}}
-	// {{{ public function getXhtmlColspan()
-
 	/**
 	 * Gets how many XHTML table columns the visible column objects of this
 	 * table-view object span on display
@@ -495,9 +467,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
 		return $colspan;
 	}
-
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this table
@@ -530,9 +499,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this table
 	 *
@@ -563,9 +529,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -638,9 +601,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
 		return $out;
 	}
-
-	// }}}
-	// {{{ public function getFirstDescendant()
 
 	/**
 	 * Gets the first descendant UI-object of a specific class
@@ -720,9 +680,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -742,9 +699,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -760,9 +714,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -824,9 +775,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $copy;
 	}
 
-	// }}}
-	// {{{ protected function hasHeader()
-
 	/**
 	 * Whether this table has a header to display
 	 *
@@ -846,9 +794,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $has_header;
 	}
 
-	// }}}
-	// {{{ protected function displayHeader()
-
 	/**
 	 * Displays the column headers for this table-view
 	 *
@@ -866,9 +811,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		echo '</tr>';
 		echo '</thead>';
 	}
-
-	// }}}
-	// {{{ protected function displayBody()
 
 	/**
 	 * Displays the contents of this view
@@ -911,9 +853,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ protected function displayRow()
-
 	/**
 	 * Displays a single row
 	 *
@@ -935,9 +874,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		$this->displayRowGroupFooters($row, $next_row, $count);
 	}
 
-	// }}}
-	// {{{ protected function displayRowGroupHeaders()
-
 	/**
 	 * Displays row group headers
 	 *
@@ -953,9 +889,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 			$group->display($row);
 	}
 
-	// }}}
-	// {{{ protected function displayRowGroupFooters()
-
 	/**
 	 * Displays row group headers
 	 *
@@ -970,9 +903,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		foreach ($this->groups as $group)
 			$group->displayFooter($row, $next_row);
 	}
-
-	// }}}
-	// {{{ protected function displayRowColumns()
 
 	/**
 	 * Displays the columns for a row
@@ -1019,9 +949,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ protected function displayRowSpanningColumns()
-
 	/**
 	 * Displays row spanning columns
 	 *
@@ -1049,9 +976,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 			}
 		}
 	}
-
-	// }}}
-	// {{{ protected function displayRowMessages()
 
 	/**
 	 * Displays a list of {@link SwatMessage} object for the given row
@@ -1099,9 +1023,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ protected function displayFooter()
-
 	/**
 	 * Displays any footer content for this table-view
 	 *
@@ -1125,9 +1046,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 			$tfoot_tag->display();
 		}
 	}
-
-	// }}}
-	// {{{ protected function rowHasMessage()
 
 	/**
 	 * Whether any of the columns in the row has a message
@@ -1161,9 +1079,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $has_message;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this table view
 	 *
@@ -1176,9 +1091,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getRowClasses()
 
 	/**
 	 * Gets CSS classes for the XHTML tr tag
@@ -1208,9 +1120,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function getRowClassString()
-
 	/**
 	 * Gets CSS class string for the XHTML tr tag
 	 *
@@ -1232,9 +1141,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
 		return $class_string;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets inline JavaScript required by this table-view as well as any
@@ -1297,10 +1203,7 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $javascript;
 	}
 
-	// }}}
-
 	// column methods
-	// {{{ public function appendColumn()
 
 	/**
 	 * Appends a column to this table-view
@@ -1314,9 +1217,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 	{
 		$this->insertColumn($column);
 	}
-
-	// }}}
-	// {{{ public function insertColumnBefore()
 
 	/**
 	 * Inserts a column before an existing column in this table-view
@@ -1337,9 +1237,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		$this->insertColumn($column, $reference_column, false);
 	}
 
-	// }}}
-	// {{{ public function insertColumnAfter()
-
 	/**
 	 * Inserts a column after an existing column in this table-view
 	 *
@@ -1359,9 +1256,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		$this->insertColumn($column, $reference_column, true);
 	}
 
-	// }}}
-	// {{{ public function hasColumn()
-
 	/**
 	 * Returns true if a column with the given id exists within this
 	 * table-view
@@ -1376,9 +1270,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 	{
 		return array_key_exists($id, $this->columns_by_id);
 	}
-
-	// }}}
-	// {{{ public function getColumn()
 
 	/**
 	 * Gets a column in this table-view by the column's id
@@ -1399,9 +1290,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $this->columns_by_id[$id];
 	}
 
-	// }}}
-	// {{{ public function getColumns()
-
 	/**
 	 * Gets all columns of this table-view as an array
 	 *
@@ -1412,9 +1300,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $this->columns;
 	}
 
-	// }}}
-	// {{{ public function getColumnCount()
-
 	/**
 	 * Gets the number of columns in this table-view
 	 *
@@ -1424,9 +1309,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 	{
 		return count($this->columns);
 	}
-
-	// }}}
-	// {{{ public function getVisibleColumns()
 
 	/**
 	 * Gets all visible columns of this table-view as an array
@@ -1443,9 +1325,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $columns;
 	}
 
-	// }}}
-	// {{{ public function getVisibleColumnCount()
-
 	/**
 	 * Gets the number of visible columns in this table-view
 	 *
@@ -1455,9 +1334,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 	{
 		return count($this->getVisibleColumns());
 	}
-
-	// }}}
-	// {{{ public function setDefaultOrderbyColumn()
 
 	/**
 	 * Sets a default column to use for ordering the data of this table-view
@@ -1482,9 +1358,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		$column->setDirection($direction);
 	}
 
-	// }}}
-	// {{{ protected function validateColumn()
-
 	/**
 	 * Ensures a column added to this table-view is valid for this table-view
 	 *
@@ -1506,9 +1379,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 			}
 		}
 	}
-
-	// }}}
-	// {{{ protected function insertColumn()
 
 	/**
 	 * Helper method to insert columns into this table-view
@@ -1585,10 +1455,7 @@ class SwatTableView extends SwatView implements SwatUIParent
 		$column->parent = $this;
 	}
 
-	// }}}
-
 	// spanning column methods
-	// {{{ public function appendSpanningColumn()
 
 	/**
 	 * Appends a spanning column object to this table-view
@@ -1605,9 +1472,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		$column->parent = $this;
 	}
 
-	// }}}
-	// {{{ public function hasSpanningColumn()
-
 	/**
 	 * Returns true if a spanning column with the given id exists within this table-view
 	 *
@@ -1617,9 +1481,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 	{
 		return array_key_exists($id, $this->spanning_columns_by_id);
 	}
-
-	// }}}
-	// {{{ public function getSpanningColumn()
 
 	/**
 	 * Gets a spanning column in this table-view by the spanning column's id
@@ -1641,9 +1502,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $this->spanning_columns_by_id[$id];
 	}
 
-	// }}}
-	// {{{ public function getSpanningColumns()
-
 	/**
 	 * Gets all spanning columns of this table-view as an array
 	 *
@@ -1653,9 +1511,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 	{
 		return $this->spanning_columns;
 	}
-
-	// }}}
-	// {{{ public function getVisibleSpanningColumns()
 
 	/**
 	 * Gets all visible spanning columns of this table-view as an array
@@ -1675,10 +1530,7 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $columns;
 	}
 
-	// }}}
-
 	// grouping methods
-	// {{{ public function appendGroup()
 
 	/**
 	 * Appends a grouping object to this table-view
@@ -1710,9 +1562,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		$group->parent = $this;
 	}
 
-	// }}}
-	// {{{ public function hasGroup()
-
 	/**
 	 * Returns true if a group with the given id exists within this table-view
 	 *
@@ -1726,9 +1575,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 	{
 		return array_key_exists($id, $this->groups_by_id);
 	}
-
-	// }}}
-	// {{{ public function getGroup()
 
 	/**
 	 * Gets a group in this table-view by the group's id
@@ -1749,9 +1595,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $this->groups_by_id[$id];
 	}
 
-	// }}}
-	// {{{ public function getGroups()
-
 	/**
 	 * Gets all groups of this table-view as an array
 	 *
@@ -1761,9 +1604,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 	{
 		return $this->groups;
 	}
-
-	// }}}
-	// {{{ protected function validateGroup()
 
 	/**
 	 * Ensures a group added to this table-view is valid for this table-view
@@ -1786,10 +1626,7 @@ class SwatTableView extends SwatView implements SwatUIParent
 		}
 	}
 
-	// }}}
-
 	// extra row methods
-	// {{{ public function appendRow()
 
 	/**
 	 * Appends a single row to this table-view
@@ -1806,9 +1643,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 	{
 		$this->insertRow($row);
 	}
-
-	// }}}
-	// {{{ public function insertRowBefore()
 
 	/**
 	 * Inserts a row before an existing row in this table-view
@@ -1831,9 +1665,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		$this->insertRow($row, $reference_row, false);
 	}
 
-	// }}}
-	// {{{ public function insertRowAfter()
-
 	/**
 	 * Inserts a row after an existing row in this table-view
 	 *
@@ -1855,9 +1686,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		$this->insertRow($row, $reference_row, true);
 	}
 
-	// }}}
-	// {{{ public function hasRow()
-
 	/**
 	 * Returns true if a row with the given id exists within this table-view
 	 *
@@ -1871,9 +1699,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 	{
 		return array_key_exists($id, $this->rows_by_id);
 	}
-
-	// }}}
-	// {{{ public function getRow()
 
 	/**
 	 * Gets a row in this table-view by the row's id
@@ -1894,9 +1719,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		return $this->rows_by_id[$id];
 	}
 
-	// }}}
-	// {{{ public function getRowsByClass()
-
 	/**
 	 * Gets all the extra rows of the specified class from this table-view
 	 *
@@ -1913,9 +1735,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
 		return $rows;
 	}
-
-	// }}}
-	// {{{ public function getFirstRowByClass()
 
 	/**
 	 * Gets the first extra row of the specified class from this table-view
@@ -1943,9 +1762,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		}
 		return $my_row;
 	}
-
-	// }}}
-	// {{{ protected function validateRow()
 
 	/**
 	 * Ensures a row added to this table-view is valid for this table-view
@@ -1976,9 +1792,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 					0, $row->id);
 		}
 	}
-
-	// }}}
-	// {{{ protected function insertRow()
 
 	/**
 	 * Helper method to insert rows into this table-view
@@ -2052,7 +1865,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 		$row->parent = $this;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTableViewCheckAllRow.php
+++ b/Swat/SwatTableViewCheckAllRow.php
@@ -9,7 +9,6 @@
  */
 class SwatTableViewCheckAllRow extends SwatTableViewRow
 {
-	// {{{ public properties
 
 	/**
 	 * Optional checkbox label title
@@ -68,18 +67,12 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
 	 */
 	public $tab_index;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * The check-all widget for this row
 	 *
 	 * @var SwatCheckAll
 	 */
 	protected $check_all;
-
-	// }}}
-	// {{{ private properties
 
 	/**
 	 * The table-view checkbox column to which this check-all row is bound
@@ -108,9 +101,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
 	 */
 	private $widgets_created = false;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new table-view check-all row
 	 *
@@ -126,9 +116,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
 		$this->column = $column;
 		$this->list_id = $list_id;
 	}
-
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this check-all row
@@ -148,9 +135,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this
 	 * check-all row
@@ -169,9 +153,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this check-all row
 	 */
@@ -181,9 +162,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
 		$this->createEmbeddedWidgets();
 		$this->check_all->init();
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this check-all row
@@ -195,9 +173,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
 		$this->check_all->process();
 	}
 
-	// }}}
-	// {{{ public function isExtendedSelected()
-
 	/**
 	 * Whether or not the extended-checkbox was checked
 	 *
@@ -207,9 +182,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
 	{
 		return $this->check_all->isExtendedSelected();
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this check-all row
@@ -269,9 +241,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
 		$tr_tag->close();
 	}
 
-	// }}}
-	// {{{ public function getInlineJavaScript()
-
 	/**
 	 * Gets the inline JavaScript required for this check-all row
 	 *
@@ -289,9 +258,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
 			$this->check_all->id, $this->list_id);
 	}
 
-	// }}}
-	// {{{ private function createEmbeddedWidgets()
-
 	/**
 	 * Creates internal widgets required for this check-all row
 	 */
@@ -305,7 +271,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTableViewCheckboxColumn.php
+++ b/Swat/SwatTableViewCheckboxColumn.php
@@ -18,7 +18,6 @@
  */
 class SwatTableViewCheckboxColumn extends SwatTableViewColumn
 {
-	// {{{ public properties
 
 	/**
 	 * Whether to show a check-all row for this checkbox column
@@ -89,9 +88,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
 	 */
 	public $highlight_row = true;
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * The selected rows of this checkbox column after processing this column
 	 *
@@ -112,9 +108,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
 	 */
 	private $check_all;
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this checkbox column
 	 */
@@ -129,9 +122,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
 			$this->parent->appendRow($this->check_all);
 		}
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this checkbox column
@@ -153,9 +143,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
 			$this->items = $_POST[$item_name];
 	}
 
-	// }}}
-	// {{{ public function isExtendedCheckAllSelected()
-
 	/**
 	 * Whether or not the extended-check-all check-box was checked
 	 *
@@ -165,9 +152,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
 	{
 		return $this->check_all->isExtendedSelected();
 	}
-
-	// }}}
-	// {{{ public function displayHeader()
 
 	/**
 	 * Displays the contents of the header cell for this column
@@ -186,9 +170,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
 		parent::displayHeader();
 	}
 
-	// }}}
-	// {{{ public function getItems()
-
 	/**
 	 * Gets the selected rows of this checkbox column
 	 *
@@ -204,9 +185,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
 		return $this->items;
 	}
 
-	// }}}
-	// {{{ public function getCheckboxRendererId()
-
 	/**
 	 * Gets the identifier of the first checkbox cell renderer in this column
 	 *
@@ -218,9 +196,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
 		return $this->getCheckboxRenderer()->id;
 	}
 
-	// }}}
-	// {{{ public function getCheckboxRenderer()
-
 	private function getCheckboxRenderer()
 	{
 		foreach ($this->getRenderers() as $renderer)
@@ -230,9 +205,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
 		throw new SwatException("The checkbox column ‘{$this->id}’ must ".
 			'contain a checkbox cell renderer.');
 	}
-
-	// }}}
-	// {{{ public function extendedCheckAllSelected()
 
 	/**
 	 * Whether or not the extended-check-all check-box was checked
@@ -244,16 +216,12 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
 		return $this->check_all->extendedSelected();
 	}
 
-	// }}}
-	// {{{ private function createEmbeddedWidgets()
-
 	private function createEmbeddedWidgets()
 	{
 		$renderer_id = $this->getCheckboxRendererId();
 		$this->check_all = new SwatTableViewCheckAllRow($this, $renderer_id);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTableViewColumn.php
+++ b/Swat/SwatTableViewColumn.php
@@ -16,7 +16,6 @@
  */
 class SwatTableViewColumn extends SwatCellRendererContainer
 {
-	// {{{ public properties
 
 	/**
 	 * Unique identifier of this column
@@ -86,9 +85,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 	 */
 	public $show_renderer_classes = true;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * An optional {@link SwatInputCell} object for this column
 	 *
@@ -110,9 +106,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 	 */
 	protected $has_auto_id = false;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new table-view column
 	 *
@@ -124,9 +117,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		$this->id = $id;
 		parent::__construct();
 	}
-
-	// }}}
-	// {{{ public function init()
 
 	/**
 	 * Initializes this column
@@ -156,17 +146,11 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		}
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	public function process()
 	{
 		foreach ($this->renderers as $renderer)
 			$renderer->process();
 	}
-
-	// }}}
-	// {{{ public function hasHeader()
 
 	/**
 	 * Whether this column has a header to display
@@ -175,9 +159,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 	{
 		return ($this->visible && $this->title != '');
 	}
-
-	// }}}
-	// {{{ public function displayHeaderCell()
 
 	/**
 	 * Displays the table-view header cell for this column
@@ -198,9 +179,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		$this->displayHeader();
 		$th_tag->close();
 	}
-
-	// }}}
-	// {{{ public function displayHeader()
 
 	/**
 	 * Displays the contents of the header cell for this column
@@ -232,9 +210,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		}
 	}
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this column using a data object
 	 *
@@ -252,9 +227,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		$this->setupRenderers($row);
 		$this->displayRenderers($row);
 	}
-
-	// }}}
-	// {{{ public function getMessages()
 
 	/**
 	 * Gathers all messages from this column for the given data object
@@ -275,9 +247,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 
 		return $messages;
 	}
-
-	// }}}
-	// {{{ public function hasMessage()
 
 	/**
 	 * Gets whether or not this column has any messages for the given data
@@ -305,9 +274,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		return $has_message;
 	}
 
-	// }}}
-	// {{{ public function getInlineJavaScript()
-
 	/**
 	 * Gets the inline JavaScript required by this column
 	 *
@@ -320,9 +286,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 	{
 		return '';
 	}
-
-	// }}}
-	// {{{ public function setInputCell()
 
 	/**
 	 * Sets the input cell of this column
@@ -337,9 +300,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		$this->input_cell = $cell;
 		$cell->parent = $this;
 	}
-
-	// }}}
-	// {{{ public function getTrAttributes()
 
 	/**
 	 * Gets TR-tag attributes
@@ -360,9 +320,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		return array();
 	}
 
-	// }}}
-	// {{{ public function getInputCell()
-
 	/**
 	 * Gets the input cell of this column
 	 *
@@ -380,9 +337,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 	{
 		return $this->input_cell;
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Add a child object to this object
@@ -409,9 +363,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 				'nested within SwatTableViewColumn objects.', 0, $child);
 		}
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -464,9 +415,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -493,9 +441,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this column
 	 *
@@ -514,9 +459,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this column
@@ -538,9 +480,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getTdAttributes()
-
 	/**
 	 * Gets the TD tag attributes for this column
 	 *
@@ -554,9 +493,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 			'class' => $this->getCSSClassString(),
 		);
 	}
-
-	// }}}
-	// {{{ public function getThAttributes()
 
 	/**
 	 * Gets the TH tag attributes for this column
@@ -572,9 +508,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		);
 	}
 
-	// }}}
-	// {{{ public function getXhtmlColspan()
-
 	/**
 	 * Gets how many XHTML table columns this column object spans on display
 	 *
@@ -585,9 +518,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 	{
 		return 1;
 	}
-
-	// }}}
-	// {{{ public function hasVisibleRenderer()
 
 	/**
 	 * Whether or not this column has one or more visible cell renderers
@@ -614,9 +544,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 
 		return $visible_renderers;
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -645,9 +572,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		return $copy;
 	}
 
-	// }}}
-	// {{{ protected function displayRenderers()
-
 	/**
 	 * Renders each cell renderer in this column inside a wrapping XHTML
 	 * element
@@ -667,9 +591,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		$this->displayRenderersInternal($data);
 		$td_tag->close();
 	}
-
-	// }}}
-	// {{{ protected function displayRenderersInternal()
 
 	/**
 	 * Renders each cell renderer in this column
@@ -721,9 +642,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		}
 	}
 
-	// }}}
-	// {{{ protected function setupRenderers()
-
 	/**
 	 * Sets properties of renderers using data from current row
 	 *
@@ -744,9 +662,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 			$renderer->sensitive = $renderer->sensitive && $sensitive;
 		}
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this table-view column
@@ -814,9 +729,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function getBaseCSSClassNames()
-
 	/**
 	 * Gets the base CSS class names of this table-view column
 	 *
@@ -831,7 +743,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 		return array();
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTableViewGroup.php
+++ b/Swat/SwatTableViewGroup.php
@@ -15,7 +15,6 @@
  */
 class SwatTableViewGroup extends SwatTableViewColumn
 {
-	// {{{ public properties
 
 	/**
 	 * The field of the table store to group rows by
@@ -23,9 +22,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
 	 * @var string
 	 */
 	public $group_by = null;
-
-	// }}}
-	// {{{ private properties
 
 	/**
 	 * The current value of the group_by field of the table model for the
@@ -50,9 +46,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
 	 * @var mixed
 	 */
 	private $footer_current = null;
-
-	// }}}
-	// {{{ public function displayFooter()
 
 	/**
 	 * Displays the grouping footer of this table-view group
@@ -81,9 +74,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
 		}
 	}
 
-	// }}}
-	// {{{ protected function displayGroupHeader()
-
 	/**
 	 * Displays the group header for this grouping column
 	 *
@@ -107,9 +97,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
 		$tr_tag->close();
 	}
 
-	// }}}
-	// {{{ protected function displayGroupFooter()
-
 	/**
 	 * Displays the group footer for this grouping column
 	 *
@@ -123,9 +110,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
 	protected function displayGroupFooter($row)
 	{
 	}
-
-	// }}}
-	// {{{ protected function displayRenderers()
 
 	/**
 	 * Displays the renderers for this column
@@ -155,9 +139,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
 		}
 	}
 
-	// }}}
-	// {{{ protected function isEqual()
-
 	/**
 	 * Compares the value of the current row to the value of the current
 	 * group to see if the value has changed
@@ -178,9 +159,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
 		return ($group_value === $row_value);
 	}
 
-	// }}}
-	// {{{ protected function resetSubGroups()
-
 	/**
 	 * Resets grouping columns below this one
 	 *
@@ -200,9 +178,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
 		}
 	}
 
-	// }}}
-	// {{{ protected function reset()
-
 	/**
 	 * Resets the current value of this grouping column
 	 *
@@ -217,9 +192,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
 		$this->header_current = null;
 	}
 
-	// }}}
-	// {{{ protected function getBaseCSSClassNames()
-
 	/**
 	 * Gets the base CSS class names of this table-view group
 	 *
@@ -231,7 +203,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
 		return array('swat-table-view-group');
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTableViewInputRow.php
+++ b/Swat/SwatTableViewInputRow.php
@@ -19,7 +19,6 @@
  */
 class SwatTableViewInputRow extends SwatTableViewRow
 {
-	// {{{ public properties
 
 	/**
 	 * The text to display in the link to enter a new row
@@ -56,9 +55,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 	 * @var boolean
 	 */
 	public $show_row_messages = true;
-
-	// }}}
-	// {{{ private properties
 
 	/**
 	 * The tool-link to create another row
@@ -97,9 +93,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 	 */
 	private $replicators = array();
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new input row
 	 */
@@ -114,9 +107,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 			'packages/swat/javascript/swat-table-view-input-row.js'
 		);
 	}
-
-	// }}}
-	// {{{ public function init()
 
 	/**
 	 * Initializes this input row
@@ -160,9 +150,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 			$this->replicators = explode(',', $replicator_field);
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this input row
 	 *
@@ -178,9 +165,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 			foreach ($this->input_cells as $cell)
 				$cell->process($replicator_id);
 	}
-
-	// }}}
-	// {{{ public function addInputCell()
 
 	/**
 	 * Adds an input cell to this row from a column
@@ -200,9 +184,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 	{
 		$this->input_cells[$column_id] = $cell;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this row
@@ -238,9 +219,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 		$this->displayEnterAnotherRow();
 	}
 
-	// }}}
-	// {{{ public function addReplication()
-
 	/**
 	 * Add a replicator id
 	 *
@@ -252,9 +230,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 		$this->replicators[] = $id;
 		return end($this->replicators);
 	}
-
-	// }}}
-	// {{{ public function getReplicators()
 
 	/**
 	 * Gets the replicator ids of this input row
@@ -273,9 +248,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 	{
 		return $this->replicators;
 	}
-
-	// }}}
-	// {{{ public function getWidget()
 
 	/**
 	 * Gets a particular widget in this row
@@ -307,9 +279,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 			'given column identifier.');
 	}
 
-	// }}}
-	// {{{ public function getPrototypeWidget()
-
 	/**
 	 * Gets the prototype widget for a column attached to this row
 	 *
@@ -340,9 +309,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 			'cell bound to this row or the column does not exist.');
 	}
 
-	// }}}
-	// {{{ public function removeReplicatedRow()
-
 	/**
 	 * Removes a row from this input row by its replicator id
 	 *
@@ -358,9 +324,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 		foreach ($this->input_cells as $cell)
 			$cell->unsetWidget($replicator_id);
 	}
-
-	// }}}
-	// {{{ public function getVisibleByCount()
 
 	/**
 	 * Gets whether or not to show this row based on a count of rows
@@ -378,9 +341,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 	{
 		return $this->visible;
 	}
-
-	// }}}
-	// {{{ public function rowHasMessage()
 
 	/**
 	 * Gets whether or not a given replicated row has messages
@@ -405,9 +365,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 		return $row_has_message;
 	}
 
-	// }}}
-	// {{{ public function getMessages()
-
 	/**
 	 * Gathers all messages from this table-view row
 	 *
@@ -428,9 +385,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 
 		return $messages;
 	}
-
-	// }}}
-	// {{{ public function hasMessage()
 
 	/**
 	 * Gets whether or not the widgets in this row have any messages
@@ -453,9 +407,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 
 		return $has_message;
 	}
-
-	// }}}
-	// {{{ public function getInlineJavaScript()
 
 	/**
 	 * Creates a JavaScript object to control the client behaviour of this
@@ -489,9 +440,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 			$this->getId(), $this->getId(), trim($row_string));
 	}
 
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this input row
 	 *
@@ -509,9 +457,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this input row
@@ -532,9 +477,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 		return $set;
 	}
 
-	// }}}
-	// {{{ private function getId()
-
 	private function getId()
 	{
 		$id = $this->id;
@@ -545,9 +487,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 
 		return $id;
 	}
-
-	// }}}
-	// {{{ private function displayInputRows()
 
 	/**
 	 * Displays the actual XHTML input rows for this input row
@@ -641,9 +580,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 		}
 	}
 
-	// }}}
-	// {{{ private function createEmbeddedWidgets()
-
 	/**
 	 * Instantiates the tool-link for this input row
 	 */
@@ -658,9 +594,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 			$this->widgets_created = true;
 		}
 	}
-
-	// }}}
-	// {{{ private function displayEnterAnotherRow()
 
 	/**
 	 * Displays the enter-another-row row
@@ -719,9 +652,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 		$tr_tag->close();
 	}
 
-	// }}}
-	// {{{ private function getRowString()
-
 	/**
 	 * Gets this input row as an XHTML table row with the row identifier as a
 	 * placeholder '%s'
@@ -768,9 +698,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 		return ob_get_clean();
 	}
 
-	// }}}
-	// {{{ private function getForm()
-
 	/**
 	 * Gets the form this row's view is contained in
 	 *
@@ -789,7 +716,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 		return $form;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTableViewOrderableColumn.php
+++ b/Swat/SwatTableViewOrderableColumn.php
@@ -15,7 +15,6 @@
  */
 class SwatTableViewOrderableColumn extends SwatTableViewColumn
 {
-	// {{{ constants
 
 	/**
 	 * Indicates no ordering is done
@@ -41,9 +40,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 	 * Indicates ascending ordering is done
 	 */
 	const NULLS_LAST = 2;
-
-	// }}}
-	// {{{ public properties
 
 	/**
 	 * The base of the link used when building column header links
@@ -83,9 +79,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 	 */
 	public $unset_get_vars = array();
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * The direction of ordering
 	 *
@@ -115,9 +108,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 	 */
 	protected $default_direction = self::ORDER_BY_DIR_NONE;
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * The mode of ordering
 	 *
@@ -127,9 +117,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 	 * @var integer
 	 */
 	//private $mode = SwatTableViewOrderableColumn::ORDER_MODE_TRISTATE;
-
-	// }}}
-	// {{{ public function init()
 
 	/**
 	 * Initializes this column
@@ -141,9 +128,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 		parent::init();
 		$this->initFromGetVariables();
 	}
-
-	// }}}
-	// {{{ public function setDirection()
 
 	/**
 	 * Sets the direction of ordering
@@ -170,9 +154,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 
 		$this->initFromGetVariables();
 	}
-
-	// }}}
-	// {{{ public function displayHeader()
 
 	/**
 	 * Displays the column header for this table view column
@@ -217,9 +198,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 
 		$anchor->close();
 	}
-
-	// }}}
-	// {{{ public function getDirectionAsString()
 
 	/**
 	 * Gets the direction of ordering as a string
@@ -284,9 +262,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 		return $direction;
 	}
 
-	// }}}
-	// {{{ protected function displayTitle()
-
 	protected function displayTitle($title, $content_type)
 	{
 		// Display last word of the title in its own span so it can be styled
@@ -312,9 +287,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 		$span_tag->display();
 	}
 
-	// }}}
-	// {{{ protected function getBaseCSSClassNames()
-
 	/**
 	 * Gets the base CSS class names of this orderable table-view column
 	 *
@@ -331,9 +303,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function getLinkPrefix()
-
 	/**
 	 * Gets the prefix for GET var links
 	 *
@@ -344,9 +313,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 		// TODO: is id a required field of table views?
 		return $this->view->id.'_';
 	}
-
-	// }}}
-	// {{{ protected function getNextDirection()
 
 	/**
 	 * Gets the next direction or ordering in the rotation
@@ -375,9 +341,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 				return self::ORDER_BY_DIR_ASCENDING;
 		}
 	}
-
-	// }}}
-	// {{{ private function setDirectionByString()
 
 	/**
 	 * Sets direction of ordering by a string
@@ -408,9 +371,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 			$this->direction = self::ORDER_BY_DIR_NONE;
 		}
 	}
-
-	// }}}
-	// {{{ private function getLink()
 
 	/**
 	 * Gets the link for this column's header
@@ -461,9 +421,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 		return $link;
 	}
 
-	// }}}
-	// {{{ private function initFromGetVariables()
-
 	/**
 	 * Process GET variables and set class variables
 	 */
@@ -481,7 +438,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTableViewRow.php
+++ b/Swat/SwatTableViewRow.php
@@ -9,7 +9,6 @@
  */
 abstract class SwatTableViewRow extends SwatUIObject
 {
-	// {{{ public properties
 
 	/**
 	 * The {@link SwatTableView} associated with this row
@@ -24,9 +23,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 	 * @param string
 	 */
 	public $id = null;
-
-	// }}}
-	// {{{ protected properties
 
 	/**
 	 * Whether or not this row has been processed
@@ -46,9 +42,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 	 */
 	protected $displayed = false;
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this row
 	 *
@@ -61,9 +54,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 	public function init()
 	{
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this row
@@ -79,9 +69,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 		$this->processed = true;
 	}
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this row
 	 */
@@ -89,9 +76,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 	{
 		$this->displayed = true;
 	}
-
-	// }}}
-	// {{{ public function isProcessed()
 
 	/**
 	 * Whether or not this row is processed
@@ -103,9 +87,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 		return $this->processed;
 	}
 
-	// }}}
-	// {{{ public function isDisplayed()
-
 	/**
 	 * Whether or not this row is displayed
 	 *
@@ -115,9 +96,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 	{
 		return $this->displayed;
 	}
-
-	// }}}
-	// {{{ public function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript required by this row
@@ -131,9 +109,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 	{
 		return '';
 	}
-
-	// }}}
-	// {{{ public function getVisibleByCount()
 
 	/**
 	 * Gets whether or not to show this row based on a count of rows
@@ -153,9 +128,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 
 		return true;
 	}
-
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this row
@@ -177,9 +149,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this row
 	 *
@@ -191,9 +160,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 		return new SwatHtmlHeadEntrySet($this->html_head_entry_set);
 	}
 
-	// }}}
-	// {{{ public function getMessages()
-
 	/**
 	 * Gathers all messages from this table-view row
 	 *
@@ -203,9 +169,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 	{
 		return array();
 	}
-
-	// }}}
-	// {{{ public function hasMessage()
 
 	/**
 	 * Gets whether or this row has any messages
@@ -217,9 +180,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 	{
 		return false;
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -242,7 +202,6 @@ abstract class SwatTableViewRow extends SwatUIObject
 		return $copy;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTableViewSpanningColumn.php
+++ b/Swat/SwatTableViewSpanningColumn.php
@@ -9,7 +9,6 @@
  */
 class SwatTableViewSpanningColumn extends SwatTableViewColumn
 {
-	// {{{ public properties
 
 	/**
 	 * The number of columns to offset to the right
@@ -17,9 +16,6 @@ class SwatTableViewSpanningColumn extends SwatTableViewColumn
 	 * @var integer
 	 */
 	public $offset = 0;
-
-	// }}}
-	// {{{ protected function displayRenderers()
 
 	/**
 	 * Renders each cell renderer in this column inside a wrapping XHTML
@@ -64,9 +60,6 @@ class SwatTableViewSpanningColumn extends SwatTableViewColumn
 		$td_tag->close();
 	}
 
-	// }}}
-	// {{{ public function getXhtmlColspan()
-
 	/**
 	 * Gets how many XHTML table columns this column object spans on display
 	 *
@@ -86,7 +79,6 @@ class SwatTableViewSpanningColumn extends SwatTableViewColumn
 		return $colspan;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTableViewWidgetRow.php
+++ b/Swat/SwatTableViewWidgetRow.php
@@ -9,7 +9,6 @@
  */
 class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 {
-	// {{{ class constants
 
 	/**
 	 * Display the widget in the left cell
@@ -20,9 +19,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 	 * Display the widget in the right cell
 	 */
 	const POSITION_RIGHT = 1;
-
-	// }}}
-	// {{{ public properties
 
 	/**
 	 * How far from the end of the row the widget should be displayed measured
@@ -50,9 +46,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 	 */
 	public $position = self::POSITION_LEFT;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * The contained widget
 	 *
@@ -61,9 +54,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 	 * @see SwatTableViewWidgetRow::setWidget()
 	 */
 	protected $widget;
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child object
@@ -94,9 +84,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 
 		$this->setWidget($child);
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -135,9 +122,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -164,9 +148,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -186,9 +167,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -204,9 +182,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 			if (isset($states[$id]))
 				$object->setState($states[$id]);
 	}
-
-	// }}}
-	// {{{ public function setWidget()
 
 	/**
 	 * Sets the widget contained in this row
@@ -226,9 +201,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 		$widget->parent = $this;
 	}
 
-	// }}}
-	// {{{ public function getWidget()
-
 	/**
 	 * Gets the widget contained in this row
 	 *
@@ -240,9 +212,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 		return $this->widget;
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	public function init()
 	{
 		parent::init();
@@ -251,9 +220,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 			$this->widget->init();
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	public function process()
 	{
 		parent::process();
@@ -261,9 +227,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 		if ($this->widget !== null)
 			$this->widget->process();
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	public function display()
 	{
@@ -292,9 +255,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 		$tr_tag->close();
 	}
 
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this row
 	 *
@@ -315,9 +275,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this row
 	 *
@@ -334,9 +291,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -362,9 +316,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 		return $copy;
 	}
 
-	// }}}
-	// {{{ public function getMessages()
-
 	/**
 	 * Gathers all messages from this table-view-row
 	 *
@@ -380,9 +331,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 
 		return $messages;
 	}
-
-	// }}}
-	// {{{ public function hasMessage()
 
 	/**
 	 * Gets whether or not the widgets in this row have any messages
@@ -403,9 +351,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 		return $has_message;
 	}
 
-	// }}}
-	// {{{ protected function displayOffsetCell()
-
 	protected function displayOffsetCell($offset)
 	{
 		$td_tag = new SwatHtmlTag('td');
@@ -415,9 +360,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 		echo '&nbsp;';
 		$td_tag->close();
 	}
-
-	// }}}
-	// {{{ protected function displayWidgetCell()
 
 	protected function displayWidgetCell()
 	{
@@ -429,9 +371,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 			$this->widget->display();
 			$td_tag->close();
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this row
@@ -445,7 +384,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTextCellRenderer.php
+++ b/Swat/SwatTextCellRenderer.php
@@ -9,7 +9,6 @@
  */
 class SwatTextCellRenderer extends SwatCellRenderer
 {
-	// {{{ public properties
 
 	/**
 	 * The textual content to place within this cell
@@ -48,9 +47,6 @@ class SwatTextCellRenderer extends SwatCellRenderer
 	 */
 	public $value = null;
 
-	// }}}
-	// {{{ public function render()
-
 	/**
 	 * Renders the contents of this cell
 	 *
@@ -76,7 +72,6 @@ class SwatTextCellRenderer extends SwatCellRenderer
 			echo $text;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTextarea.php
+++ b/Swat/SwatTextarea.php
@@ -9,7 +9,6 @@
  */
 class SwatTextarea extends SwatInputControl implements SwatState
 {
-	// {{{ public properties
 
 	/**
 	 * Text content of the widget
@@ -99,9 +98,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
 	 */
 	public $placeholder;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new textarea widget
 	 *
@@ -119,9 +115,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
 		$this->addJavaScript('packages/swat/javascript/swat-textarea.js');
 		$this->addStyleSheet('packages/swat/styles/swat-textarea.css');
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this textarea
@@ -146,9 +139,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
 
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this textarea
@@ -184,9 +174,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
 		}
 	}
 
-	// }}}
-	// {{{ public function getState()
-
 	/**
 	 * Gets the current state of this textarea
 	 *
@@ -199,9 +186,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
 		return $this->value;
 	}
 
-	// }}}
-	// {{{ public function setState()
-
 	/**
 	 * Sets the current state of this textarea
 	 *
@@ -213,9 +197,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
 	{
 		$this->value = $state;
 	}
-
-	// }}}
-	// {{{ public function getFocusableHtmlId()
 
 	/**
 	 * Gets the id attribute of the XHTML element displayed by this widget
@@ -231,9 +212,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
 	{
 		return ($this->visible) ? $this->id : null;
 	}
-
-	// }}}
-	// {{{ protected function getTextareaTag()
 
 	/**
 	 * Gets the textarea tag used to display this textarea control
@@ -275,9 +253,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
 		return $textarea_tag;
 	}
 
-	// }}}
-	// {{{ protected function getValueLength()
-
 	/**
 	 * Gets the computed length of the value of this textarea
 	 *
@@ -296,9 +271,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
 		return $length;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this textarea
 	 *
@@ -310,9 +282,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript for this textarea widget
@@ -326,7 +295,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
 			$this->id, $this->id, $resizeable);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -13,13 +13,9 @@
  */
 class SwatTextareaEditor extends SwatTextarea
 {
-	// {{{ class constants
 
 	const MODE_VISUAL = 1;
 	const MODE_SOURCE = 2;
-
-	// }}}
-	// {{{ public properties
 
 	/**
 	 * Width of the editor
@@ -121,9 +117,6 @@ class SwatTextareaEditor extends SwatTextarea
 	 */
 	public $basehref = null;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new what-you-see-is-what-you-get XHTML textarea editor
 	 *
@@ -143,9 +136,6 @@ class SwatTextareaEditor extends SwatTextarea
 			'packages/swat/javascript/swat-z-index-manager.js'
 		);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	public function display()
 	{
@@ -207,9 +197,6 @@ class SwatTextareaEditor extends SwatTextarea
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function getFocusableHtmlId()
-
 	/**
 	 * Gets the id attribute of the XHTML element displayed by this widget
 	 * that should receive focus
@@ -224,9 +211,6 @@ class SwatTextareaEditor extends SwatTextarea
 	{
 		return null;
 	}
-
-	// }}}
-	// {{{ protected function getConfig()
 
 	protected function getConfig()
 	{
@@ -270,9 +254,6 @@ class SwatTextareaEditor extends SwatTextarea
 		return $config;
 	}
 
-	// }}}
-	// {{{ protected function getConfigButtons()
-
 	protected function getConfigButtons()
 	{
 		return array(
@@ -297,9 +278,6 @@ class SwatTextareaEditor extends SwatTextarea
 			'snippet',
 		);
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	protected function getInlineJavaScript()
 	{
@@ -388,9 +366,6 @@ class SwatTextareaEditor extends SwatTextarea
 		return ob_get_clean();
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this textarea
 	 *
@@ -403,7 +378,6 @@ class SwatTextareaEditor extends SwatTextarea
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTile.php
+++ b/Swat/SwatTile.php
@@ -10,7 +10,6 @@
  */
 class SwatTile extends SwatCellRendererContainer
 {
-	// {{{ public properties
 
 	/**
 	 * Whether or not to include CSS classes from the first cell renderer
@@ -20,18 +19,12 @@ class SwatTile extends SwatCellRendererContainer
 	 */
 	public $show_renderer_classes = true;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * Messages affixed to this tile
 	 *
 	 * @var array
 	 */
 	protected $messages = array();
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this tile using a data object
@@ -48,9 +41,6 @@ class SwatTile extends SwatCellRendererContainer
 		$this->displayRenderers($data);
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this tile
 	 *
@@ -62,9 +52,6 @@ class SwatTile extends SwatCellRendererContainer
 			$renderer->init();
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this tile
 	 *
@@ -75,9 +62,6 @@ class SwatTile extends SwatCellRendererContainer
 		foreach ($this->renderers as $renderer)
 			$renderer->process();
 	}
-
-	// }}}
-	// {{{ public function getMessages()
 
 	/**
 	 * Gathers all messages from this tile
@@ -94,9 +78,6 @@ class SwatTile extends SwatCellRendererContainer
 		return $messages;
 	}
 
-	// }}}
-	// {{{ public function addMessages()
-
 	/**
 	 * Adds a message to this tile
 	 *
@@ -108,9 +89,6 @@ class SwatTile extends SwatCellRendererContainer
 	{
 		$this->messages[] = $message;
 	}
-
-	// }}}
-	// {{{ public function hasMessage()
 
 	/**
 	 * Gets whether or not this tile has any messages
@@ -131,9 +109,6 @@ class SwatTile extends SwatCellRendererContainer
 
 		return $has_message;
 	}
-
-	// }}}
-	// {{{ protected function setupRenderers()
 
 	/**
 	 * Sets properties of renderers using data from current row
@@ -156,9 +131,6 @@ class SwatTile extends SwatCellRendererContainer
 		}
 	}
 
-	// }}}
-	// {{{ protected function displayRenderers()
-
 	/**
 	 * Renders cell renderers
 	 *
@@ -173,9 +145,6 @@ class SwatTile extends SwatCellRendererContainer
 		$this->displayRenderersInternal($data);
 		$div_tag->close();
 	}
-
-	// }}}
-	// {{{ protected function displayRenderersInternal()
 
 	/**
 	 * Renders each cell renderer in this tile
@@ -215,9 +184,6 @@ class SwatTile extends SwatCellRendererContainer
 			}
 		}
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this tile
@@ -274,9 +240,6 @@ class SwatTile extends SwatCellRendererContainer
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function getBaseCSSClassNames()
-
 	/**
 	 * Gets the base CSS class names of this tile
 	 *
@@ -290,7 +253,6 @@ class SwatTile extends SwatCellRendererContainer
 		return array('swat-tile');
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTileView.php
+++ b/Swat/SwatTileView.php
@@ -14,7 +14,6 @@
  */
 class SwatTileView extends SwatView implements SwatUIParent
 {
-	// {{{ public properties
 
 	/**
 	 * Whether to show a "check all" widget
@@ -105,9 +104,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 	 */
 	public $no_records_message_type = 'text/plain';
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * The groups of this tile-view indexed by their unique identifier
 	 *
@@ -130,18 +126,12 @@ class SwatTileView extends SwatView implements SwatUIParent
 	 */
 	protected $groups = array();
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * The tile of this tile view
 	 *
 	 * @var SwatTile
 	 */
 	private $tile = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new tile view
@@ -157,9 +147,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		$this->addStyleSheet('packages/swat/styles/swat-tile-view.css');
 		$this->addJavaScript('packages/swat/javascript/swat-tile-view.js');
 	}
-
-	// }}}
-	// {{{ public function init()
 
 	/**
 	 * Initializes this tile view
@@ -183,9 +170,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this tile view
 	 *
@@ -208,9 +192,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 			$this->tile->process();
 	}
 
-	// }}}
-	// {{{ public function isExtendedCheckAllSelected()
-
 	/**
 	 * Whether or not the extended-check-all check-box was checked
 	 *
@@ -221,9 +202,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		$check_all = $this->getCompositeWidget('check_all');
 		return $check_all->isExtendedSelected();
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this tile view
@@ -280,9 +258,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
-
-	// }}}
-	// {{{ public function displayTiles()
 
 	/**
 	 * Displays the tiles of this tile view
@@ -343,9 +318,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		}
 	}
 
-	// }}}
-	// {{{ public function displayTile()
-
 	/**
 	 * Displays a simgle tile of this tile view
 	 *
@@ -357,9 +329,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 	{
 		$this->tile->display($record);
 	}
-
-	// }}}
-	// {{{ public function displayTileGroupHeaders()
 
 	/**
 	 * Displays tile group headers
@@ -374,9 +343,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 			$group->display($record);
 	}
 
-	// }}}
-	// {{{ public function displayTileGroupFooters()
-
 	/**
 	 * Displays tile group footers
 	 *
@@ -389,9 +355,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		foreach ($this->groups as $group)
 			$group->displayFooter($record, $next_record);
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child object
@@ -429,9 +392,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 				0, $child);
 		}
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -482,9 +442,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -511,9 +468,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -533,9 +487,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -552,9 +503,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 				$object->setState($states[$id]);
 	}
 
-	// }}}
-	// {{{ public function getMessages()
-
 	/**
 	 * Gathers all messages from this tile view
 	 *
@@ -568,9 +516,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 
 		return $messages;
 	}
-
-	// }}}
-	// {{{ public function hasMessage()
 
 	/**
 	 * Gets whether or not this tile view has any messages
@@ -586,9 +531,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 
 		return $has_message;
 	}
-
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this tile view
@@ -613,9 +555,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this tile view
 	 *
@@ -638,9 +577,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -679,9 +615,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		return $copy;
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets the inline JavaScript required for this tile view
 	 *
@@ -718,9 +651,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		return $javascript;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this tile view
 	 *
@@ -733,9 +663,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function showCheckAll()
 
 	/**
 	 * Whether or not a check-all widget is to be displayed for the tiles
@@ -765,9 +692,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		return $show;
 	}
 
-	// }}}
-	// {{{ protected function getCheckboxCellRenderer()
-
 	/**
 	 * Gets the first checkbox cell renderer in this tile view's tile
 	 *
@@ -789,9 +713,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		return $checkbox_cell_renderer;
 	}
 
-	// }}}
-	// {{{ protected function createCompositeWidgets()
-
 	/**
 	 * Creates the composite check-all widget used by this tile view
 	 */
@@ -803,10 +724,7 @@ class SwatTileView extends SwatView implements SwatUIParent
 		}
 	}
 
-	// }}}
-
 	// tile methods
-	// {{{ public function getTile()
 
 	/**
 	 * Gets a reference to a tile contained in the view.
@@ -817,9 +735,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 	{
 		return $this->tile;
 	}
-
-	// }}}
-	// {{{ public function setTile()
 
 	/**
 	 * Sets a tile of this tile view
@@ -836,10 +751,7 @@ class SwatTileView extends SwatView implements SwatUIParent
 		$tile->parent = $this;
 	}
 
-	// }}}
-
 	// grouping methods
-	// {{{ public function appendGroup()
 
 	/**
 	 * Appends a grouping object to this tile-view
@@ -871,9 +783,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		$group->parent = $this;
 	}
 
-	// }}}
-	// {{{ public function hasGroup()
-
 	/**
 	 * Returns true if a group with the given id exists within this tile-view
 	 *
@@ -887,9 +796,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 	{
 		return array_key_exists($id, $this->groups_by_id);
 	}
-
-	// }}}
-	// {{{ public function getGroup()
 
 	/**
 	 * Gets a group in this tile-view by the group's id
@@ -910,9 +816,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		return $this->groups_by_id[$id];
 	}
 
-	// }}}
-	// {{{ public function getGroups()
-
 	/**
 	 * Gets all groups of this tile-view as an array
 	 *
@@ -922,9 +825,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 	{
 		return $this->groups;
 	}
-
-	// }}}
-	// {{{ protected function validateGroup()
 
 	/**
 	 * Ensures a group added to this tile-view is valid for this tile-view
@@ -947,7 +847,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTileViewGroup.php
+++ b/Swat/SwatTileViewGroup.php
@@ -15,7 +15,6 @@
  */
 class SwatTileViewGroup extends SwatTile
 {
-	// {{{ public properties
 
 	/**
 	 * Unique identifier of this group
@@ -31,9 +30,6 @@ class SwatTileViewGroup extends SwatTile
 	 */
 	public $group_by = null;
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * The current value of the group_by field of the tile view for the
 	 * grouping header
@@ -45,9 +41,6 @@ class SwatTileViewGroup extends SwatTile
 	 * @var mixed
 	 */
 	private $header_current = null;
-
-	// }}}
-	// {{{ public function displayFooter()
 
 	/**
 	 * Displays the grouping footer of this tile-view group
@@ -76,9 +69,6 @@ class SwatTileViewGroup extends SwatTile
 		}
 	}
 
-	// }}}
-	// {{{ protected function displayGroupHeader()
-
 	/**
 	 * Displays the group header for this grouping tile
 	 *
@@ -106,9 +96,6 @@ class SwatTileViewGroup extends SwatTile
 
 	}
 
-	// }}}
-	// {{{ protected function displayGroupFooter()
-
 	/**
 	 * Displays the group footer for this grouping tile
 	 *
@@ -122,9 +109,6 @@ class SwatTileViewGroup extends SwatTile
 	protected function displayGroupFooter($row)
 	{
 	}
-
-	// }}}
-	// {{{ protected function displayRenderers()
 
 	/**
 	 * Displays the renderers for this tile
@@ -154,9 +138,6 @@ class SwatTileViewGroup extends SwatTile
 		}
 	}
 
-	// }}}
-	// {{{ protected function isEqual()
-
 	/**
 	 * Compares the value of the current row to the value of the current
 	 * group to see if the value has changed
@@ -177,9 +158,6 @@ class SwatTileViewGroup extends SwatTile
 		return ($group_value === $row_value);
 	}
 
-	// }}}
-	// {{{ protected function resetSubGroups()
-
 	/**
 	 * Resets grouping tiles below this one
 	 *
@@ -199,9 +177,6 @@ class SwatTileViewGroup extends SwatTile
 		}
 	}
 
-	// }}}
-	// {{{ protected function reset()
-
 	/**
 	 * Resets the current value of this grouping tile
 	 *
@@ -216,7 +191,6 @@ class SwatTileViewGroup extends SwatTile
 		$this->header_current = null;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTimeEntry.php
+++ b/Swat/SwatTimeEntry.php
@@ -10,14 +10,10 @@
  */
 class SwatTimeEntry extends SwatInputControl implements SwatState
 {
-	// {{{ constants
 
 	const HOUR   = 1;
 	const MINUTE = 2;
 	const SECOND = 4;
-
-	// }}}
-	// {{{ public properties
 
 	/**
 	 * Time of this time entry widget
@@ -102,9 +98,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 	 */
 	public $use_current_time = true;
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * Default year value used for time value
 	 *
@@ -131,9 +124,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 	 * @var integer
 	 */
 	private static $date_day = 1;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new time entry widget
@@ -169,9 +159,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 			(preg_match('/(%T|%R|%k|.*%H.*)/', $locale_format) == 0);
 	}
 
-	// }}}
-	// {{{ public function __clone()
-
 	/**
 	 * Clones the valid time range of this time entry
 	 */
@@ -180,9 +167,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 		$this->valid_range_start = clone $this->valid_range_start;
 		$this->valid_range_end = clone $this->valid_range_end;
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this time entry
@@ -262,9 +246,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 
 		$div_tag->close();
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this time entry
@@ -394,9 +375,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 		}
 	}
 
-	// }}}
-	// {{{ public function getState()
-
 	/**
 	 * Gets the current state of this time entry widget
 	 *
@@ -412,9 +390,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 			return $this->value->getDate();
 	}
 
-	// }}}
-	// {{{ public function setState()
-
 	/**
 	 * Sets the current state of this time entry widget
 	 *
@@ -426,9 +401,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 	{
 		$this->value = new SwatDate($state);
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this time entry widget
@@ -442,9 +414,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getInlineJavaScript()
 
 	/**
 	 * Gets the inline JavaScript required for this control
@@ -500,9 +469,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 		return $javascript;
 	}
 
-	// }}}
-	// {{{ protected function validateRanges()
-
 	/**
 	 * Makes sure the date the user entered is within the valid range
 	 *
@@ -527,9 +493,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 		}
 	}
 
-	// }}}
-	// {{{ protected function isStartTimeValid()
-
 	/**
 	 * Checks if the entered time is valid with respect to the valid start
 	 * time
@@ -549,9 +512,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 			$this->value, $this->valid_range_start, true) >= 0);
 	}
 
-	// }}}
-	// {{{ protected function isEndTimeValid()
-
 	/**
 	 * Checks if the entered time is valid with respect to the valid end time
 	 *
@@ -569,9 +529,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 		return (SwatDate::compare(
 			$this->value, $this->valid_range_end, true) <= 0);
 	}
-
-	// }}}
-	// {{{ protected function createCompositeWidgets()
 
 	/**
 	 * Creates the composite widgets used by this time entry
@@ -598,9 +555,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 				$this->createSecondFlydown(), 'second_flydown');
 	}
 
-	// }}}
-	// {{{ private function createHourFlydown()
-
 	/**
 	 * Creates the hour flydown for this time entry
 	 *
@@ -622,9 +576,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 		return $flydown;
 	}
 
-	// }}}
-	// {{{ private function createMinuteFlydown()
-
 	/**
 	 * Creates the minute flydown for this time entry
 	 *
@@ -640,9 +591,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 
 		return $flydown;
 	}
-
-	// }}}
-	// {{{ private function createSecondFlydown()
 
 	/**
 	 * Creates the second flydown for this time entry
@@ -660,9 +608,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 		return $flydown;
 	}
 
-	// }}}
-	// {{{ private function createAmPmFlydown()
-
 	/**
 	 * Creates the am/pm flydown for this time entry
 	 *
@@ -679,9 +624,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 
 		return $flydown;
 	}
-
-	// }}}
-	// {{{ private function getFormattedTime()
 
 	/**
 	 * Formats a time for display in error messages
@@ -717,7 +659,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 		return $time->formatLikeIntl($format);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTimeZoneEntry.php
+++ b/Swat/SwatTimeZoneEntry.php
@@ -9,7 +9,6 @@
  */
 class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 {
-	// {{{ public properties
 
 	/**
 	 * Time zone identifier
@@ -19,9 +18,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 	 * @var string
 	 */
 	public $value = null;
-
-	// }}}
-	// {{{ private properties
 
 	/**
 	 * Time zone areas available for this time zone entry widget
@@ -40,9 +36,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 	 * @var array
 	 */
 	private $regions = array();
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new time zone selector widget
@@ -73,9 +66,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 		$this->setAreas($time_zone_list);
 	}
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this time zone entry widget
 	 *
@@ -105,9 +95,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 
 		$div_tag->close();
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this time zone entry widget
@@ -146,9 +133,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 		}
 	}
 
-	// }}}
-	// {{{ public function getState()
-
 	/**
 	 * Gets the current state of this time zone entry widget
 	 *
@@ -161,9 +145,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 		return $this->value;
 	}
 
-	// }}}
-	// {{{ public function setState()
-
 	/**
 	 * Sets the current state of this time zone entry widget
 	 *
@@ -175,9 +156,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 	{
 		$this->value = $state;
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this time zone entry
@@ -192,9 +170,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 		$classes = array_merge($classes, parent::getCSSClassNames());
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function createCompositeWidgets()
 
 	/**
 	 * Creates all internal widgets required for this time zone entry
@@ -214,9 +189,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 		$regions_flydown->width = '15em';
 		$this->addCompositeWidget($regions_flydown, 'regions_flydown');
 	}
-
-	// }}}
-	// {{{ private function parseAreaWhitelist()
 
 	/**
 	 * Parses a whitelist of valid areas
@@ -253,9 +225,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 		return $areas;
 	}
 
-	// }}}
-	// {{{ private function setAreas()
-
 	/**
 	 * Sets areas
 	 *
@@ -280,9 +249,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 			$this->setRegions($regions, $area);
 		}
 	}
-
-	// }}}
-	// {{{ private function setRegions()
 
 	/**
 	 * Builds the internal array of {@link SwatOption} objects for the
@@ -314,9 +280,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 		}
 	}
 
-	// }}}
-	// {{{ private function getArea()
-
 	/**
 	 * Gets an area from a time zone identifier
 	 *
@@ -340,9 +303,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 		return $area;
 	}
 
-	// }}}
-	// {{{ private function getRegion()
-
 	/**
 	 * Gets a region from a time zone identifier
 	 *
@@ -365,9 +325,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 		return $region;
 	}
 
-	// }}}
-	// {{{ private function getRegionTitle()
-
 	/**
 	 * Gets a formatted region title from the region part of a time zone
 	 * identifier
@@ -389,7 +346,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 		return $title;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTitleable.php
+++ b/Swat/SwatTitleable.php
@@ -10,7 +10,6 @@
  */
 interface SwatTitleable
 {
-	// {{{ public function getTitle()
 
 	/**
 	 * Gets the title of this object
@@ -18,9 +17,6 @@ interface SwatTitleable
 	 * @return string the title of this object.
 	 */
 	public function getTitle();
-
-	// }}}
-	// {{{ public function getTitleContentType()
 
 	/**
 	 * Gets the content-type of the title of this object
@@ -31,7 +27,6 @@ interface SwatTitleable
 	 */
 	public function getTitleContentType();
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatToolLink.php
+++ b/Swat/SwatToolLink.php
@@ -9,7 +9,6 @@
  */
 class SwatToolLink extends SwatControl
 {
-	// {{{ public properties
 
 	/**
 	 * The href attribute in the XHTML anchor tag
@@ -93,18 +92,12 @@ class SwatToolLink extends SwatControl
 	 */
 	public $target = null;
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * A CSS class set by the stock_id of this tool link
 	 *
 	 * @var string
 	 */
 	protected $stock_class = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new toollink
@@ -120,9 +113,6 @@ class SwatToolLink extends SwatControl
 		$this->addStyleSheet('packages/swat/styles/swat-tool-link.css');
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this widget
 	 *
@@ -137,9 +127,6 @@ class SwatToolLink extends SwatControl
 		if ($this->stock_id !== null)
 			$this->setFromStock($this->stock_id, false);
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this tool link
@@ -177,9 +164,6 @@ class SwatToolLink extends SwatControl
 
 		$tag->close();
 	}
-
-	// }}}
-	// {{{ public function setFromStock()
 
 	/**
 	 * Sets the values of this tool link to a stock type
@@ -273,9 +257,6 @@ class SwatToolLink extends SwatControl
 		$this->stock_class = $class;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this tool link
 	 *
@@ -296,9 +277,6 @@ class SwatToolLink extends SwatControl
 
 		return $classes;
 	}
-
-	// }}}
-	// {{{ protected function getSensitiveTag()
 
 	/**
 	 * Gets the tag used to display this tool link when it is sensitive
@@ -332,9 +310,6 @@ class SwatToolLink extends SwatControl
 		return $tag;
 	}
 
-	// }}}
-	// {{{ protected function getInsensitiveTag()
-
 	/**
 	 * Gets the tag used to display this tool link when it is not sensitive
 	 *
@@ -354,7 +329,6 @@ class SwatToolLink extends SwatControl
 		return $tag;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatToolbar.php
+++ b/Swat/SwatToolbar.php
@@ -9,7 +9,6 @@
  */
 class SwatToolbar extends SwatDisplayableContainer
 {
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new toolbar
@@ -24,9 +23,6 @@ class SwatToolbar extends SwatDisplayableContainer
 
 		$this->addStyleSheet('packages/swat/styles/swat-toolbar.css');
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this toolbar as an unordered list with each sub-item
@@ -48,9 +44,6 @@ class SwatToolbar extends SwatDisplayableContainer
 		$toolbar_ul->close();
 	}
 
-	// }}}
-	// {{{ public function setToolLinkValues()
-
 	/**
 	 * Sets the value of all {@link SwatToolLink} objects within this toolbar
 	 *
@@ -64,9 +57,6 @@ class SwatToolbar extends SwatDisplayableContainer
 		foreach ($this->getToolLinks() as $tool)
 			$tool->value = $value;
 	}
-
-	// }}}
-	// {{{ public function getToolLinks()
 
 	/**
 	 * Gets the tool links of this toolbar
@@ -86,9 +76,6 @@ class SwatToolbar extends SwatDisplayableContainer
 		return $tools;
 	}
 
-	// }}}
-	// {{{ protected function displayChildren()
-
 	/**
 	 * Displays the child widgets of this container
 	 */
@@ -102,9 +89,6 @@ class SwatToolbar extends SwatDisplayableContainer
 				echo '<li>', $content, '</li>';
 		}
 	}
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS classes that are applied to this tool bar
@@ -126,7 +110,6 @@ class SwatToolbar extends SwatDisplayableContainer
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTreeFlydown.php
+++ b/Swat/SwatTreeFlydown.php
@@ -10,7 +10,6 @@
  */
 class SwatTreeFlydown extends SwatFlydown
 {
-	// {{{ public properties
 
 	/**
 	 * An array containing the branch of the selected node formed by node
@@ -21,9 +20,6 @@ class SwatTreeFlydown extends SwatFlydown
 	 * @var array
 	 */
 	public $path = array();
-
-	// }}}
-	// {{{ protected properties
 
 	/**
 	 * A tree collection of {@link SwatTreeFlydownNode} objects for this
@@ -37,9 +33,6 @@ class SwatTreeFlydown extends SwatFlydown
 	 */
 	protected $tree = null;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new tree flydown control
 	 *
@@ -52,9 +45,6 @@ class SwatTreeFlydown extends SwatFlydown
 		parent::__construct($id);
 		$this->setTree(new SwatTreeFlydownNode(null, 'root'));
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this tree flydown
@@ -80,9 +70,6 @@ class SwatTreeFlydown extends SwatFlydown
 		$this->value = $actual_value;
 	}
 
-	// }}}
-	// {{{ protected function &getOptions()
-
 	/**
 	 * Gets this flydown's tree as a flat array used in the
 	 * {@link SwatFlydown::display()} method
@@ -99,9 +86,6 @@ class SwatTreeFlydown extends SwatFlydown
 
 		return $options;
 	}
-
-	// }}}
-	// {{{ private function flattenTree()
 
 	/**
 	 * Flattens this flydown's tree into an array of flydown options
@@ -137,9 +121,6 @@ class SwatTreeFlydown extends SwatFlydown
 			$this->flattenTree($options, $child_node, $level + 1, $path);
 	}
 
-	// }}}
-	// {{{ public function setTree()
-
 	/**
 	 * Sets the tree to use for display
 	 *
@@ -158,9 +139,6 @@ class SwatTreeFlydown extends SwatFlydown
 		$this->tree = $tree;
 	}
 
-	// }}}
-	// {{{ public function getTree()
-
 	/**
 	 * Gets the tree collection of {@link SwatTreeFlydownNode} objects for this
 	 * tree flydown
@@ -171,9 +149,6 @@ class SwatTreeFlydown extends SwatFlydown
 	{
 		return $this->tree;
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this tree flydown
@@ -194,7 +169,6 @@ class SwatTreeFlydown extends SwatFlydown
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTreeFlydownNode.php
+++ b/Swat/SwatTreeFlydownNode.php
@@ -11,7 +11,6 @@
  */
 class SwatTreeFlydownNode extends SwatTreeNode
 {
-	// {{{ protected properties
 
 	/**
 	 * The flydown option for this node
@@ -19,9 +18,6 @@ class SwatTreeFlydownNode extends SwatTreeNode
 	 * @var SwatOption
 	 */
 	protected $flydown_option;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new tree flydown node
@@ -59,9 +55,6 @@ class SwatTreeFlydownNode extends SwatTreeNode
 			$this->flydown_option = new SwatOption($param1, $param2);
 	}
 
-	// }}}
-	// {{{ public function getOption()
-
 	/**
 	 * Gets the option for this node
 	 *
@@ -71,9 +64,6 @@ class SwatTreeFlydownNode extends SwatTreeNode
 	{
 		return $this->flydown_option;
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child node to this node
@@ -90,9 +80,6 @@ class SwatTreeFlydownNode extends SwatTreeNode
 		parent::addChild($child);
 	}
 
-	// }}}
-	// {{{ public staticfunction convertFromDataTree()
-
 	public static function convertFromDataTree(SwatDataTreeNode $tree)
 	{
 		$new_tree = new SwatTreeFlydownNode($tree->value, $tree->title);
@@ -103,7 +90,6 @@ class SwatTreeFlydownNode extends SwatTreeNode
 		return $new_tree;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatTreeNode.php
+++ b/Swat/SwatTreeNode.php
@@ -12,7 +12,6 @@
 abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 	Countable
 {
-	// {{{ protected properties
 
 	/**
 	 * An array of children tree nodes
@@ -22,9 +21,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 	 * @var array
 	 */
 	protected $children = array();
-
-	// }}}
-	// {{{ private properties
 
 	/**
 	 * The parent tree node of this tree node
@@ -43,9 +39,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 	 */
 	private $index = 0;
 
-	// }}}
-	// {{{ public function addChild()
-
 	/**
 	 * Adds a child node to this node
 	 *
@@ -60,9 +53,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 		$this->children[] = $child;
 	}
 
-	// }}}
-	// {{{ public function addTree()
-
 	/**
 	 * Adds a full tree structure to this node
 	 *
@@ -76,9 +66,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 		foreach ($tree->getChildren() as $child)
 			$this->addChild($child);
 	}
-
-	// }}}
-	// {{{ public function getPath()
 
 	/**
 	 * Gets the path to this node
@@ -105,9 +92,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 		return $path;
 	}
 
-	// }}}
-	// {{{ public function getParent()
-
 	/**
 	 * Gets the parent node of this node
 	 *
@@ -117,9 +101,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 	{
 		return $this->parent;
 	}
-
-	// }}}
-	// {{{ public function getChildren()
 
 	/**
 	 * Gets this node's children
@@ -132,9 +113,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 	{
 		return $this->children;
 	}
-
-	// }}}
-	// {{{ public function hasChildren()
 
 	/**
 	 * Whether or not this tree node has children
@@ -149,9 +127,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 		return (count($this->children) > 0);
 	}
 
-	// }}}
-	// {{{ public function getIndex()
-
 	/**
 	 * Gets this node's index
 	 *
@@ -161,9 +136,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 	{
 		return $this->index;
 	}
-
-	// }}}
-	// {{{ public function current()
 
 	/**
 	 * Gets the current child node in this node
@@ -179,9 +151,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 		return current($this->children);
 	}
 
-	// }}}
-	// {{{ public function key()
-
 	/**
 	 * Gets the key of the current child node in this node
 	 *
@@ -193,9 +162,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 	{
 		return key($this->children);
 	}
-
-	// }}}
-	// {{{ public function next()
 
 	/**
 	 * Gets the next child node in this node and moves the internal array
@@ -212,9 +178,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 		return next($this->children);
 	}
 
-	// }}}
-	// {{{ public function rewind()
-
 	/**
 	 * Sets the internal pointer in the child nodes array back to the
 	 * beginning
@@ -230,9 +193,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 		return reset($this->children);
 	}
 
-	// }}}
-	// {{{ public function valid()
-
 	/**
 	 * Whether the current child node in this node is valid
 	 *
@@ -245,9 +205,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 	{
 		return ($this->current() !== false);
 	}
-
-	// }}}
-	// {{{ public function count()
 
 	/**
 	 * Gets the number of nodes in this tree or subtree
@@ -265,7 +222,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator,
 		return $count;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatUI.php
+++ b/Swat/SwatUI.php
@@ -9,7 +9,6 @@
  */
 class SwatUI extends SwatObject
 {
-	// {{{ private properties
 
 	/**
 	 * An associative array of class-prefix-to-filename-mappings
@@ -73,9 +72,6 @@ class SwatUI extends SwatObject
 	 */
 	private static $validate_mode = true;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new UI
 	 *
@@ -96,9 +92,6 @@ class SwatUI extends SwatObject
 			$this->root = new SwatContainer();
 	}
 
-	// }}}
-	// {{{ public static function mapClassPrefixToPath()
-
 	/**
 	 * Maps a class prefix to a path for filename lookup in this UI
 	 *
@@ -114,9 +107,6 @@ class SwatUI extends SwatObject
 	{
 		self::$class_map[$class_prefix] = $path;
 	}
-
-	// }}}
-	// {{{ public static function setValidateMode()
 
 	/**
 	 * Sets the default validation mode used by {@link SwatUI::loadFromXML()}
@@ -144,9 +134,6 @@ class SwatUI extends SwatObject
 	{
 		self::$validate_mode = (boolean)$mode;
 	}
-
-	// }}}
-	// {{{ public function loadFromXML()
 
 	/**
 	 * Loads a UI tree from an XML file
@@ -262,9 +249,6 @@ class SwatUI extends SwatObject
 		$this->parseUI($document->documentElement, $container);
 	}
 
-	// }}}
-	// {{{ public function hasWidget()
-
 	/**
 	 * Checks whether this UI tree contains a specified widget
 	 *
@@ -277,9 +261,6 @@ class SwatUI extends SwatObject
 	{
 		return (array_key_exists($id, $this->widgets));
 	}
-
-	// }}}
-	// {{{ public function getWidget()
 
 	/**
 	 * Retrieves a widget from the internal widget list
@@ -302,9 +283,6 @@ class SwatUI extends SwatObject
 				0, $id);
 	}
 
-	// }}}
-	// {{{ public function getRoot()
-
 	/**
 	 * Retrieves the topmost widget
 	 *
@@ -318,9 +296,6 @@ class SwatUI extends SwatObject
 		return $this->root;
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this interface
 	 *
@@ -330,9 +305,6 @@ class SwatUI extends SwatObject
 	{
 		$this->root->init();
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this interface
@@ -344,9 +316,6 @@ class SwatUI extends SwatObject
 		$this->root->process();
 	}
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this interface
 	 *
@@ -356,9 +325,6 @@ class SwatUI extends SwatObject
 	{
 		$this->root->display();
 	}
-
-	// }}}
-	// {{{ public function displayTidy()
 
 	/**
 	 * Displays this interface with tidy XHTML
@@ -381,9 +347,6 @@ class SwatUI extends SwatObject
 		$tidy = str_replace("\n\n", "\n", $tidy);
 		echo $tidy;
 	}
-
-	// }}}
-	// {{{ public function setTranslationCallback()
 
 	/**
 	 * Sets the translation callback function for this UI
@@ -409,9 +372,6 @@ class SwatUI extends SwatObject
 				'Cannot set translation callback to an uncallable callback.',
 				0, $callback);
 	}
-
-	// }}}
-	// {{{ private function parseUI()
 
 	/**
 	 * Recursivly parses an XML node into a widget tree
@@ -462,9 +422,6 @@ class SwatUI extends SwatObject
 
 		array_pop($this->stack);
 	}
-
-	// }}}
-	// {{{ private function checkParsedObject()
 
 	/**
 	 * Does some error checking on a parsed object
@@ -520,9 +477,6 @@ class SwatUI extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ private function attachToParent()
-
 	/**
 	 * Attaches a widget to a parent widget in the widget tree
 	 *
@@ -542,9 +496,6 @@ class SwatUI extends SwatObject
 				'implement SwatUIParent.', 0, $parent);
 		}
 	}
-
-	// }}}
-	// {{{ private function parseObject()
 
 	/**
 	 * Parses an XML object or widget element node into a PHP object
@@ -582,9 +533,6 @@ class SwatUI extends SwatObject
 
 		return $object;
 	}
-
-	// }}}
-	// {{{ private function parseProperty()
 
 	/**
 	 * Parses a single XML property node and applies it to an object
@@ -660,9 +608,6 @@ class SwatUI extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ private function parseValue()
-
 	/**
 	 * Parses the value of a property
 	 *
@@ -722,9 +667,6 @@ class SwatUI extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ private function parseMapping()
-
 	/**
 	 * Handle a 'data' type property value by parsing it into a mapping object
 	 *
@@ -762,9 +704,6 @@ class SwatUI extends SwatObject
 		return $mapping;
 	}
 
-	// }}}
-	// {{{ private function translateValue()
-
 	/**
 	 * Translates a property value if possible
 	 *
@@ -785,9 +724,6 @@ class SwatUI extends SwatObject
 
 		return $value;
 	}
-
-	// }}}
-	// {{{ private function parseConstantExpression()
 
 	/**
 	 * Evaluate a constant property value
@@ -940,7 +876,6 @@ class SwatUI extends SwatObject
 		return array_pop($eval_stack);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatUIObject.php
+++ b/Swat/SwatUIObject.php
@@ -12,7 +12,6 @@
  */
 abstract class SwatUIObject extends SwatObject
 {
-	// {{{ public properties
 
 	/**
 	 * The object which contains this object
@@ -43,9 +42,6 @@ abstract class SwatUIObject extends SwatObject
 	 */
 	public $classes = array();
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * A set of HTML head entries needed by this user-interface element
 	 *
@@ -56,16 +52,10 @@ abstract class SwatUIObject extends SwatObject
 	 */
 	protected $html_head_entry_set;
 
-	// }}}
-	// {{{ public function __construct()
-
 	public function __construct()
 	{
 		$this->html_head_entry_set = new SwatHtmlHeadEntrySet();
 	}
-
-	// }}}
-	// {{{ public function addStyleSheet()
 
 	/**
 	 * Adds a stylesheet to the list of stylesheets needed by this
@@ -88,9 +78,6 @@ abstract class SwatUIObject extends SwatObject
 		);
 	}
 
-	// }}}
-	// {{{ public function addJavaScript()
-
 	/**
 	 * Adds a JavaScript include to the list of JavaScript includes needed
 	 * by this user-interface element
@@ -112,9 +99,6 @@ abstract class SwatUIObject extends SwatObject
 		);
 	}
 
-	// }}}
-	// {{{ public function addComment()
-
 	/**
 	 * Adds a comment to the list of HTML head entries needed by this user-
 	 * interface element
@@ -134,16 +118,10 @@ abstract class SwatUIObject extends SwatObject
 		);
 	}
 
-	// }}}
-	// {{{ public function addInlineScript()
-
 	public function addInlineScript($script)
 	{
 		$this->inline_scripts->add($script);
 	}
-
-	// }}}
-	// {{{ public function getFirstAncestor()
 
 	/**
 	 * Gets the first ancestor object of a specific class
@@ -174,9 +152,6 @@ abstract class SwatUIObject extends SwatObject
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this UI object
 	 *
@@ -197,9 +172,6 @@ abstract class SwatUIObject extends SwatObject
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that MAY needed by this UI object
 	 *
@@ -213,9 +185,6 @@ abstract class SwatUIObject extends SwatObject
 	{
 		return new SwatHtmlHeadEntrySet($this->html_head_entry_set);
 	}
-
-	// }}}
-	// {{{ public function isVisible()
 
 	/**
 	 * Gets whether or not this UI object is visible
@@ -235,9 +204,6 @@ abstract class SwatUIObject extends SwatObject
 			return $this->visible;
 	}
 
-	// }}}
-	// {{{ public function __toString()
-
 	/**
 	 * Gets this object as a string
 	 *
@@ -255,9 +221,6 @@ abstract class SwatUIObject extends SwatObject
 		// set parent back again
 		$this->parent = $parent;
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -284,9 +247,6 @@ abstract class SwatUIObject extends SwatObject
 		return $copy;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this user-interface
 	 * object
@@ -304,9 +264,6 @@ abstract class SwatUIObject extends SwatObject
 		return $this->classes;
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
-
 	/**
 	 * Gets inline JavaScript used by this user-interface object
 	 *
@@ -316,9 +273,6 @@ abstract class SwatUIObject extends SwatObject
 	{
 		return '';
 	}
-
-	// }}}
-	// {{{ protected final function getCSSClassString()
 
 	/**
 	 * Gets the string representation of this user-interface object's list of
@@ -342,9 +296,6 @@ abstract class SwatUIObject extends SwatObject
 		return $class_string;
 	}
 
-	// }}}
-	// {{{ protected final function getUniqueId()
-
 	/**
 	 * Generates a unique id for this UI object
 	 *
@@ -366,7 +317,6 @@ abstract class SwatUIObject extends SwatObject
 		return get_class($this).$counter;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatUIParent.php
+++ b/Swat/SwatUIParent.php
@@ -9,7 +9,6 @@
  */
 interface SwatUIParent
 {
-	// {{{ public function addChild()
 
 	/**
 	 * Adds a child object to this parent object
@@ -21,9 +20,6 @@ interface SwatUIParent
 	 * @param SwatObject $child the child object to add to this parent object.
 	 */
 	public function addChild(SwatObject $child);
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -42,9 +38,6 @@ interface SwatUIParent
 	 */
 	public function getDescendants($class_name = null);
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -61,9 +54,6 @@ interface SwatUIParent
 	 */
 	public function getFirstDescendant($class_name);
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -74,9 +64,6 @@ interface SwatUIParent
 	 *                array keys.
 	 */
 	public function getDescendantStates();
-
-	// }}}
-	// {{{ public function setDescendantStates()
 
 	/**
 	 * Sets descendant states
@@ -89,7 +76,6 @@ interface SwatUIParent
 	 */
 	public function setDescendantStates(array $states);
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatUriEntry.php
+++ b/Swat/SwatUriEntry.php
@@ -14,7 +14,6 @@
  */
 class SwatUriEntry extends SwatEntry
 {
-	// {{{ public properties
 
 	/**
 	 * Whether or not to require the scheme for the URI
@@ -39,9 +38,6 @@ class SwatUriEntry extends SwatEntry
 	 * @var array
 	 */
 	public $valid_schemes = array('http', 'https', 'ftp');
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this URI entry
@@ -77,9 +73,6 @@ class SwatUriEntry extends SwatEntry
 			}
 		}
 	}
-
-	// }}}
-	// {{{ protected function validateUri()
 
 	/**
 	 * Validates a URI
@@ -117,9 +110,6 @@ class SwatUriEntry extends SwatEntry
 		return (preg_match($regexp, $value) === 1);
 	}
 
-	// }}}
-	// {{{ protected function getValidationMessage()
-
 	/**
 	 * Gets a validation message for this entry
 	 *
@@ -152,9 +142,6 @@ class SwatUriEntry extends SwatEntry
 		return $message;
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
-
 	/**
 	 * Gets the array of CSS classes that are applied to this entry
 	 *
@@ -168,7 +155,6 @@ class SwatUriEntry extends SwatEntry
 		return $classes;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatView.php
+++ b/Swat/SwatView.php
@@ -9,7 +9,6 @@
  */
 abstract class SwatView extends SwatControl
 {
-	// {{{ public properties
 
 	/**
 	 * A data structure that holds the data to display in this view
@@ -33,9 +32,6 @@ abstract class SwatView extends SwatControl
 	 */
 	public $checked_items = array();
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * The selections of this view
 	 *
@@ -56,9 +52,6 @@ abstract class SwatView extends SwatControl
 	 */
 	protected $selectors = array();
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new recordset view
 	 *
@@ -75,9 +68,6 @@ abstract class SwatView extends SwatControl
 		$this->addJavaScript('packages/swat/javascript/swat-view.js');
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this view
 	 */
@@ -91,9 +81,6 @@ abstract class SwatView extends SwatControl
 			if ($selector->getFirstAncestor('SwatView') === $this)
 				$this->addSelector($selector);
 	}
-
-	// }}}
-	// {{{ public function getSelection()
 
 	/**
 	 * Gets a selection of this view
@@ -151,9 +138,6 @@ abstract class SwatView extends SwatControl
 
 		return $this->selections[$selector->getId()];
 	}
-
-	// }}}
-	// {{{ public function setSelection()
 
 	/**
 	 * Sets a selection of this view
@@ -213,9 +197,6 @@ abstract class SwatView extends SwatControl
 		$this->selections[$selector->getId()] = $selection;
 	}
 
-	// }}}
-	// {{{ protected final function addSelector()
-
 	/**
 	 * This method should be called internally by the
 	 * {@link SwatView::init() method on all descendant UI-objects that are
@@ -227,7 +208,6 @@ abstract class SwatView extends SwatControl
 		$this->selectors[$selector->getId()] = $selector;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatViewSelection.php
+++ b/Swat/SwatViewSelection.php
@@ -29,7 +29,6 @@
  */
 class SwatViewSelection extends SwatObject implements Countable, Iterator
 {
-	// {{{ private properties
 
 	/**
 	 * The selected items of this selection
@@ -47,9 +46,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
 	 */
 	private $current_index = 0;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new selection object
 	 *
@@ -62,9 +58,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
 		$this->selected_items = array_values($selected_items);
 	}
 
-	// }}}
-	// {{{ public function current()
-
 	/**
 	 * Returns the current selected item
 	 *
@@ -74,9 +67,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
 	{
 		return $this->selected_items[$this->current_index];
 	}
-
-	// }}}
-	// {{{ public function key()
 
 	/**
 	 * Returns the key of the current selected item
@@ -88,9 +78,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
 		return $this->current_index;
 	}
 
-	// }}}
-	// {{{ public function next()
-
 	/**
 	 * Moves forward to the next selected item
 	 */
@@ -98,9 +85,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
 	{
 		$this->current_index++;
 	}
-
-	// }}}
-	// {{{ public function prev()
 
 	/**
 	 * Moves forward to the previous selected item
@@ -110,9 +94,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
 		$this->current_index--;
 	}
 
-	// }}}
-	// {{{ public function rewind()
-
 	/**
 	 * Rewinds this iterator to the first selected item
 	 */
@@ -120,9 +101,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
 	{
 		$this->current_index = 0;
 	}
-
-	// }}}
-	// {{{ public function valid()
 
 	/**
 	 * Checks is there is a current selected item after calls to rewind() and
@@ -136,9 +114,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
 		return isset($this->selected_items[$this->current_index]);
 	}
 
-	// }}}
-	// {{{ public funciton count()
-
 	/**
 	 * Gets the number of items in this selection
 	 *
@@ -150,9 +125,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
 	{
 		return count($this->selected_items);
 	}
-
-	// }}}
-	// {{{ public function contains()
 
 	/**
 	 * Checks whether or not this selection contains an item
@@ -167,7 +139,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
 		return in_array($item, $this->selected_items);
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatViewSelector.php
+++ b/Swat/SwatViewSelector.php
@@ -11,7 +11,6 @@
  */
 interface SwatViewSelector
 {
-	// {{{ public function getId()
 
 	/**
 	 * Gets the identifier of this selector
@@ -20,7 +19,6 @@ interface SwatViewSelector
 	 */
 	public function getId();
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatWidget.php
+++ b/Swat/SwatWidget.php
@@ -33,7 +33,6 @@
  */
 abstract class SwatWidget extends SwatUIObject
 {
-	// {{{ public properties
 
 	/**
 	 * A non-visible unique id for this widget, or null
@@ -68,9 +67,6 @@ abstract class SwatWidget extends SwatUIObject
 	 */
 	public $stylesheet = null;
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * Composite widgets of this widget
 	 *
@@ -89,9 +85,6 @@ abstract class SwatWidget extends SwatUIObject
 	 * @var boolean
 	 */
 	private $composite_widgets_created = false;
-
-	// }}}
-	// {{{ protected properties
 
 	/**
 	 * Messages affixed to this widget
@@ -139,9 +132,6 @@ abstract class SwatWidget extends SwatUIObject
 	 */
 	protected $displayed = false;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new widget
 	 *
@@ -154,9 +144,6 @@ abstract class SwatWidget extends SwatUIObject
 		$this->id = $id;
 		$this->addStylesheet('packages/swat/styles/swat.css');
 	}
-
-	// }}}
-	// {{{ public function init()
 
 	/**
 	 * Initializes this widget
@@ -188,9 +175,6 @@ abstract class SwatWidget extends SwatUIObject
 		$this->initialized = true;
 	}
 
-	// }}}
-	// {{{ public function process()
-
 	/**
 	 * Processes this widget
 	 *
@@ -213,9 +197,6 @@ abstract class SwatWidget extends SwatUIObject
 		$this->processed = true;
 	}
 
-	// }}}
-	// {{{ public function display()
-
 	/**
 	 * Displays this widget
 	 *
@@ -233,9 +214,6 @@ abstract class SwatWidget extends SwatUIObject
 		$this->displayed = true;
 	}
 
-	// }}}
-	// {{{ public function displayHtmlHeadEntries()
-
 	/**
 	 * Displays the HTML head entries for this widget
 	 *
@@ -247,9 +225,6 @@ abstract class SwatWidget extends SwatUIObject
 		$set = $this->getHtmlHeadEntrySet();
 		$set->display();
 	}
-
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this widget
@@ -275,9 +250,6 @@ abstract class SwatWidget extends SwatUIObject
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this widget
 	 *
@@ -295,9 +267,6 @@ abstract class SwatWidget extends SwatUIObject
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function addMessage()
-
 	/**
 	 * Adds a message to this widget
 	 *
@@ -310,9 +279,6 @@ abstract class SwatWidget extends SwatUIObject
 	{
 		$this->messages[] = $message;
 	}
-
-	// }}}
-	// {{{ public function getMessages()
 
 	/**
 	 * Gets all messages
@@ -332,9 +298,6 @@ abstract class SwatWidget extends SwatUIObject
 
 		return $messages;
 	}
-
-	// }}}
-	// {{{ public function hasMessage()
 
 	/**
 	 * Checks for the presence of messages
@@ -358,9 +321,6 @@ abstract class SwatWidget extends SwatUIObject
 		return $has_message;
 	}
 
-	// }}}
-	// {{{ public function isSensitive()
-
 	/**
 	 * Determines the sensitivity of this widget.
 	 *
@@ -379,9 +339,6 @@ abstract class SwatWidget extends SwatUIObject
 			return $this->sensitive;
 	}
 
-	// }}}
-	// {{{ public function isInitialized()
-
 	/**
 	 * Whether or not this widget is initialized
 	 *
@@ -391,9 +348,6 @@ abstract class SwatWidget extends SwatUIObject
 	{
 		return $this->initialized;
 	}
-
-	// }}}
-	// {{{ public function isProcessed()
 
 	/**
 	 * Whether or not this widget is processed
@@ -405,9 +359,6 @@ abstract class SwatWidget extends SwatUIObject
 		return $this->processed;
 	}
 
-	// }}}
-	// {{{ public function isDisplayed()
-
 	/**
 	 * Whether or not this widget is displayed
 	 *
@@ -417,9 +368,6 @@ abstract class SwatWidget extends SwatUIObject
 	{
 		return $this->displayed;
 	}
-
-	// }}}
-	// {{{ public function getFocusableHtmlId()
 
 	/**
 	 * Gets the id attribute of the XHTML element displayed by this widget
@@ -442,9 +390,6 @@ abstract class SwatWidget extends SwatUIObject
 	{
 		return null;
 	}
-
-	// }}}
-	// {{{ public function replaceWithContainer()
 
 	/**
 	 * Replace this widget with a new container
@@ -473,9 +418,6 @@ abstract class SwatWidget extends SwatUIObject
 
 		return $container;
 	}
-
-	// }}}
-	// {{{ public function copy()
 
 	/**
 	 * Performs a deep copy of the UI tree starting with this UI object
@@ -507,16 +449,10 @@ abstract class SwatWidget extends SwatUIObject
 		return $copy;
 	}
 
-	// }}}
-	// {{{ abstract public function printWidgetTree()
-
 	/**
 	 * @todo document me
 	 */
 	abstract public function printWidgetTree();
-
-	// }}}
-	// {{{ protected function getCSSClassNames()
 
 	/**
 	 * Gets the array of CSS  classes that are applied  to this widget
@@ -535,9 +471,6 @@ abstract class SwatWidget extends SwatUIObject
 		return $classes;
 	}
 
-	// }}}
-	// {{{ protected function createCompositeWidgets()
-
 	/**
 	 * Creates and adds composite widgets of this widget
 	 *
@@ -547,9 +480,6 @@ abstract class SwatWidget extends SwatUIObject
 	protected function createCompositeWidgets()
 	{
 	}
-
-	// }}}
-	// {{{ protected final function addCompositeWidget()
 
 	/**
 	 * Adds a composite a widget to this widget
@@ -582,9 +512,6 @@ abstract class SwatWidget extends SwatUIObject
 		$widget->parent = $this;
 	}
 
-	// }}}
-	// {{{ protected final function getCompositeWidget()
-
 	/**
 	 * Gets a composite widget of this widget by the composite widget's key
 	 *
@@ -611,9 +538,6 @@ abstract class SwatWidget extends SwatUIObject
 
 		return $this->composite_widgets[$key];
 	}
-
-	// }}}
-	// {{{ protected final function getCompositeWidgets()
 
 	/**
 	 * Gets all composite widgets added to this widget
@@ -647,9 +571,6 @@ abstract class SwatWidget extends SwatUIObject
 		return $out;
 	}
 
-	// }}}
-	// {{{ protected final function confirmCompositeWidgets()
-
 	/**
 	 * Confirms composite widgets have been created
 	 *
@@ -670,7 +591,6 @@ abstract class SwatWidget extends SwatUIObject
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatWidgetCellRenderer.php
+++ b/Swat/SwatWidgetCellRenderer.php
@@ -9,7 +9,6 @@
 class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 	SwatTitleable
 {
-	// {{{ public properties
 
 	/**
 	 * Identifier of this widget cell renderer
@@ -26,9 +25,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 	 * If null, no replicating is done and the prototype widget is used.
 	 */
 	public $replicator_id = null;
-
-	// }}}
-	// {{{ private properties
 
 	/**
 	 * A reference to the prototype widget for this cell renderer
@@ -63,9 +59,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 	 */
 	private $using_null_replication = false;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new radio button cell renderer
 	 */
@@ -78,9 +71,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		// auto-generate an id to use if no id is set
 		$this->id = $this->getUniqueId();
 	}
-
-	// }}}
-	// {{{ public function addChild()
 
 	/**
 	 * Fulfills SwatUIParent::addChild()
@@ -96,9 +86,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 				'Can only add one widget to a widget cell renderer');
 		}
 	}
-
-	// }}}
-	// {{{ public function getPropertyNameToMap()
 
 	public function getPropertyNameToMap(SwatUIObject $object, $name)
 	{
@@ -124,9 +111,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		return $mangled_name;
 	}
 
-	// }}}
-	// {{{ public function init()
-
 	/**
 	 * Initializes this cell renderer
 	 *
@@ -151,9 +135,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		if ($replicators === null)
 			$this->prototype_widget->init();
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 *
@@ -182,9 +163,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 			}
 		}
 	}
-
-	// }}}
-	// {{{ public function render()
 
 	/**
 	 *
@@ -245,9 +223,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		}
 	}
 
-	// }}}
-	// {{{ public function setPrototypeWidget()
-
 	/**
 	 *
 	 * @param SwatWidget $widget
@@ -258,9 +233,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		$widget->parent = $this;
 	}
 
-	// }}}
-	// {{{ public function getPrototypeWidget()
-
 	/**
 	 * Gets the prototype widget of this widget cell renderer
 	 *
@@ -270,9 +242,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 	{
 		return $this->prototype_widget;
 	}
-
-	// }}}
-	// {{{ public function getWidget()
 
 	/**
 	 * Retrieves a reference to a replicated widget
@@ -300,9 +269,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 
 		return $widget;
 	}
-
-	// }}}
-	// {{{ public function getWidgets()
 
 	/**
 	 * Gets an array of replicated widgets indexed by the replicator_id
@@ -350,9 +316,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		return $widgets;
 	}
 
-	// }}}
-	// {{{ public function getClonedWidgets()
-
 	/**
 	 * Gets an array of cloned widgets indexed by the replicator_id
 	 *
@@ -386,9 +349,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		return $clones;
 	}
 
-	// }}}
-	// {{{ public function getDataSpecificCSSClassNames()
-
 	/**
 	 * Gets the data specific CSS class names for this widget cell renderer
 	 *
@@ -409,9 +369,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 
 		return $classes;
 	}
-
-	// }}}
-	// {{{ public function getMessages()
 
 	/**
 	 * Gathers all messages from the widget of this cell renderer for the given
@@ -437,9 +394,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 
 		return $messages;
 	}
-
-	// }}}
-	// {{{ public function hasMessage()
 
 	/**
 	 * Gets whether or not this widget cell renderer has messages
@@ -468,9 +422,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		return $has_message;
 	}
 
-	// }}}
-	// {{{ public function getTitle()
-
 	/**
 	 * Gets the title of this widget cell renderer
 	 *
@@ -489,9 +440,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		return $title;
 	}
 
-	// }}}
-	// {{{ public function getTitleContentType()
-
 	/**
 	 * Gets the title content-type of this widget cell renderer
 	 *
@@ -508,9 +456,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 
 		return $title_content_type;
 	}
-
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
 
 	/**
 	 * Gets the SwatHtmlHeadEntry objects needed by this widget cell renderer
@@ -537,9 +482,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		return $set;
 	}
 
-	// }}}
-	// {{{ public function getAvailableHtmlHeadEntrySet()
-
 	/**
 	 * Gets the SwatHtmlHeadEntry objects that may be needed by this widget
 	 * cell renderer
@@ -565,9 +507,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 
 		return $set;
 	}
-
-	// }}}
-	// {{{ public function getDescendants()
 
 	/**
 	 * Gets descendant UI-objects
@@ -612,9 +551,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getFirstDescendant()
-
 	/**
 	 * Gets the first descendant UI-object of a specific class
 	 *
@@ -651,9 +587,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		return $out;
 	}
 
-	// }}}
-	// {{{ public function getDescendantStates()
-
 	/**
 	 * Gets descendant states
 	 *
@@ -673,9 +606,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		return $states;
 	}
 
-	// }}}
-	// {{{ public function setDescendantStates()
-
 	/**
 	 * Sets descendant states
 	 *
@@ -693,9 +623,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		}
 	}
 
-	// }}}
-	// {{{ public function __set()
-
 	/**
 	 * Maps a data field to a property of a widget in the widget tree
 	 *
@@ -711,9 +638,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		}
 	}
 
-	// }}}
-	// {{{ protected function getReplicatorFieldName()
-
 	protected function getReplicatorFieldName()
 	{
 		$name = $this->id.'_replicators';
@@ -726,9 +650,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		return $name;
 	}
 
-	// }}}
-	// {{{ private function getForm()
-
 	/**
 	 * Gets the form
 	 *
@@ -740,9 +661,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		return $form;
 	}
 
-	// }}}
-	// {{{ private function getClonedWidget()
-
 	private function getClonedWidget($replicator)
 	{
 		if (!isset($this->clones[$replicator]))
@@ -750,9 +668,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 
 		return $this->clones[$replicator];
 	}
-
-	// }}}
-	// {{{ private function applyPropertyValuesToPrototypeWidget()
 
 	private function applyPropertyValuesToPrototypeWidget()
 	{
@@ -762,9 +677,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 			$object->$property = $value;
 		}
 	}
-
-	// }}}
-	// {{{ private function applyPropertyValuesToClonedWidget()
 
 	private function applyPropertyValuesToClonedWidget($cloned_widget)
 	{
@@ -803,9 +715,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		}
 	}
 
-	// }}}
-	// {{{ private function createClonedWidget()
-
 	private function createClonedWidget($replicator)
 	{
 		if ($this->prototype_widget === null)
@@ -841,7 +750,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent,
 		$this->clones[$replicator] = $new_widget;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatXHTMLTextarea.php
+++ b/Swat/SwatXHTMLTextarea.php
@@ -10,7 +10,6 @@
  */
 class SwatXHTMLTextarea extends SwatTextarea
 {
-	// {{{ public properties
 
 	/**
 	 * Whether or not to allow the user to ignore validation errors
@@ -22,9 +21,6 @@ class SwatXHTMLTextarea extends SwatTextarea
 	 * @var boolean
 	 */
 	public $allow_ignore_validation_errors = false;
-
-	// }}}
-	// {{{ protected properties
 
 	/**
 	 * Whether or not this XHTML entry has validation errors or not
@@ -40,12 +36,8 @@ class SwatXHTMLTextarea extends SwatTextarea
 	 */
 	protected $ignore_errors_checkbox;
 
-	// }}}
-	// {{{ public function process()
-
 	public function process()
 	{
-		// {{{ defines the xhtml template
 
 		static $xhtml_template = '';
 
@@ -70,8 +62,6 @@ class SwatXHTMLTextarea extends SwatTextarea
 XHTML;
 		}
 
-		// }}}
-
 		parent::process();
 
 		$ignore_validation_errors = ($this->allow_ignore_validation_errors &&
@@ -95,9 +85,6 @@ XHTML;
 		}
 	}
 
-	// }}}
-	// {{{ public function display()
-
 	public function display()
 	{
 		if (!$this->visible)
@@ -112,9 +99,6 @@ XHTML;
 			$ignore_field->display();
 		}
 	}
-
-	// }}}
-	// {{{ protected function getValidationErrorMessage()
 
 	/**
 	 * Gets a human readable error message for XHTML validation errors on
@@ -184,9 +168,6 @@ XHTML;
 		return $message;
 	}
 
-	// }}}
-	// {{{ protected function createCompositeWidgets()
-
 	/**
 	 * Creates the composite checkbox used by this XHTML textarea
 	 *
@@ -204,15 +185,11 @@ XHTML;
 		$this->addCompositeWidget($ignore_field, 'ignore_field');
 	}
 
-	// }}}
-	// {{{ protected function getXHTMLContent()
-
 	protected function getXHTMLContent()
 	{
 		return $this->value;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatYUI.php
+++ b/Swat/SwatYUI.php
@@ -37,7 +37,6 @@
  */
 class SwatYUI extends SwatObject
 {
-	// {{{ private static properties
 
 	/**
 	 * Static component definitions
@@ -50,18 +49,12 @@ class SwatYUI extends SwatObject
 	 */
 	private static $components = array();
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * The {@link SwatHtmlHeadEntrySet} required for this SwaYUI object
 	 *
 	 * @var SwatHtmlHeadEntrySet
 	 */
 	private $html_head_entry_set;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new SwatYUI HTML head entry set building object
@@ -83,9 +76,6 @@ class SwatYUI extends SwatObject
 			$this->buildHtmlHeadEntrySet($component_ids, $mode);
 	}
 
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
-
 	/**
 	 * Gets the HTML head entry set required for the YUI components of this
 	 * object
@@ -96,9 +86,6 @@ class SwatYUI extends SwatObject
 	{
 		return $this->html_head_entry_set;
 	}
-
-	// }}}
-	// {{{ private function buildHtmlHeadEntrySet()
 
 	/**
 	 * Builds the HTML head entry set required for the YUI components of this
@@ -125,9 +112,6 @@ class SwatYUI extends SwatObject
 		return $set;
 	}
 
-	// }}}
-	// {{{ private function getAttributionHtmlHeadEntry()
-
 	private function getAttributionHtmlHeadEntry()
 	{
 		$comment = "Yahoo! UI Library (YUI) is Copyright (c) 2007-2009, ".
@@ -135,9 +119,6 @@ class SwatYUI extends SwatObject
 
 		return new SwatCommentHtmlHeadEntry($comment);
 	}
-
-	// }}}
-	// {{{ private static function buildComponents()
 
 	/**
 	 * Builds the YUI component definitions and dependency information
@@ -428,7 +409,6 @@ class SwatYUI extends SwatObject
 		$components_built = true;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatYUIComponent.php
+++ b/Swat/SwatYUIComponent.php
@@ -13,15 +13,11 @@
  */
 class SwatYUIComponent extends SwatObject
 {
-	// {{{ private properties
 
 	private $id;
 	private $dependencies = array();
 	private $html_head_entries = array();
 	private $beta = false;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new YUI component
@@ -48,9 +44,6 @@ class SwatYUIComponent extends SwatObject
 			new SwatHtmlHeadEntrySet();
 	}
 
-	// }}}
-	// {{{ public function addDependency()
-
 	/**
 	 * Adds a YUI component dependency to this YUI component
 	 *
@@ -60,9 +53,6 @@ class SwatYUIComponent extends SwatObject
 	{
 		$this->dependencies[] = $component;
 	}
-
-	// }}}
-	// {{{ public function addJavaScript()
 
 	/**
 	 * Adds a {@link SwatJavaScriptHtmlHeadEntry} to this YUI component
@@ -111,9 +101,6 @@ class SwatYUIComponent extends SwatObject
 			$this->html_head_entry_set[$mode]->addEntry($filename);
 		}
 	}
-
-	// }}}
-	// {{{ public function addStyleSheet()
 
 	/**
 	 * Adds a {@link SwatStyleSheetHtmlHeadEntry} to this YUI component
@@ -167,9 +154,6 @@ class SwatYUIComponent extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ public function getHtmlHeadEntrySet()
-
 	/**
 	 * Gets the set of {@link SwatHtmlHeadEntry} objects required for this
 	 * YUI component
@@ -190,7 +174,6 @@ class SwatYUIComponent extends SwatObject
 		return $set;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatYesNoFlydown.php
+++ b/Swat/SwatYesNoFlydown.php
@@ -9,13 +9,9 @@
  */
 class SwatYesNoFlydown extends SwatFlydown
 {
-	// {{{ constants
 
 	const NO  = false;
 	const YES = true;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new yes/no flydown
@@ -33,7 +29,6 @@ class SwatYesNoFlydown extends SwatFlydown
 		$this->addOption(self::YES, Swat::_('Yes'));
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/SwatYesNoRadioList.php
+++ b/Swat/SwatYesNoRadioList.php
@@ -9,13 +9,9 @@
  */
 class SwatYesNoRadioList extends SwatRadioList
 {
-	// {{{ constants
 
 	const NO  = false;
 	const YES = true;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new yes/no radio list
@@ -33,7 +29,6 @@ class SwatYesNoRadioList extends SwatRadioList
 		$this->addOption(self::YES, Swat::_('Yes'));
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatClassNotFoundException.php
+++ b/Swat/exceptions/SwatClassNotFoundException.php
@@ -9,7 +9,6 @@
  */
 class SwatClassNotFoundException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The name of the class that is not found
@@ -17,9 +16,6 @@ class SwatClassNotFoundException extends SwatException
 	 * @var string
 	 */
 	protected $class_name = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new class not found exception
@@ -34,9 +30,6 @@ class SwatClassNotFoundException extends SwatException
 		$this->class_name = $class_name;
 	}
 
-	// }}}
-	// {{{ public function getClassName()
-
 	/**
 	 * Gets the name of the class that is not found
 	 *
@@ -47,7 +40,6 @@ class SwatClassNotFoundException extends SwatException
 		return $this->class_name;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatCrossSiteRequestForgeryException.php
+++ b/Swat/exceptions/SwatCrossSiteRequestForgeryException.php
@@ -15,7 +15,6 @@
  */
 class SwatCrossSiteRequestForgeryException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The form that did not authenticate
@@ -23,9 +22,6 @@ class SwatCrossSiteRequestForgeryException extends SwatException
 	 * @var SwatForm
 	 */
 	protected $form = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new cross-site request forgery exception
@@ -40,9 +36,6 @@ class SwatCrossSiteRequestForgeryException extends SwatException
 		$this->form = $form;
 	}
 
-	// }}}
-	// {{{ public function getForm()
-
 	/**
 	 * Gets the form that did not authenticate
 	 *
@@ -53,7 +46,6 @@ class SwatCrossSiteRequestForgeryException extends SwatException
 		return $this->form;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatDoesNotImplementException.php
+++ b/Swat/exceptions/SwatDoesNotImplementException.php
@@ -9,7 +9,6 @@
  */
 class SwatDoesNotImplementException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The object that does not implement a required interface
@@ -17,9 +16,6 @@ class SwatDoesNotImplementException extends SwatException
 	 * @var mixed
 	 */
 	protected $object = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new does not implement exception
@@ -35,9 +31,6 @@ class SwatDoesNotImplementException extends SwatException
 		$this->object = $object;
 	}
 
-	// }}}
-	// {{{ public function getObject()
-
 	/**
 	 * Gets the object that does not implement a required interface
 	 *
@@ -48,7 +41,6 @@ class SwatDoesNotImplementException extends SwatException
 		return $this->object;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatDuplicateIdException.php
+++ b/Swat/exceptions/SwatDuplicateIdException.php
@@ -9,7 +9,6 @@
  */
 class SwatDuplicateIdException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The id that is colliding
@@ -17,9 +16,6 @@ class SwatDuplicateIdException extends SwatException
 	 * @var string
 	 */
 	protected $id = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new duplicate id exception
@@ -34,9 +30,6 @@ class SwatDuplicateIdException extends SwatException
 		$this->id = $id;
 	}
 
-	// }}}
-	// {{{ public function getId()
-
 	/**
 	 * Gets the id that is colliding
 	 *
@@ -47,7 +40,6 @@ class SwatDuplicateIdException extends SwatException
 		return $this->id;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatException.php
+++ b/Swat/exceptions/SwatException.php
@@ -38,7 +38,6 @@
  */
 class SwatException extends Exception
 {
-	// {{{ protected properties
 
 	protected $backtrace = null;
 	protected $class = null;
@@ -53,18 +52,12 @@ class SwatException extends Exception
 	 */
 	protected static $loggers = array();
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * Whether or not this excception was manually handled
 	 *
 	 * @var boolean
 	 */
 	private $handled = false;
-
-	// }}}
-	// {{{ public static function setLogger()
 
 	/**
 	 * Sets the object that logs SwatException objects when they are processed
@@ -80,9 +73,6 @@ class SwatException extends Exception
 	{
 		self::$loggers = array($logger);
 	}
-
-	// }}}
-	// {{{ public static function addLogger()
 
 	/**
 	 * Adds an object to the array of objects that log SwatException objects
@@ -101,9 +91,6 @@ class SwatException extends Exception
 		self::$loggers[] = $logger;
 	}
 
-	// }}}
-	// {{{ public static function setDisplayer()
-
 	/**
 	 * Sets the object that displays SwatException objects when they are
 	 * processed
@@ -121,9 +108,6 @@ class SwatException extends Exception
 		self::$displayer = $displayer;
 	}
 
-	// }}}
-	// {{{ public static function setupHandler()
-
 	/**
 	 * Set the PHP exception handler to use SwatException
 	 *
@@ -134,9 +118,6 @@ class SwatException extends Exception
 	{
 		set_exception_handler(array($class, 'handle'));
 	}
-
-	// }}}
-	// {{{ public function __construct()
 
 	public function __construct($message = null, $code = 0)
 	{
@@ -155,9 +136,6 @@ class SwatException extends Exception
 			$this->class = get_class($this);
 		}
 	}
-
-	// }}}
-	// {{{ public function process()
 
 	/**
 	 * Processes this exception
@@ -187,9 +165,6 @@ class SwatException extends Exception
 			exit(1);
 	}
 
-	// }}}
-	// {{{ public function processAndContinue()
-
 	/**
 	 * Processes this exception and continues execution
 	 *
@@ -201,9 +176,6 @@ class SwatException extends Exception
 		$this->process(false, true);
 	}
 
-	// }}}
-	// {{{ public function processAndExit()
-
 	/**
 	 * Processes this exception and stops execution
 	 *
@@ -214,9 +186,6 @@ class SwatException extends Exception
 	{
 		$this->process(true, true);
 	}
-
-	// }}}
-	// {{{ public function log()
 
 	/**
 	 * Logs this exception
@@ -233,9 +202,6 @@ class SwatException extends Exception
 			}
 		}
 	}
-
-	// }}}
-	// {{{ public function display()
 
 	/**
 	 * Displays this exception
@@ -260,9 +226,6 @@ class SwatException extends Exception
 		}
 	}
 
-	// }}}
-	// {{{ public function getSummary()
-
 	/**
 	 * Gets a one-line short text summary of this exception
 	 *
@@ -284,9 +247,6 @@ class SwatException extends Exception
 
 		return ob_get_clean();
 	}
-
-	// }}}
-	// {{{ public function toString()
 
 	/**
 	 * Gets this exception as a nicely formatted text block
@@ -339,9 +299,6 @@ class SwatException extends Exception
 
 		return ob_get_clean();
 	}
-
-	// }}}
-	// {{{ public function toXHTML()
 
 	/**
 	 * Gets this exception as a nicely formatted XHTML fragment
@@ -411,9 +368,6 @@ class SwatException extends Exception
 		return ob_get_clean();
 	}
 
-	// }}}
-	// {{{ public function getClass()
-
 	/**
 	 * Gets the name of the class this exception represents
 	 *
@@ -426,9 +380,6 @@ class SwatException extends Exception
 		return $this->class;
 	}
 
-	// }}}
-	// {{{ public function wasHandled()
-
 	/**
 	 * Gets whether or not this exception was manually handled
 	 *
@@ -439,9 +390,6 @@ class SwatException extends Exception
 	{
 		return $this->handled;
 	}
-
-	// }}}
-	// {{{ public static function handle()
 
 	/**
 	 * Handles an exception
@@ -461,9 +409,6 @@ class SwatException extends Exception
 		$e->process(true, false);
 	}
 
-	// }}}
-	// {{{ protected function getMessageAsHtml()
-
 	/**
 	 * Formats the exception's message as Html
 	 *
@@ -473,9 +418,6 @@ class SwatException extends Exception
 	{
 		return nl2br(htmlspecialchars($this->getMessage()));
 	}
-
-	// }}}
-	// {{{ protected function getArguments()
 
 	/**
 	 * Formats a method call's arguments
@@ -531,9 +473,6 @@ class SwatException extends Exception
 		return implode(', ', $formatted_values);
 	}
 
-	// }}}
-	// {{{ protected function formatSensitiveParam()
-
 	/**
 	 * Removes sensitive information from a parameter value and formats
 	 * the parameter as a string
@@ -553,9 +492,6 @@ class SwatException extends Exception
 	{
 		return '[$'.$name.' FILTERED]';
 	}
-
-	// }}}
-	// {{{ protected function formatValue()
 
 	/**
 	 * Formats a parameter value for display in a stack trace
@@ -618,9 +554,6 @@ class SwatException extends Exception
 		return $formatted_value;
 	}
 
-	// }}}
-	// {{{ protected function displayStyleSheet()
-
 	/**
 	 * Displays style sheet required for XHMTL exception formatting
 	 *
@@ -651,9 +584,6 @@ class SwatException extends Exception
 			$displayed = true;
 		}
 	}
-
-	// }}}
-	// {{{ protected function isSensitiveParameter()
 
 	/**
 	 * Detects whether or not a parameter is sensitive from the method-level
@@ -699,7 +629,6 @@ class SwatException extends Exception
 		return $sensitive;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatFileNotFoundException.php
+++ b/Swat/exceptions/SwatFileNotFoundException.php
@@ -9,7 +9,6 @@
  */
 class SwatFileNotFoundException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The filename that caused this exception to be thrown.
@@ -17,9 +16,6 @@ class SwatFileNotFoundException extends SwatException
 	 * @var string
 	 */
 	protected $filename = '';
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new file not found exception
@@ -34,9 +30,6 @@ class SwatFileNotFoundException extends SwatException
 		$this->filename = $filename;
 	}
 
-	// }}}
-	// {{{ public function getFilename()
-
 	/**
 	 * Gets the filename of that caused this exception to be thrown
 	 *
@@ -47,7 +40,6 @@ class SwatFileNotFoundException extends SwatException
 		return $this->filename;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatIntegerOverflowException.php
+++ b/Swat/exceptions/SwatIntegerOverflowException.php
@@ -9,7 +9,6 @@
  */
 class SwatIntegerOverflowException extends OverflowException
 {
-	// {{{ protected properties
 
 	/**
 	 * Sign
@@ -19,9 +18,6 @@ class SwatIntegerOverflowException extends OverflowException
 	 * @var integer
 	 */
 	protected $sign = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new invalid type exception
@@ -38,9 +34,6 @@ class SwatIntegerOverflowException extends OverflowException
 		$this->sign = $sign;
 	}
 
-	// }}}
-	// {{{ public function getSign()
-
 	/**
 	 * Gets the sign of the integer
 	 *
@@ -51,7 +44,6 @@ class SwatIntegerOverflowException extends OverflowException
 		return $this->sign;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatInvalidCallbackException.php
+++ b/Swat/exceptions/SwatInvalidCallbackException.php
@@ -10,7 +10,6 @@
  */
 class SwatInvalidCallbackException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The value the user tried to set the callback to
@@ -18,9 +17,6 @@ class SwatInvalidCallbackException extends SwatException
 	 * @var mixed
 	 */
 	protected $callback = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new invalid callback exception
@@ -35,9 +31,6 @@ class SwatInvalidCallbackException extends SwatException
 		$this->callback = $callback;
 	}
 
-	// }}}
-	// {{{ public function getCallback()
-
 	/**
 	 * Gets the value the user tried to set the callback to
 	 *
@@ -48,7 +41,6 @@ class SwatInvalidCallbackException extends SwatException
 		return $this->callback;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatInvalidClassException.php
+++ b/Swat/exceptions/SwatInvalidClassException.php
@@ -9,7 +9,6 @@
  */
 class SwatInvalidClassException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The object that is of the wrong class
@@ -17,9 +16,6 @@ class SwatInvalidClassException extends SwatException
 	 * @var mixed
 	 */
 	protected $object = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new invalid class exception
@@ -34,9 +30,6 @@ class SwatInvalidClassException extends SwatException
 		$this->object = $object;
 	}
 
-	// }}}
-	// {{{ public function getObject()
-
 	/**
 	 * Gets the object that is of the wrong class
 	 *
@@ -47,7 +40,6 @@ class SwatInvalidClassException extends SwatException
 		return $this->object;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatInvalidConstantExpressionException.php
+++ b/Swat/exceptions/SwatInvalidConstantExpressionException.php
@@ -9,7 +9,6 @@
  */
 class SwatInvalidConstantExpressionException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The constant expression that is invalid
@@ -17,9 +16,6 @@ class SwatInvalidConstantExpressionException extends SwatException
 	 * @var string
 	 */
 	protected $expression = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new class not found exception
@@ -34,9 +30,6 @@ class SwatInvalidConstantExpressionException extends SwatException
 		$this->expression = $expression;
 	}
 
-	// }}}
-	// {{{ public function getExpression()
-
 	/**
 	 * Gets the constant expression that is invalid
 	 *
@@ -47,7 +40,6 @@ class SwatInvalidConstantExpressionException extends SwatException
 		return $this->expression;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatInvalidPropertyException.php
+++ b/Swat/exceptions/SwatInvalidPropertyException.php
@@ -9,7 +9,6 @@
  */
 class SwatInvalidPropertyException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The name of the property that is invalid
@@ -24,9 +23,6 @@ class SwatInvalidPropertyException extends SwatException
 	 * @var mixed
 	 */
 	protected $object = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new invalid class exception
@@ -47,9 +43,6 @@ class SwatInvalidPropertyException extends SwatException
 		$this->property = $property;
 	}
 
-	// }}}
-	// {{{ public function getObject()
-
 	/**
 	 * Gets the object the property is invalid for
 	 *
@@ -59,9 +52,6 @@ class SwatInvalidPropertyException extends SwatException
 	{
 		return $this->object;
 	}
-
-	// }}}
-	// {{{ public function getProperty()
 
 	/**
 	 * Gets the name of the property that is invalid
@@ -73,7 +63,6 @@ class SwatInvalidPropertyException extends SwatException
 		return $this->property;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatInvalidPropertyTypeException.php
+++ b/Swat/exceptions/SwatInvalidPropertyTypeException.php
@@ -9,7 +9,6 @@
  */
 class SwatInvalidPropertyTypeException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The name of the type that is invalid
@@ -24,9 +23,6 @@ class SwatInvalidPropertyTypeException extends SwatException
 	 * @var mixed
 	 */
 	protected $object = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new invalid class exception
@@ -47,9 +43,6 @@ class SwatInvalidPropertyTypeException extends SwatException
 		$this->type = $type;
 	}
 
-	// }}}
-	// {{{ public function getObject()
-
 	/**
 	 * Gets the object the property is invalid for
 	 *
@@ -59,9 +52,6 @@ class SwatInvalidPropertyTypeException extends SwatException
 	{
 		return $this->object;
 	}
-
-	// }}}
-	// {{{ public function getType()
 
 	/**
 	 * Gets the name of the type that is invalid
@@ -73,7 +63,6 @@ class SwatInvalidPropertyTypeException extends SwatException
 		return $this->type;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatInvalidSerializedDataException.php
+++ b/Swat/exceptions/SwatInvalidSerializedDataException.php
@@ -9,7 +9,6 @@
  */
 class SwatInvalidSerializedDataException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The unsafe serialized data
@@ -17,9 +16,6 @@ class SwatInvalidSerializedDataException extends SwatException
 	 * @var string
 	 */
 	protected $data = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new invalid serialized data exception
@@ -34,9 +30,6 @@ class SwatInvalidSerializedDataException extends SwatException
 		$this->data = $data;
 	}
 
-	// }}}
-	// {{{ public function getData()
-
 	/**
 	 * Gets the unsafe serialized data
 	 *
@@ -47,7 +40,6 @@ class SwatInvalidSerializedDataException extends SwatException
 		return $this->data;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatInvalidSwatMLException.php
+++ b/Swat/exceptions/SwatInvalidSwatMLException.php
@@ -12,7 +12,6 @@
  */
 class SwatInvalidSwatMLException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The filename of the SwatML file that caused this exception to be thrown.
@@ -20,9 +19,6 @@ class SwatInvalidSwatMLException extends SwatException
 	 * @var string
 	 */
 	protected $filename = '';
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new invalid SwatML exception
@@ -37,9 +33,6 @@ class SwatInvalidSwatMLException extends SwatException
 		$this->filename = $filename;
 	}
 
-	// }}}
-	// {{{ public function getFilename()
-
 	/**
 	 * Gets the filename of the SwatML file that caused this exception to be
 	 * thrown
@@ -52,7 +45,6 @@ class SwatInvalidSwatMLException extends SwatException
 		return $this->filename;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatInvalidTypeException.php
+++ b/Swat/exceptions/SwatInvalidTypeException.php
@@ -9,7 +9,6 @@
  */
 class SwatInvalidTypeException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The value that is of the wrong type
@@ -17,9 +16,6 @@ class SwatInvalidTypeException extends SwatException
 	 * @var mixed
 	 */
 	protected $value = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new invalid type exception
@@ -34,9 +30,6 @@ class SwatInvalidTypeException extends SwatException
 		$this->value = $value;
 	}
 
-	// }}}
-	// {{{ public function getValue()
-
 	/**
 	 * Gets the value that is of the wrong type
 	 *
@@ -47,7 +40,6 @@ class SwatInvalidTypeException extends SwatException
 		return $this->value;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatObjectNotFoundException.php
+++ b/Swat/exceptions/SwatObjectNotFoundException.php
@@ -9,7 +9,6 @@
  */
 class SwatObjectNotFoundException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The object id that was searched for
@@ -17,9 +16,6 @@ class SwatObjectNotFoundException extends SwatException
 	 * @var string
 	 */
 	protected $object_id = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new object not found exception
@@ -34,9 +30,6 @@ class SwatObjectNotFoundException extends SwatException
 		$this->object_id = $object_id;
 	}
 
-	// }}}
-	// {{{ public function getObjectId()
-
 	/**
 	 * Gets the object id that was searched for
 	 *
@@ -47,7 +40,6 @@ class SwatObjectNotFoundException extends SwatException
 		return $this->object_id;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatUndefinedConstantException.php
+++ b/Swat/exceptions/SwatUndefinedConstantException.php
@@ -9,7 +9,6 @@
  */
 class SwatUndefinedConstantException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The name of the constant that is undefined
@@ -17,9 +16,6 @@ class SwatUndefinedConstantException extends SwatException
 	 * @var string
 	 */
 	protected $constant_name = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new undefined constant exception
@@ -37,9 +33,6 @@ class SwatUndefinedConstantException extends SwatException
 		$this->constant_name = $constant_name;
 	}
 
-	// }}}
-	// {{{ public function getConstantName()
-
 	/**
 	 * Gets the name of the constant that is undefined
 	 *
@@ -50,7 +43,6 @@ class SwatUndefinedConstantException extends SwatException
 		return $this->constant_name;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatUndefinedMessageTypeException.php
+++ b/Swat/exceptions/SwatUndefinedMessageTypeException.php
@@ -9,7 +9,6 @@
  */
 class SwatUndefinedMessageTypeException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The name of the message type that is undefined
@@ -17,9 +16,6 @@ class SwatUndefinedMessageTypeException extends SwatException
 	 * @var string
 	 */
 	protected $message_type = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new undefined message type exception
@@ -38,9 +34,6 @@ class SwatUndefinedMessageTypeException extends SwatException
 		$this->message_type = $message_type;
 	}
 
-	// }}}
-	// {{{ public function getMessageType()
-
 	/**
 	 * Gets the name of the message type that is undefined
 	 *
@@ -51,7 +44,6 @@ class SwatUndefinedMessageTypeException extends SwatException
 		return $this->message_type;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatUndefinedStockTypeException.php
+++ b/Swat/exceptions/SwatUndefinedStockTypeException.php
@@ -9,7 +9,6 @@
  */
 class SwatUndefinedStockTypeException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The name of the stock type that is undefined
@@ -17,9 +16,6 @@ class SwatUndefinedStockTypeException extends SwatException
 	 * @var string
 	 */
 	protected $stock_type = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new undefined stock type exception
@@ -37,9 +33,6 @@ class SwatUndefinedStockTypeException extends SwatException
 		$this->stock_type = $stock_type;
 	}
 
-	// }}}
-	// {{{ public function getStockType()
-
 	/**
 	 * Gets the name of the stock type that is undefined
 	 *
@@ -50,7 +43,6 @@ class SwatUndefinedStockTypeException extends SwatException
 		return $this->stock_type;
 	}
 
-	// }}}
 }
 
 ?>

--- a/Swat/exceptions/SwatWidgetNotFoundException.php
+++ b/Swat/exceptions/SwatWidgetNotFoundException.php
@@ -9,7 +9,6 @@
  */
 class SwatWidgetNotFoundException extends SwatException
 {
-	// {{{ protected properties
 
 	/**
 	 * The widget id that was searched for
@@ -17,9 +16,6 @@ class SwatWidgetNotFoundException extends SwatException
 	 * @var string
 	 */
 	protected $widget_id = null;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new widget not found exception
@@ -34,9 +30,6 @@ class SwatWidgetNotFoundException extends SwatException
 		$this->widget_id = $widget_id;
 	}
 
-	// }}}
-	// {{{ public function getWidgetId()
-
 	/**
 	 * Gets the widget id that was searched for
 	 *
@@ -47,7 +40,6 @@ class SwatWidgetNotFoundException extends SwatException
 		return $this->widget_id;
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDB.php
+++ b/SwatDB/SwatDB.php
@@ -11,15 +11,11 @@
  */
 class SwatDB extends SwatObject
 {
-	// {{{ protected static properties
 
 	protected static $query_count = 0;
 	protected static $debug = false;
 	protected static $debug_info = array();
 	protected static $debug_wrapper_depth = 0;
-
-	// }}}
-	// {{{ public static function setDebug()
 
 	/**
 	 * Sets the debug mode used by SwatDB
@@ -31,9 +27,6 @@ class SwatDB extends SwatObject
 	{
 		self::$debug = (boolean)$debug;
 	}
-
-	// }}}
-	// {{{ public static function connect()
 
 	/**
 	 * Connects to a database
@@ -56,9 +49,6 @@ class SwatDB extends SwatObject
 
 		return $db;
 	}
-
-	// }}}
-	// {{{ public static function query()
 
 	/**
 	 * Performs an SQL query
@@ -109,9 +99,6 @@ class SwatDB extends SwatObject
 		return $rs;
 	}
 
-	// }}}
-	// {{{ public static function exec()
-
 	/**
 	 * Execute a data manipulation SQL statement
 	 *
@@ -128,9 +115,6 @@ class SwatDB extends SwatObject
 	{
 		return self::executeQuery($db, 'exec', array($sql));
 	}
-
-	// }}}
-	// {{{ public static function updateColumn()
 
 	/**
 	 * Update a column
@@ -204,9 +188,6 @@ class SwatDB extends SwatObject
 		return self::exec($db, $sql);
 	}
 
-	// }}}
-	// {{{ public static function queryColumn()
-
 	/**
 	 * Query a column
 	 *
@@ -264,9 +245,6 @@ class SwatDB extends SwatObject
 		return $values;
 	}
 
-	// }}}
-	// {{{ public static function queryOne()
-
 	/**
 	 * Query a single value
 	 *
@@ -286,9 +264,6 @@ class SwatDB extends SwatObject
 		$mdb2_type = $type === null ? true : $type;
 		return self::executeQuery($db, 'queryOne', array($sql, $mdb2_type));
 	}
-
-	// }}}
-	// {{{ public static function queryRow()
 
 	/**
 	 * Query a single row
@@ -312,9 +287,6 @@ class SwatDB extends SwatObject
 
 		return $row;
 	}
-
-	// }}}
-	// {{{ public static function queryOneFromTable()
 
 	/**
 	 * Query a single value from a specified table and column
@@ -367,9 +339,6 @@ class SwatDB extends SwatObject
 		return $value;
 	}
 
-	// }}}
-	// {{{ public static function queryRowFromTable()
-
 	/**
 	 * Query a single row from a specified table and column
 	 *
@@ -417,9 +386,6 @@ class SwatDB extends SwatObject
 
 		return $row;
 	}
-
-	// }}}
-	// {{{ public static function executeStoredProc()
 
 	/**
 	 * Performs a stored procedure
@@ -487,9 +453,6 @@ class SwatDB extends SwatObject
 		return $rs;
 	}
 
-	// }}}
-	// {{{ public static function executeStoredProcOne()
-
 	/**
 	 * Execute a stored procedure that returns a single value
 	 *
@@ -516,9 +479,6 @@ class SwatDB extends SwatObject
 		$row = $rs->getFirst();
 		return current($row);
 	}
-
-	// }}}
-	// {{{ public static function updateBinding()
 
 	/**
 	 * Update a binding table
@@ -622,9 +582,6 @@ class SwatDB extends SwatObject
 		$transaction->commit();
 	}
 
-	// }}}
-	// {{{ public static function insertRow()
-
 	/**
 	 * Insert a row
 	 *
@@ -713,9 +670,6 @@ class SwatDB extends SwatObject
 		return $ret;
 	}
 
-	// }}}
-	// {{{ public static function updateRow()
-
 	/**
 	 * Update a row
 	 *
@@ -777,9 +731,6 @@ class SwatDB extends SwatObject
 		self::exec($db, $sql);
 	}
 
-	// }}}
-	// {{{ public static function deleteRow()
-
 	/**
 	 * Delete a row
 	 *
@@ -811,9 +762,6 @@ class SwatDB extends SwatObject
 
 		self::exec($db, $sql);
 	}
-
-	// }}}
-	// {{{ public static function getOptionArray()
 
 	/**
 	 * Query for an option array
@@ -885,9 +833,6 @@ class SwatDB extends SwatObject
 
 		return $options;
 	}
-
-	// }}}
-	// {{{ public static function getCascadeOptionArray()
 
 	/**
 	 * Query for an option array cascaded by a field
@@ -975,9 +920,6 @@ class SwatDB extends SwatObject
 
 		return $options;
 	}
-
-	// }}}
-	// {{{ public static function getGroupedOptionArray()
 
 	/**
 	 * Queries for a grouped option array
@@ -1101,9 +1043,6 @@ class SwatDB extends SwatObject
 		return $base_parent;
 	}
 
-	// }}}
-	// {{{ public static function getFieldMax()
-
 	/**
 	 * Get max field value
 	 *
@@ -1131,9 +1070,6 @@ class SwatDB extends SwatObject
 		return self::queryOne($db, $sql);
 	}
 
-	// }}}
-	// {{{ public static function equalityOperator()
-
 	/**
 	 * Get proper conditional operator
 	 *
@@ -1158,9 +1094,6 @@ class SwatDB extends SwatObject
 		else
 			return '=';
 	}
-
-	// }}}
-	// {{{ public static function getDataTree()
 
 	/**
 	 * Get a tree of data nodes
@@ -1229,9 +1162,6 @@ class SwatDB extends SwatObject
 		return $base_parent;
 	}
 
-	// }}}
-	// {{{ public static function implodeSelection()
-
 	/**
 	 * Implodes a view selection object
 	 *
@@ -1257,9 +1187,6 @@ class SwatDB extends SwatObject
 		return implode(',', $quoted_ids);
 	}
 
-	// }}}
-	// {{{ private static function executeQuery()
-
 	private static function executeQuery($db, $method, array $args)
 	{
 		self::$query_count++;
@@ -1274,9 +1201,6 @@ class SwatDB extends SwatObject
 		return $ret;
 	}
 
-	// }}}
-	// {{{ private static function getFieldNameArray()
-
 	private static function getFieldNameArray($fields)
 	{
 		if (count($fields) == 0)
@@ -1290,9 +1214,6 @@ class SwatDB extends SwatObject
 		return $names;
 	}
 
-	// }}}
-	// {{{ private static function getFieldTypeArray()
-
 	private static function getFieldTypeArray($fields)
 	{
 		if (count($fields) == 0)
@@ -1305,9 +1226,6 @@ class SwatDB extends SwatObject
 
 		return $types;
 	}
-
-	// }}}
-	// {{{ private static function initFields()
 
 	/**
 	 * Transforms an array of text field identifiers ('type:name') into
@@ -1328,9 +1246,6 @@ class SwatDB extends SwatObject
 		foreach ($fields as &$field)
 			$field = new SwatDBField($field, 'text');
 	}
-
-	// }}}
-	// {{{ private static function initArray()
 
 	/**
 	 * Noramlizes Iterator objects into simple arrays
@@ -1359,9 +1274,6 @@ class SwatDB extends SwatObject
 
 		throw new SwatDBException('Value is not an array');
 	}
-
-	// }}}
-	// {{{ private static function debugStart()
 
 	private static function debugStart($message)
 	{
@@ -1402,9 +1314,6 @@ class SwatDB extends SwatObject
 			self::$debug_wrapper_depth++;
 		}
 	}
-
-	// }}}
-	// {{{ private static function debugEnd()
 
 	private static function debugEnd()
 	{
@@ -1470,7 +1379,6 @@ class SwatDB extends SwatObject
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDBCacheNsFlushable.php
+++ b/SwatDB/SwatDBCacheNsFlushable.php
@@ -9,7 +9,6 @@
  */
 interface SwatDBCacheNsFlushable
 {
-	// {{{ public function flushNs()
 
 	/**
 	 * Flushes a cache name-space
@@ -18,7 +17,6 @@ interface SwatDBCacheNsFlushable
 	 */
 	public function flushNs($ns);
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDBClassMap.php
+++ b/SwatDB/SwatDBClassMap.php
@@ -16,7 +16,6 @@
  */
 class SwatDBClassMap extends SwatObject
 {
-	// {{{ private properties
 
 	/**
 	 * An associative array of class-mappings
@@ -34,9 +33,6 @@ class SwatDBClassMap extends SwatObject
 	 * @var array
 	 */
 	private static $search_paths = array('.');
-
-	// }}}
-	// {{{ public static function add()
 
 	/**
 	 * Maps a class name to another class name
@@ -86,9 +82,6 @@ class SwatDBClassMap extends SwatObject
 		self::$map[$from_class_name] = $to_class_name;
 	}
 
-	// }}}
-	// {{{ public static function get()
-
 	/**
 	 * Resolves a class name from the class map
 	 *
@@ -119,9 +112,6 @@ class SwatDBClassMap extends SwatObject
 		return $to_class_name;
 	}
 
-	// }}}
-	// {{{ public static function addPath()
-
 	/**
 	 * Adds a search path for class-definition files
 	 *
@@ -144,9 +134,6 @@ class SwatDBClassMap extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ public static function removePath()
-
 	/**
 	 * Removes a search path for class-definition files
 	 *
@@ -161,9 +148,6 @@ class SwatDBClassMap extends SwatObject
 			array_splice(self::$search_paths, $index, 1);
 	}
 
-	// }}}
-	// {{{ private function __construct()
-
 	/**
 	 * The class map is a static object and should not be instantiated
 	 */
@@ -171,10 +155,7 @@ class SwatDBClassMap extends SwatObject
 	{
 	}
 
-	// }}}
-
 	// deprecated API
-	// {{{ private properties
 
 	/**
 	 * Singleton instance
@@ -205,9 +186,6 @@ class SwatDBClassMap extends SwatObject
 	 */
 	private $path = null;
 
-	// }}}
-	// {{{ public static function instance()
-
 	/**
 	 * Gets the singleton instance of the class-mapping object
 	 *
@@ -224,9 +202,6 @@ class SwatDBClassMap extends SwatObject
 		return self::$instance;
 	}
 
-	// }}}
-	// {{{ public function addMapping()
-
 	/**
 	 * Adds a class-mapping to the class-mapping object
 	 *
@@ -241,9 +216,6 @@ class SwatDBClassMap extends SwatObject
 		$this->mappings[$package_class_name] = $class_name;
 		self::add($package_class_name, $class_name);
 	}
-
-	// }}}
-	// {{{ public function resolveClass()
 
 	/**
 	 * Gets the appropriate class name for a given package class name
@@ -264,9 +236,6 @@ class SwatDBClassMap extends SwatObject
 		return self::get($name);
 	}
 
-	// }}}
-	// {{{ public function setPath()
-
 	/**
 	 * Sets the path to search for site-specific class files
 	 *
@@ -281,7 +250,6 @@ class SwatDBClassMap extends SwatObject
 		self::addPath($path);
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDBDataObject.php
+++ b/SwatDB/SwatDBDataObject.php
@@ -10,7 +10,6 @@
 class SwatDBDataObject extends SwatObject implements
 	Serializable, SwatDBRecordable, SwatDBMarshallable, SwatDBFlushable
 {
-	// {{{ private properties
 
 	/**
 	 * @var array
@@ -57,9 +56,6 @@ class SwatDBDataObject extends SwatObject implements
 	 */
 	private $deprecated_properties = array();
 
-	// }}}
-	// {{{ protected properties
-
 	/**
 	 * @var MDB2
 	 */
@@ -86,18 +82,12 @@ class SwatDBDataObject extends SwatObject implements
 	 */
 	protected $flushable_cache;
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * Cache of public property names indexed by class name
 	 *
 	 * @var array
 	 */
 	private static $public_properties_cache = array();
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * @param mixed $data
@@ -119,9 +109,6 @@ class SwatDBDataObject extends SwatObject implements
 		$this->generatePropertyHashes();
 	}
 
-	// }}}
-	// {{{ public function setTable()
-
 	/**
 	 * @param string $table Database table
 	 */
@@ -129,9 +116,6 @@ class SwatDBDataObject extends SwatObject implements
 	{
 		$this->table = $table;
 	}
-
-	// }}}
-	// {{{ public function getModifiedProperties()
 
 	/**
 	 * Gets a list of all the modified properties of this object
@@ -154,9 +138,6 @@ class SwatDBDataObject extends SwatObject implements
 
 		return $modified_properties;
 	}
-
-	// }}}
-	// {{{ public function __get()
 
 	public function __get($key)
 	{
@@ -192,9 +173,6 @@ class SwatDBDataObject extends SwatObject implements
 
 		return $value;
 	}
-
-	// }}}
-	// {{{ public function __set()
 
 	public function __set($key, $value)
 	{
@@ -249,9 +227,6 @@ class SwatDBDataObject extends SwatObject implements
 		}
 	}
 
-	// }}}
-	// {{{ public function __isset()
-
 	public function __isset($key)
 	{
 		$is_set = false;
@@ -271,9 +246,6 @@ class SwatDBDataObject extends SwatObject implements
 
 		return $is_set;
 	}
-
-	// }}}
-	// {{{ public function __toString()
 
 	/**
 	 * Gets a string representation of this data-object
@@ -343,9 +315,6 @@ class SwatDBDataObject extends SwatObject implements
 		return $string;
 	}
 
-	// }}}
-	// {{{ public function getInternalValue()
-
 	public function getInternalValue($name)
 	{
 		if (array_key_exists($name, $this->internal_properties))
@@ -354,16 +323,10 @@ class SwatDBDataObject extends SwatObject implements
 			return null;
 	}
 
-	// }}}
-	// {{{ public function hasInternalValue()
-
 	public function hasInternalValue($name)
 	{
 		return array_key_exists($name, $this->internal_properties);
 	}
-
-	// }}}
-	// {{{ public function hasPublicProperty()
 
 	/**
 	 * Whether or not a public property exists for the given property name
@@ -382,9 +345,6 @@ class SwatDBDataObject extends SwatObject implements
 		return array_key_exists($name, $public_properties);
 	}
 
-	// }}}
-	// {{{ public function hasDateProperty()
-
 	/**
 	 * Whether or not a registered date property exists for the given property
 	 * name
@@ -400,9 +360,6 @@ class SwatDBDataObject extends SwatObject implements
 	{
 		return in_array($name, $this->date_properties);
 	}
-
-	// }}}
-	// {{{ public function duplicate()
 
 	/**
 	 * Duplicates this object
@@ -469,9 +426,6 @@ class SwatDBDataObject extends SwatObject implements
 		return $new_object;
 	}
 
-	// }}}
-	// {{{ public function getAttributes()
-
 	/**
 	 * Returns an array of the public and protected properties of this object
 	 *
@@ -493,32 +447,20 @@ class SwatDBDataObject extends SwatObject implements
 		);
 	}
 
-	// }}}
-	// {{{ protected function setInternalValue()
-
 	protected function setInternalValue($name, $value)
 	{
 		if (array_key_exists($name, $this->internal_properties))
 			$this->internal_properties[$name] = $value;
 	}
 
-	// }}}
-	// {{{ protected function init()
-
 	protected function init()
 	{
 	}
-
-	// }}}
-	// {{{ protected function registerDateProperty()
 
 	protected function registerDateProperty($name)
 	{
 		$this->date_properties[] = $name;
 	}
-
-	// }}}
-	// {{{ protected function registerInternalProperty()
 
 	protected function registerInternalProperty(
 		$name,
@@ -532,16 +474,10 @@ class SwatDBDataObject extends SwatObject implements
 		$this->internal_property_classes[$name] = $class;
 	}
 
-	// }}}
-	// {{{ protected function registerDeprecatedProperty()
-
 	protected function registerDeprecatedProperty($name)
 	{
 		$this->deprecated_properties[] = $name;
 	}
-
-	// }}}
-	// {{{ protected function initFromRow()
 
 	/**
 	 * Takes a data row and sets the properties of this object according to
@@ -590,9 +526,6 @@ class SwatDBDataObject extends SwatObject implements
 		$this->loaded_from_database = true;
 	}
 
-	// }}}
-	// {{{ protected function generatePropertyHashes()
-
 	/**
 	 * Generates the set of md5 hashes for this data object
 	 *
@@ -612,9 +545,6 @@ class SwatDBDataObject extends SwatObject implements
 			$this->property_hashes[$name] = $hashed_value;
 		}
 	}
-
-	// }}}
-	// {{{ protected function generatePropertyHash()
 
 	/**
 	 * Generates the MD5 hash for a property of this object
@@ -636,9 +566,6 @@ class SwatDBDataObject extends SwatObject implements
 		}
 	}
 
-	// }}}
-	// {{{ protected function getHashValue()
-
 	/**
 	 * Gets the hash of a value
 	 *
@@ -653,9 +580,6 @@ class SwatDBDataObject extends SwatObject implements
 		return md5(serialize($value));
 	}
 
-	// }}}
-	// {{{ protected function getId()
-
 	protected function getId()
 	{
 		if ($this->id_field === null)
@@ -668,16 +592,10 @@ class SwatDBDataObject extends SwatObject implements
 		return $this->$temp;
 	}
 
-	// }}}
-	// {{{ protected function getSubDataObject()
-
 	protected function getSubDataObject($name)
 	{
 		return $this->sub_data_objects[$name];
 	}
-
-	// }}}
-	// {{{ protected function setSubDataObject()
 
 	protected function setSubDataObject($name, $value)
 	{
@@ -689,16 +607,10 @@ class SwatDBDataObject extends SwatObject implements
 		}
 	}
 
-	// }}}
-	// {{{ protected function unsetSubDataObject()
-
 	protected function unsetSubDataObject($name)
 	{
 		unset($this->sub_data_objects[$name]);
 	}
-
-	// }}}
-	// {{{ protected function hasSubDataObject()
 
 	/**
 	 * Whether or not a sub data object is loaded for the given key
@@ -713,23 +625,14 @@ class SwatDBDataObject extends SwatObject implements
 		return (isset($this->sub_data_objects[(string)$key]));
 	}
 
-	// }}}
-	// {{{ protected function setDeprecatedProperty()
-
 	protected function setDeprecatedProperty($key, $value)
 	{
 	}
-
-	// }}}
-	// {{{ protected function getDeprecatedProperty()
 
 	protected function getDeprecatedProperty($key)
 	{
 		return null;
 	}
-
-	// }}}
-	// {{{ protected function getProtectedPropertyList()
 
 	/**
 	 * Gets a list of all protected properties of this data-object
@@ -747,9 +650,6 @@ class SwatDBDataObject extends SwatObject implements
 	{
 		return array();
 	}
-
-	// }}}
-	// {{{ private function getPublicProperties()
 
 	/**
 	 * Gets the public properties of this data-object
@@ -788,9 +688,6 @@ class SwatDBDataObject extends SwatObject implements
 		return $properties;
 	}
 
-	// }}}
-	// {{{ private function getSerializableProtectedProperties()
-
 	/**
 	 * Gets the serializable protected properties of this data-object.
 	 *
@@ -813,9 +710,6 @@ class SwatDBDataObject extends SwatObject implements
 		return $properties;
 	}
 
-	// }}}
-	// {{{ private function getProtectedProperties()
-
 	/**
 	 * Gets the protected properties of this data-object using the getter
 	 * accessor.
@@ -836,9 +730,6 @@ class SwatDBDataObject extends SwatObject implements
 
 		return $properties;
 	}
-
-	// }}}
-	// {{{ private function getProperties()
 
 	/**
 	 * Gets all the modifyable properties of this data-object
@@ -862,9 +753,6 @@ class SwatDBDataObject extends SwatObject implements
 		return $property_array;
 	}
 
-	// }}}
-	// {{{ private function getLoaderMethod()
-
 	private function getLoaderMethod($key)
 	{
 		/*
@@ -881,9 +769,6 @@ class SwatDBDataObject extends SwatObject implements
 
 		return $cache[$key];
 	}
-
-	// }}}
-	// {{{ private function getUsingLoaderMethod()
 
 	private function getUsingLoaderMethod($key)
 	{
@@ -909,9 +794,6 @@ class SwatDBDataObject extends SwatObject implements
 
 		return $value;
 	}
-
-	// }}}
-	// {{{ private function getUsingInternalProperty()
 
 	private function getUsingInternalProperty($key)
 	{
@@ -954,10 +836,7 @@ class SwatDBDataObject extends SwatObject implements
 		return $value;
 	}
 
-	// }}}
-
 	// database loading and saving
-	// {{{ public function setDatabase()
 
 	/**
 	 * Sets the database driver for this data-object
@@ -990,9 +869,6 @@ class SwatDBDataObject extends SwatObject implements
 			}
 		}
 	}
-
-	// }}}
-	// {{{ public function save()
 
 	/**
 	 * Saves this object to the database
@@ -1031,9 +907,6 @@ class SwatDBDataObject extends SwatObject implements
 		$this->generatePropertyHashes();
 	}
 
-	// }}}
-	// {{{ public function load()
-
 	/**
 	 * Loads this object's properties from the database given an id
 	 *
@@ -1054,9 +927,6 @@ class SwatDBDataObject extends SwatObject implements
 		$this->generatePropertyHashes();
 		return true;
 	}
-
-	// }}}
-	// {{{ public function delete()
 
 	/**
 	 * Deletes this object from the database
@@ -1080,9 +950,6 @@ class SwatDBDataObject extends SwatObject implements
 			throw $e;
 		}
 	}
-
-	// }}}
-	// {{{ public function isModified()
 
 	/**
 	 * Returns true if this object has been modified since it was loaded
@@ -1124,9 +991,6 @@ class SwatDBDataObject extends SwatObject implements
 		return false;
 	}
 
-	// }}}
-	// {{{ protected function checkDB()
-
 	protected function checkDB()
 	{
 		if ($this->db === null)
@@ -1134,9 +998,6 @@ class SwatDBDataObject extends SwatObject implements
 				sprintf('No database available to this dataobject (%s). '.
 					'Call the setDatabase method.', get_class($this)));
 	}
-
-	// }}}
-	// {{{ protected function loadInternal()
 
 	/**
 	 * Loads this object's properties from the database given an id
@@ -1164,9 +1025,6 @@ class SwatDBDataObject extends SwatObject implements
 		}
 		return null;
 	}
-
-	// }}}
-	// {{{ protected function saveInternal()
 
 	/**
 	 * Saves this object to the database
@@ -1248,9 +1106,6 @@ class SwatDBDataObject extends SwatObject implements
 		$this->flushCacheNamespaces();
 	}
 
-	// }}}
-	// {{{ protected function saveInternalProperties()
-
 	protected function saveInternalProperties()
 	{
 		foreach ($this->internal_property_autosave as $name => $autosave) {
@@ -1261,9 +1116,6 @@ class SwatDBDataObject extends SwatObject implements
 			}
 		}
 	}
-
-	// }}}
-	// {{{ protected function saveSubDataObjects()
 
 	protected function saveSubDataObjects()
 	{
@@ -1292,9 +1144,6 @@ class SwatDBDataObject extends SwatObject implements
 		}
 	}
 
-	// }}}
-	// {{{ protected function deleteInternal()
-
 	/**
 	 * Deletes this object from the database
 	 */
@@ -1322,9 +1171,6 @@ class SwatDBDataObject extends SwatObject implements
 
 	}
 
-	// }}}
-	// {{{ protected function saveNewBinding()
-
 	/**
 	 * Saves a new binding object without an id to the database
 	 *
@@ -1351,9 +1197,6 @@ class SwatDBDataObject extends SwatObject implements
 		$this->flushCacheNamespaces();
 	}
 
-	// }}}
-	// {{{ protected function guessType()
-
 	protected function guessType($name, $value)
 	{
 		switch (gettype($value)) {
@@ -1372,9 +1215,6 @@ class SwatDBDataObject extends SwatObject implements
 		}
 	}
 
-	// }}}
-	// {{{ protected function rollback()
-
 	protected function rollback(
 		SwatDBTransaction $transaction,
 		array $rollback_property_hashes
@@ -1383,10 +1223,7 @@ class SwatDBDataObject extends SwatObject implements
 		$transaction->rollback();
 	}
 
-	// }}}
-
 	// cache flushing
-	// {{{ public function setFlushableCache()
 
 	/**
 	 * Sets the flushable cache to use for this dataobject
@@ -1402,9 +1239,6 @@ class SwatDBDataObject extends SwatObject implements
 		$this->flushable_cache = $cache;
 	}
 
-	// }}}
-	// {{{ public function getCacheNamespaces()
-
 	/**
 	 * Gets the name-spaces that should be flushed for this dataobject.
 	 *
@@ -1414,9 +1248,6 @@ class SwatDBDataObject extends SwatObject implements
 	{
 		return array();
 	}
-
-	// }}}
-	// {{{ public function getAvailableCacheNamespaces()
 
 	/**
 	 * Gets all available name-spaces that should be flushed for this dataobject
@@ -1428,9 +1259,6 @@ class SwatDBDataObject extends SwatObject implements
 	{
 		return array();
 	}
-
-	// }}}
-	// {{{ public function flushCacheNamespaces()
 
 	/**
 	 * Flushes the cache name-spaces for this object.
@@ -1457,9 +1285,6 @@ class SwatDBDataObject extends SwatObject implements
 		}
 	}
 
-	// }}}
-	// {{{ public function flushAvailableCacheNamespaces()
-
 	/**
 	 * Flushes all possible cache name-spaces for this object.
 	 *
@@ -1473,10 +1298,7 @@ class SwatDBDataObject extends SwatObject implements
 		$this->flushCacheNamespaces($namespaces);
 	}
 
-	// }}}
-
 	// serialization
-	// {{{ public function serialize()
 
 	public function serialize()
 	{
@@ -1520,9 +1342,6 @@ class SwatDBDataObject extends SwatObject implements
 
 		return $serialized_data;
 	}
-
-	// }}}
-	// {{{ public function unserialize()
 
 	public function unserialize($data)
 	{
@@ -1571,9 +1390,6 @@ class SwatDBDataObject extends SwatObject implements
 			}
 		}
 	}
-
-	// }}}
-	// {{{ public function marshall()
 
 	public function marshall(array $tree = array())
 	{
@@ -1643,9 +1459,6 @@ class SwatDBDataObject extends SwatObject implements
 		return $data;
 	}
 
-	// }}}
-	// {{{ public function unmarshall()
-
 	public function unmarshall(array $data = array())
 	{
 		// public properties
@@ -1703,24 +1516,15 @@ class SwatDBDataObject extends SwatObject implements
 		}
 	}
 
-	// }}}
-	// {{{ protected function wakeup()
-
 	protected function wakeup()
 	{
 		$this->class_map = SwatDBClassMap::instance();
 	}
 
-	// }}}
-	// {{{ protected function getSerializableSubDataObjects()
-
 	protected function getSerializableSubDataObjects()
 	{
 		return array();
 	}
-
-	// }}}
-	// {{{ protected function getSerializablePrivateProperties()
 
 	protected function getSerializablePrivateProperties()
 	{
@@ -1735,7 +1539,6 @@ class SwatDBDataObject extends SwatObject implements
 		);
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDBDefaultRecordsetWrapper.php
+++ b/SwatDB/SwatDBDefaultRecordsetWrapper.php
@@ -11,7 +11,6 @@
  */
 class SwatDBDefaultRecordsetWrapper extends SwatDBRecordsetWrapper
 {
-	// {{{ public function __construct()
 
 	public function __construct($rs = null)
 	{
@@ -19,7 +18,6 @@ class SwatDBDefaultRecordsetWrapper extends SwatDBRecordsetWrapper
 		parent::__construct($rs);
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDBField.php
+++ b/SwatDB/SwatDBField.php
@@ -11,7 +11,6 @@
  */
 class SwatDBField extends SwatObject
 {
-	// {{{ public properties
 
 	/**
 	 * The name of the database field
@@ -28,9 +27,6 @@ class SwatDBField extends SwatObject
 	 * @var string
 	 */
 	public $type;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * @param string $field A string representation of a database field in the
@@ -54,9 +50,6 @@ class SwatDBField extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ public function __toString()
-
 	/**
 	 * Get the field as a string
 	 *
@@ -69,7 +62,6 @@ class SwatDBField extends SwatObject
 		return $this->type.':'.$this->name;
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDBFlushable.php
+++ b/SwatDB/SwatDBFlushable.php
@@ -9,7 +9,6 @@
  */
 interface SwatDBFlushable
 {
-	// {{{ public function setFlushableCache()
 
 	/**
 	 * Sets the flushable cache to use for this object
@@ -20,7 +19,6 @@ interface SwatDBFlushable
 	 */
 	public function setFlushableCache(SwatDBCacheNsFlushable $cache);
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDBMarshallable.php
+++ b/SwatDB/SwatDBMarshallable.php
@@ -16,7 +16,6 @@
  */
 interface SwatDBMarshallable
 {
-	// {{{ public function marshall()
 
 	/**
 	 * Marshalls this object
@@ -44,9 +43,6 @@ interface SwatDBMarshallable
 	 */
 	public function marshall(array $tree = array());
 
-	// }}}
-	// {{{ public function unmarshall()
-
 	/**
 	 * Unmarshalls this object using the specified data
 	 *
@@ -60,7 +56,6 @@ interface SwatDBMarshallable
 	 */
 	public function unmarshall(array $data = array());
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDBRange.php
+++ b/SwatDB/SwatDBRange.php
@@ -18,7 +18,6 @@
  */
 class SwatDBRange extends SwatObject
 {
-	// {{{ private properties
 
 	/**
 	 * The limit of this range
@@ -38,9 +37,6 @@ class SwatDBRange extends SwatObject
 	 */
 	private $offset;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new database range
 	 *
@@ -54,9 +50,6 @@ class SwatDBRange extends SwatObject
 		$this->offset = intval($offset);
 	}
 
-	// }}}
-	// {{{ public function getLimit()
-
 	/**
 	 * Gets the limit of this range
 	 *
@@ -66,9 +59,6 @@ class SwatDBRange extends SwatObject
 	{
 		return $this->limit;
 	}
-
-	// }}}
-	// {{{ public function getOffset()
 
 	/**
 	 * Gets the offset of this range
@@ -80,9 +70,6 @@ class SwatDBRange extends SwatObject
 		return $this->offset;
 	}
 
-	// }}}
-	// {{{ public function addOffset()
-
 	/**
 	 * Increases the offset of this range
 	 *
@@ -92,9 +79,6 @@ class SwatDBRange extends SwatObject
 	{
 		$this->offset += intval($offset);
 	}
-
-	// }}}
-	// {{{ public function combine()
 
 	/**
 	 * Combines this range with another range forming a new range
@@ -131,7 +115,6 @@ class SwatDBRange extends SwatObject
 		return new SwatDBRange($limit, $offset);
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDBReadaheadIterator.php
+++ b/SwatDB/SwatDBReadaheadIterator.php
@@ -24,7 +24,6 @@
  */
 class SwatDBReadaheadIterator extends SwatObject
 {
-	// {{{ private properties
 
 	/**
 	 * The iterator object being iterated
@@ -46,9 +45,6 @@ class SwatDBReadaheadIterator extends SwatObject
 	 * @var mixed
 	 */
 	private $key;
-
-	// }}}
-	// {{{ public function __construct()
 
 	/**
 	 * Creates a new readahead iterator
@@ -74,9 +70,6 @@ class SwatDBReadaheadIterator extends SwatObject
 		$this->rewind();
 	}
 
-	// }}}
-	// {{{ public function getCurrent()
-
 	/**
 	 * Gets the current item
 	 *
@@ -88,9 +81,6 @@ class SwatDBReadaheadIterator extends SwatObject
 	{
 		return $this->current;
 	}
-
-	// }}}
-	// {{{ public function getKey()
 
 	/**
 	 * Gets the key of the current item
@@ -104,9 +94,6 @@ class SwatDBReadaheadIterator extends SwatObject
 	{
 		return $this->key;
 	}
-
-	// }}}
-	// {{{ public function getNext()
 
 	/**
 	 * Gets the next item
@@ -122,9 +109,6 @@ class SwatDBReadaheadIterator extends SwatObject
 		return ($this->isLast()) ? null : $this->iterator->current();
 	}
 
-	// }}}
-	// {{{ public function getNextKey()
-
 	/**
 	 * Gets the next item key
 	 *
@@ -138,9 +122,6 @@ class SwatDBReadaheadIterator extends SwatObject
 		return ($this->isLast()) ? null : $this->iterator->key();
 	}
 
-	// }}}
-	// {{{ public function isLast()
-
 	/**
 	 * Gets whether the current item is the last item
 	 *
@@ -151,9 +132,6 @@ class SwatDBReadaheadIterator extends SwatObject
 	{
 		return (!$this->iterator->valid());
 	}
-
-	// }}}
-	// {{{ public function iterate()
 
 	/**
 	 * Iterates over this readahead iterator
@@ -174,9 +152,6 @@ class SwatDBReadaheadIterator extends SwatObject
 		return $valid;
 	}
 
-	// }}}
-	// {{{ public function rewind()
-
 	/**
 	 * Rewinds this readahead iterator back to the start
 	 */
@@ -187,7 +162,6 @@ class SwatDBReadaheadIterator extends SwatObject
 		$this->key = null;
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDBRecordable.php
+++ b/SwatDB/SwatDBRecordable.php
@@ -9,7 +9,6 @@
  */
 interface SwatDBRecordable
 {
-	// {{{ public function setDatabase()
 
 	/**
 	 * Sets the database driver to use for this object
@@ -23,16 +22,10 @@ interface SwatDBRecordable
 	 */
 	public function setDatabase(MDB2_Driver_Common $db, array $set = array());
 
-	// }}}
-	// {{{ public function save()
-
 	/**
 	 * Saves this object to the database
 	 */
 	public function save();
-
-	// }}}
-	// {{{ public function load()
 
 	/**
 	 * Loads this object from the database
@@ -45,16 +38,10 @@ interface SwatDBRecordable
 	 */
 	public function load($data);
 
-	// }}}
-	// {{{ public function delete()
-
 	/**
 	 * Deletes this object from the database
 	 */
 	public function delete();
-
-	// }}}
-	// {{{ public function isModified()
 
 	/**
 	 * Gets whether or not this object is modified
@@ -63,7 +50,6 @@ interface SwatDBRecordable
 	 */
 	public function isModified();
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDBRecordsetWrapper.php
+++ b/SwatDB/SwatDBRecordsetWrapper.php
@@ -23,7 +23,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 	implements Serializable, ArrayAccess, SwatTableModel, SwatDBRecordable,
 	SwatDBMarshallable, SwatDBFlushable
 {
-	// {{{ protected properties
 
 	/**
 	 * The name of the row wrapper class to use for this recordset wrapper
@@ -57,9 +56,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 	 * @see SwatDBRecordsetWrapper::setOptions()
 	 */
 	protected $options = array();
-
-	// }}}
-	// {{{ private properties
 
 	/**
 	 * Records contained in this recordset
@@ -100,9 +96,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 	 */
 	private $current_index = 0;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Creates a new recordset wrapper
 	 *
@@ -122,9 +115,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 			$this->initializeFromResultSet($rs);
 		}
 	}
-
-	// }}}
-	// {{{ public function initializeFromResultSet()
 
 	public function initializeFromResultSet(MDB2_Result_Common $rs)
 	{
@@ -156,9 +146,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		} while ($rs->nextResult());
 	}
 
-	// }}}
-	// {{{ public function duplicate()
-
 	/**
 	 * Duplicates this record set wrapper
 	 *
@@ -181,9 +168,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 
 		return $new_wrapper;
 	}
-
-	// }}}
-	// {{{ public function setOptions()
 
 	/**
 	 * Sets one or more options for this recordset wrapper
@@ -224,9 +208,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return $this;
 	}
 
-	// }}}
-	// {{{ public function getOption()
-
 	/**
 	 * Gets an option value or a default value if the option is not set
 	 *
@@ -248,9 +229,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return $value;
 	}
 
-	// }}}
-	// {{{ public function copyEmpty()
-
 	/**
 	 * Creates a new empty copy of this recordset wrapper
 	 *
@@ -267,9 +245,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 
 		return $wrapper;
 	}
-
-	// }}}
-	// {{{ protected function instantiateRowWrapperObject()
 
 	/**
 	 * Creates a new dataobject
@@ -294,9 +269,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return $object;
 	}
 
-	// }}}
-	// {{{ protected function init()
-
 	/**
 	 * Initializes this recordset wrapper
 	 *
@@ -315,9 +287,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 	{
 	}
 
-	// }}}
-	// {{{ protected function checkDB()
-
 	protected function checkDB()
 	{
 		if ($this->db === null)
@@ -326,10 +295,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 					'Call the setDatabase method.', get_class($this)));
 	}
 
-	// }}}
-
 	// array access
-	// {{{ public function offsetExists()
 
 	/**
 	 * Gets whether or not a value exists for the given offset
@@ -348,9 +314,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 
 		return isset($this->objects_by_index[$offset]);
 	}
-
-	// }}}
-	// {{{ public function offsetGet()
 
 	/**
 	 * Gets a record in this recordset by an offset value
@@ -377,9 +340,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 
 		return $this->objects_by_index[$offset];
 	}
-
-	// }}}
-	// {{{ public function offsetSet()
 
 	/**
 	 * Sets a record at a specified offset
@@ -465,9 +425,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 			unset($this->removed_objects[$key]);
 	}
 
-	// }}}
-	// {{{ public function offsetUnset()
-
 	/**
 	 * Unsets a record in this recordset at the specified offset
 	 *
@@ -512,10 +469,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		}
 	}
 
-	// }}}
-
 	// iteration
-	// {{{ public function current()
 
 	/**
 	 * Returns the current element
@@ -526,9 +480,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 	{
 		return $this->objects[$this->current_index];
 	}
-
-	// }}}
-	// {{{ public function key()
 
 	/**
 	 * Returns the key of the current record
@@ -550,9 +501,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return $key;
 	}
 
-	// }}}
-	// {{{ public function next()
-
 	/**
 	 * Moves forward to the next element
 	 */
@@ -561,9 +509,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		$this->current_index++;
 	}
 
-	// }}}
-	// {{{ public function rewind()
-
 	/**
 	 * Rewinds this iterator to the first element
 	 */
@@ -571,9 +516,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 	{
 		$this->current_index = 0;
 	}
-
-	// }}}
-	// {{{ public function valid()
 
 	/**
 	 * Checks is there is a current element after calls to rewind() and next()
@@ -586,10 +528,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return array_key_exists($this->current_index, $this->objects);
 	}
 
-	// }}}
-
 	// counting
-	// {{{ public function getCount()
 
 	/**
 	 * Gets the number of records in this recordset
@@ -604,9 +543,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return count($this);
 	}
 
-	// }}}
-	// {{{ public function count()
-
 	/**
 	 * Gets the number of records in this recordset
 	 *
@@ -619,10 +555,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return count($this->objects);
 	}
 
-	// }}}
-
 	// serialization
-	// {{{ public function serialize()
 
 	public function serialize()
 	{
@@ -643,9 +576,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return serialize($data);
 	}
 
-	// }}}
-	// {{{ public function unserialize()
-
 	public function unserialize($data)
 	{
 		$data = unserialize($data);
@@ -654,9 +584,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 			$this->$property = $value;
 		}
 	}
-
-	// }}}
-	// {{{ public function marshall()
 
 	public function marshall(array $tree = array())
 	{
@@ -683,9 +610,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 
 		return $data;
 	}
-
-	// }}}
-	// {{{ public function unmarshall()
 
 	public function unmarshall(array $data = array())
 	{
@@ -720,10 +644,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 
 	}
 
-	// }}}
-
 	// manipulating of sub data objects
-	// {{{ public function getInternalValues()
 
 	/**
 	 * Gets the values of an internal property for each record in this set
@@ -754,9 +675,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 
 		return $values;
 	}
-
-	// }}}
-	// {{{ public function loadAllSubDataObjects()
 
 	/**
 	 * Loads all sub-data-objects for an internal property of the data-objects
@@ -807,9 +725,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return $sub_data_objects;
 	}
 
-	// }}}
-	// {{{ public function attachSubDataObjects()
-
 	/**
 	 * Attach existing sub-dataobjects for an internal property of the
 	 * dataobjects in this recordset
@@ -837,10 +752,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		}
 	}
 
-	// }}}
-
 	// manipulating of sub-recordsets
-	// {{{ public function loadAllSubRecordsets()
 
 	/**
 	 * Efficiently loads sub-recordsets for records in this recordset
@@ -931,9 +843,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		);
 	}
 
-	// }}}
-	// {{{ public function attachSubRecordset()
-
 	/**
 	 * Efficiently loads sub-recordsets for records in this recordset
 	 *
@@ -992,10 +901,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return $recordset;
 	}
 
-	// }}}
-
 	// manipulating of objects
-	// {{{ public function getIndexes()
 
 	/**
 	 * Gets the index values of the records in this recordset
@@ -1014,9 +920,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return array_keys($this->objects_by_index);
 	}
 
-	// }}}
-	// {{{ public function getArray()
-
 	/**
 	 * Gets this recordset as an array of objects
 	 *
@@ -1027,9 +930,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 	{
 		return $this->objects;
 	}
-
-	// }}}
-	// {{{ public function getFirst()
 
 	/**
 	 * Retrieves the first object in this recordset
@@ -1047,9 +947,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return $first;
 	}
 
-	// }}}
-	// {{{ public function getLast()
-
 	/**
 	 * Retrieves the last object in this recordset
 	 *
@@ -1066,9 +963,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 
 		return $last;
 	}
-
-	// }}}
-	// {{{ public function getByIndex()
 
 	/**
 	 * Retrieves a record in this recordset by index
@@ -1093,9 +987,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return (isset($this[$index])) ? $this[$index] : null;
 	}
 
-	// }}}
-	// {{{ public function add()
-
 	/**
 	 * Adds a record to this recordset
 	 *
@@ -1113,9 +1004,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 	{
 		$this[] = $object;
 	}
-
-	// }}}
-	// {{{ public function remove()
 
 	/**
 	 * Removes a record from this recordset
@@ -1146,9 +1034,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ public function removeByIndex()
-
 	/**
 	 * Removes a record from this recordset given the record's index value
 	 *
@@ -1168,9 +1053,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		unset($this[$index]);
 	}
 
-	// }}}
-	// {{{ public function removeAll()
-
 	/**
 	 * Removes all records from this recordset
 	 */
@@ -1181,9 +1063,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		$this->objects_by_index = array();
 		$this->current_index = 0;
 	}
-
-	// }}}
-	// {{{ public function reindex()
 
 	/**
 	 * Reindexes this recordset
@@ -1202,9 +1081,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 					$this->objects_by_index[$object->$index_field] = $object;
 		}
 	}
-
-	// }}}
-	// {{{ public function getPropertyValues()
 
 	/**
 	 * Gets the values of a property for each record in this set
@@ -1236,10 +1112,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return $values;
 	}
 
-	// }}}
-
 	// database loading and saving
-	// {{{ public function setDatabase()
 
 	/**
 	 * Sets the database driver for this recordset
@@ -1272,9 +1145,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 			}
 		}
 	}
-
-	// }}}
-	// {{{ public function save()
 
 	/**
 	 * Saves this recordset to the database
@@ -1312,9 +1182,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		$this->removed_objects = array();
 		$this->reindex();
 	}
-
-	// }}}
-	// {{{ public function load()
 
 	/**
 	 * Loads a set of records into this recordset
@@ -1385,9 +1252,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return $success;
 	}
 
-	// }}}
-	// {{{ public function delete()
-
 	/**
 	 * Deletes this recordset from the database
 	 *
@@ -1399,9 +1263,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		$this->removeAll();
 		$this->save();
 	}
-
-	// }}}
-	// {{{ public function isModified()
 
 	/**
 	 * Returns true if this recordset has been modified since it was loaded
@@ -1425,9 +1286,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		return false;
 	}
 
-	// }}}
-	// {{{ public function setFlushableCache()
-
 	/**
 	 * Sets the flushable cache to use for this record-set
 	 *
@@ -1446,7 +1304,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/SwatDBTransaction.php
+++ b/SwatDB/SwatDBTransaction.php
@@ -22,7 +22,6 @@
  */
 class SwatDBTransaction extends SwatObject
 {
-	// {{{ private properties
 
 	/**
 	 * The database driver object to perform the transaction with
@@ -49,9 +48,6 @@ class SwatDBTransaction extends SwatObject
 	 */
 	private $finished;
 
-	// }}}
-	// {{{ public function __construct()
-
 	/**
 	 * Begins a new database transaction
 	 *
@@ -68,9 +64,6 @@ class SwatDBTransaction extends SwatObject
 		if (!$this->in_another_transaction)
 			$this->db->beginTransaction();
 	}
-
-	// }}}
-	// {{{ public function commit()
 
 	/**
 	 * Commits this database transaction
@@ -93,9 +86,6 @@ class SwatDBTransaction extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ public function rollback()
-
 	/**
 	 * Rolls-back this database transaction
 	 *
@@ -117,7 +107,6 @@ class SwatDBTransaction extends SwatObject
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/exceptions/SwatDBException.php
+++ b/SwatDB/exceptions/SwatDBException.php
@@ -9,7 +9,6 @@
  */
 class SwatDBException extends SwatException
 {
-	// {{{ private function ___construct()
 
 	public function __construct($message = null, $code = 0)
 	{
@@ -23,7 +22,6 @@ class SwatDBException extends SwatException
 		parent::__construct($message, $code);
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatDB/exceptions/SwatDBMarshallException.php
+++ b/SwatDB/exceptions/SwatDBMarshallException.php
@@ -10,15 +10,11 @@
  */
 class SwatDBMarshallException extends SwatDBException
 {
-	// {{{ protected properties
 
 	/**
 	 * @var string
 	 */
 	protected $property = '';
-
-	// }}}
-	// {{{ public function __construct()
 
 	public function __construct($message, $code = 0, $property = '')
 	{
@@ -26,15 +22,11 @@ class SwatDBMarshallException extends SwatDBException
 		$this->property = $property;
 	}
 
-	// }}}
-	// {{{ public function getProperty()
-
 	public function getProperty()
 	{
 		return $this->property;
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatI18N/SwatI18NCurrencyFormat.php
+++ b/SwatI18N/SwatI18NCurrencyFormat.php
@@ -11,7 +11,6 @@
  */
 class SwatI18NCurrencyFormat extends SwatI18NNumberFormat
 {
-	// {{{ public properties
 
 	/**
 	 * Number of fractional digits
@@ -111,9 +110,6 @@ class SwatI18NCurrencyFormat extends SwatI18NNumberFormat
 	 */
 	public $symbol;
 
-	// }}}
-	// {{{ public function __toString()
-
 	/**
 	 * Gets a string representation of this format
 	 *
@@ -154,7 +150,6 @@ class SwatI18NCurrencyFormat extends SwatI18NNumberFormat
 		return $string;
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatI18N/SwatI18NLocale.php
+++ b/SwatI18N/SwatI18NLocale.php
@@ -12,7 +12,6 @@
  */
 class SwatI18NLocale extends SwatObject
 {
-	// {{{ protected properties
 
 	/**
 	 * The locale string or array specified in the constructor for this locale
@@ -69,9 +68,6 @@ class SwatI18NLocale extends SwatObject
 	 */
 	protected $old_locale_by_category = array();
 
-	// }}}
-	// {{{ private properties
-
 	/**
 	 * Cache of existing locale objects
 	 *
@@ -83,9 +79,6 @@ class SwatI18NLocale extends SwatObject
 	 * @see SwatI18NLocale::get()
 	 */
 	private static $locales = array();
-
-	// }}}
-	// {{{ public static function get()
 
 	/**
 	 * Gets a locale object
@@ -142,9 +135,6 @@ class SwatI18NLocale extends SwatObject
 		return $locale_object;
 	}
 
-	// }}}
-	// {{{ public static function setlocale()
-
 	/**
 	 * Sets the current locale
 	 *
@@ -198,9 +188,6 @@ class SwatI18NLocale extends SwatObject
 		return $return;
 	}
 
-	// }}}
-	// {{{ public function set()
-
 	/**
 	 * Sets the system locale to this locale
 	 *
@@ -217,9 +204,6 @@ class SwatI18NLocale extends SwatObject
 		self::setlocale($category, $this->locale);
 	}
 
-	// }}}
-	// {{{ public function reset()
-
 	/**
 	 * Resets the system to the previous locale after a call to
 	 * {@link SwatI18NLocale::set()}
@@ -233,9 +217,6 @@ class SwatI18NLocale extends SwatObject
 	{
 		self::setlocale($category, $this->old_locale_by_category[$category]);
 	}
-
-	// }}}
-	// {{{ public function formatCurrency()
 
 	/**
 	 * Formats a monetary value for this locale
@@ -442,9 +423,6 @@ class SwatI18NLocale extends SwatObject
 		return $formatted_value;
 	}
 
-	// }}}
-	// {{{ public function formatNumber()
-
 	/**
 	 * Formats a numeric value for this locale
 	 *
@@ -496,9 +474,6 @@ class SwatI18NLocale extends SwatObject
 		return $formatted_value;
 	}
 
-	// }}}
-	// {{{ public function parseCurrency()
-
 	/**
 	 * Parses a currency string formatted for this locale into a floating-point
 	 * number
@@ -546,9 +521,6 @@ class SwatI18NLocale extends SwatObject
 		return $value;
 	}
 
-	// }}}
-	// {{{ public function parseFloat()
-
 	/**
 	 * Parses a numeric string formatted for this locale into a floating-point
 	 * number
@@ -592,9 +564,6 @@ class SwatI18NLocale extends SwatObject
 
 		return $value;
 	}
-
-	// }}}
-	// {{{ public function parseInteger()
 
 	/**
 	 * Parses a numeric string formatted for this locale into an integer number
@@ -660,9 +629,6 @@ class SwatI18NLocale extends SwatObject
 		return $value;
 	}
 
-	// }}}
-	// {{{ public function getNumberFormat()
-
 	/**
 	 * Gets the number format for this locale
 	 *
@@ -674,9 +640,6 @@ class SwatI18NLocale extends SwatObject
 	{
 		return clone $this->number_format;
 	}
-
-	// }}}
-	// {{{ public function getNationalCurrencyFormat()
 
 	/**
 	 * Gets the national currency format for this locale
@@ -690,9 +653,6 @@ class SwatI18NLocale extends SwatObject
 		return clone $this->national_currency_format;
 	}
 
-	// }}}
-	// {{{ public function getInternationalCurrencyFormat()
-
 	/**
 	 * Gets the international currency format for this locale
 	 *
@@ -704,9 +664,6 @@ class SwatI18NLocale extends SwatObject
 	{
 		return clone $this->international_currency_format;
 	}
-
-	// }}}
-	// {{{ public function getInternationalCurrencySymbol()
 
 	/**
 	 * Gets the international currency symbol of this locale
@@ -725,9 +682,6 @@ class SwatI18NLocale extends SwatObject
 		return $symbol;
 	}
 
-	// }}}
-	// {{{ public function getLocaleInfo()
-
 	/**
 	 * Gets numeric formatting information for this locale
 	 *
@@ -743,9 +697,6 @@ class SwatI18NLocale extends SwatObject
 		return $this->locale_info;
 	}
 
-	// }}}
-	// {{{ public function __toString()
-
 	/**
 	 * Gets a string representation of this locale
 	 *
@@ -757,9 +708,6 @@ class SwatI18NLocale extends SwatObject
 	{
 		return $this->preferred_locale;
 	}
-
-	// }}}
-	// {{{ protected function detectCharacterEncoding()
 
 	/**
 	 * Detects the character encoding used by this locale
@@ -809,9 +757,6 @@ class SwatI18NLocale extends SwatObject
 		return $encoding;
 	}
 
-	// }}}
-	// {{{ protected function buildLocaleInfo()
-
 	/**
 	 * Builds the locale info array for this locale
 	 */
@@ -845,9 +790,6 @@ class SwatI18NLocale extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ protected function buildNumberFormat()
-
 	/**
 	 * Builds the number format of this locale
 	 */
@@ -863,9 +805,6 @@ class SwatI18NLocale extends SwatObject
 
 		$this->number_format = $format;
 	}
-
-	// }}}
-	// {{{ protected function buildNationalCurrencyFormat()
 
 	/**
 	 * Builds the national currency format of this locale
@@ -907,9 +846,6 @@ class SwatI18NLocale extends SwatObject
 		$this->national_currency_format = $format;
 	}
 
-	// }}}
-	// {{{ protected function buildInternationalCurrencyFormat()
-
 	/**
 	 * Builds the internatiobal currency format for this locale
 	 */
@@ -937,9 +873,6 @@ class SwatI18NLocale extends SwatObject
 
 		$this->international_currency_format = $format;
 	}
-
-	// }}}
-	// {{{ protected function formatIntegerGroupings()
 
 	/**
 	 * Formats the integer part of a value according to format-specific numeric
@@ -1036,9 +969,6 @@ class SwatI18NLocale extends SwatObject
 		return $formatted_value;
 	}
 
-	// }}}
-	// {{{ protected function formatFractionalPart()
-
 	/**
 	 * Formats the fractional  part of a value
 	 *
@@ -1071,9 +1001,6 @@ class SwatI18NLocale extends SwatObject
 
 		return $formatted_value;
 	}
-
-	// }}}
-	// {{{ protected function parseNegativeNotation
 
 	/**
 	 * Parses the negative notation for a numeric string formatted in this
@@ -1149,9 +1076,6 @@ class SwatI18NLocale extends SwatObject
 		return $string;
 	}
 
-	// }}}
-	// {{{ protected function getFractionalPrecision()
-
 	/**
 	 * Gets the fractional precision of a floating point number
 	 *
@@ -1195,9 +1119,6 @@ class SwatI18NLocale extends SwatObject
 		return $precision;
 	}
 
-	// }}}
-	// {{{ protected function roundToEven()
-
 	/**
 	 * Rounds a number to the specified number of fractional digits using the
 	 * round-to-even rounding method
@@ -1232,9 +1153,6 @@ class SwatI18NLocale extends SwatObject
 
 		return $value;
 	}
-
-	// }}}
-	// {{{ private function __construct()
 
 	/**
 	 * Creates a new locale object
@@ -1280,9 +1198,6 @@ class SwatI18NLocale extends SwatObject
 		}
 	}
 
-	// }}}
-	// {{{ private function iconvArray()
-
 	/**
 	 * Recursivly converts the character encoding of all strings in an array
 	 *
@@ -1317,7 +1232,6 @@ class SwatI18NLocale extends SwatObject
 		return $array;
 	}
 
-	// }}}
 }
 
 ?>

--- a/SwatI18N/SwatI18NNumberFormat.php
+++ b/SwatI18N/SwatI18NNumberFormat.php
@@ -11,7 +11,6 @@
  */
 class SwatI18NNumberFormat extends SwatObject
 {
-	// {{{ public properties
 
 	/**
 	 * Decimal point character
@@ -33,9 +32,6 @@ class SwatI18NNumberFormat extends SwatObject
 	 * @var array
 	 */
 	public $grouping;
-
-	// }}}
-	// {{{ public function override()
 
 	/**
 	 * Gets a new number format object with certain properties overridden from
@@ -83,9 +79,6 @@ class SwatI18NNumberFormat extends SwatObject
 		return $new_format;
 	}
 
-	// }}}
-	// {{{ public function __toString()
-
 	/**
 	 * Gets a string representation of this format
 	 *
@@ -108,7 +101,6 @@ class SwatI18NNumberFormat extends SwatObject
 		return $string;
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/DemoApplication.php
+++ b/demo/include/DemoApplication.php
@@ -11,7 +11,6 @@
  */
 class DemoApplication
 {
-	// {{{ private properties
 
 	private $ui;
 	private $demo;
@@ -58,9 +57,6 @@ class DemoApplication
 		'YesNoFlydown'      => 'SwatYesNoFlydown',
 	);
 
-	// }}}
-	// {{{ public function run()
-
 	/**
 	 * test
 	 */
@@ -94,17 +90,11 @@ class DemoApplication
 		$this->buildLayout();
 	}
 
-	// }}}
-	// {{{ private function buildTitle()
-
 	private function buildTitle()
 	{
 		$this->layout_ui->getWidget('main_frame')->title =
 			sprintf(Swat::_('%s Demo'), $this->available_demos[$this->demo]);
 	}
-
-	// }}}
-	// {{{ private function buildDemo()
 
 	private function buildDemo()
 	{
@@ -122,9 +112,6 @@ class DemoApplication
 			}
 		}
 	}
-
-	// }}}
-	// {{{ private function buildXmlSourceView()
 
 	private function buildXmlSourceView()
 	{
@@ -144,9 +131,6 @@ class DemoApplication
 		}
 	}
 
-	// }}}
-	// {{{ private function buildPhpSourceView()
-
 	private function buildPhpSourceView()
 	{
 		$filename = '../include/demos/'.$this->demo.'Demo.php';
@@ -164,17 +148,11 @@ class DemoApplication
 		}
 	}
 
-	// }}}
-	// {{{ private function buildDemoMenuBar()
-
 	private function buildDemoMenuBar()
 	{
 		$this->layout_ui->getWidget('menu')->setEntries($this->available_demos);
 		$this->layout_ui->getWidget('menu')->setSelectedEntry($this->demo);
 	}
-
-	// }}}
-	// {{{ private function buildDemoNavBar()
 
 	private function buildDemoNavBar()
 	{
@@ -187,9 +165,6 @@ class DemoApplication
 			$navbar->addEntry(new SwatNavBarEntry('Swat Demos'));
 		}
 	}
-
-	// }}}
-	// {{{ private function buildDemoDocumentationMenuBar()
 
 	private function buildDemoDocumentationMenuBar()
 	{
@@ -447,9 +422,6 @@ class DemoApplication
 		$documentation_links->setEntries($entries);
 	}
 
-	// }}}
-	// {{{ private function buildFrontPage()
-
 	private function buildFrontPage()
 	{
 		$content_block = new SwatContentBlock();
@@ -462,9 +434,6 @@ class DemoApplication
 		$main_frame->title = 'Swat Demos';
 		$main_frame->add($content_block);
 	}
-
-	// }}}
-	// {{{ private function buildLayout()
 
 	private function buildLayout()
 	{
@@ -489,9 +458,6 @@ class DemoApplication
 		require '../include/layout.php';
 	}
 
-	// }}}
-	// {{{ private function getDemo()
-
 	/**
 	 * Gets the demo page
 	 */
@@ -506,7 +472,6 @@ class DemoApplication
 		return $demo;
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/ButtonDemo.php
+++ b/demo/include/demos/ButtonDemo.php
@@ -14,7 +14,6 @@ require_once 'Demo.php';
  */
 class ButtonDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -29,7 +28,6 @@ class ButtonDemo extends Demo
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/CalendarDemo.php
+++ b/demo/include/demos/CalendarDemo.php
@@ -14,7 +14,6 @@ require_once 'Demo.php';
  */
 class CalendarDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -32,7 +31,6 @@ class CalendarDemo extends Demo
 		);
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/ChangeOrderDemo.php
+++ b/demo/include/demos/ChangeOrderDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class ChangeOrderDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -28,7 +27,6 @@ class ChangeOrderDemo extends Demo
 			8 => 'Strawberry'));
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/CheckboxDemo.php
+++ b/demo/include/demos/CheckboxDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class CheckboxDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -101,7 +100,6 @@ class CheckboxDemo extends Demo
 		$checkbox_entry_list->addOptionsByArray($checkbox_entry_list_options);
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/DetailsViewDemo.php
+++ b/demo/include/demos/DetailsViewDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class DetailsViewDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -40,7 +39,6 @@ class DetailsViewDemo extends Demo
 		$details_view->data = $fruit;
 	}
 
-	// }}}
 }
 
 /**
@@ -52,7 +50,6 @@ class DetailsViewDemo extends Demo
  */
 class FruitObject
 {
-	// {{{ public properties
 
 	public $align = '';
 	public $image = '';
@@ -66,7 +63,6 @@ class FruitObject
 	public $cost = 0;
 	public $text = '';
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/DisclosureDemo.php
+++ b/demo/include/demos/DisclosureDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class DisclosureDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -36,7 +35,6 @@ class DisclosureDemo extends Demo
 		$ui->getWidget('note')->add($message, SwatMessageDisplay::DISMISS_OFF);
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/FieldsetDemo.php
+++ b/demo/include/demos/FieldsetDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class FieldsetDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -28,7 +27,6 @@ class FieldsetDemo extends Demo
 			8 => 'Strawberry'));
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/FlydownDemo.php
+++ b/demo/include/demos/FlydownDemo.php
@@ -15,7 +15,6 @@ require_once 'Demo.php';
  */
 class FlydownDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -134,7 +133,6 @@ class FlydownDemo extends Demo
 		);
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/MessageDisplayDemo.php
+++ b/demo/include/demos/MessageDisplayDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class MessageDisplayDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -58,7 +57,6 @@ class MessageDisplayDemo extends Demo
 		$long_message_display->add($message);
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/NavBarDemo.php
+++ b/demo/include/demos/NavBarDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class NavBarDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -21,7 +20,6 @@ class NavBarDemo extends Demo
 		$navbar->addEntry(new SwatNavBarEntry('NavBar'));
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/PaginationDemo.php
+++ b/demo/include/demos/PaginationDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class PaginationDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -24,7 +23,6 @@ class PaginationDemo extends Demo
 		$ui->getWidget('small')->setCurrentPage(50);
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/PasswordEntryDemo.php
+++ b/demo/include/demos/PasswordEntryDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class PasswordEntryDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -20,7 +19,6 @@ class PasswordEntryDemo extends Demo
 		$confirm_password->password_widget = $password;
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/ProgressBarDemo.php
+++ b/demo/include/demos/ProgressBarDemo.php
@@ -14,7 +14,6 @@ require_once 'Demo.php';
  */
 class ProgressBarDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -28,7 +27,6 @@ class ProgressBarDemo extends Demo
 		$ui->getWidget('note')->add($message, SwatMessageDisplay::DISMISS_OFF);
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/RadioListDemo.php
+++ b/demo/include/demos/RadioListDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class RadioListDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -75,7 +74,6 @@ class RadioListDemo extends Demo
 		$radiotable->addOption(new SwatOption(9, 'I don\'t like fruit'));
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/SelectListDemo.php
+++ b/demo/include/demos/SelectListDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class SelectListDemo extends Demo
 {
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -27,7 +26,6 @@ class SelectListDemo extends Demo
 		$select_list->addOptionsByArray($select_list_options);
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/StringDemo.php
+++ b/demo/include/demos/StringDemo.php
@@ -14,7 +14,6 @@ require_once 'Demo.php';
  */
 class StringDemo extends Demo
 {
-	// {{{ private properties
 
 	private $strings = array(
 		'Suspendisse potenti. Cras varius diam. Fusce mollis pharetra sapien. Curabitur vel tellus vel nisi luctus tempus.',
@@ -32,9 +31,6 @@ class StringDemo extends Demo
 	private $text_blocks = array();
 
 	private $unformatted_text_blocks = array();
-
-	// }}}
-	// {{{ public function buildDemoUI()
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -83,17 +79,11 @@ class StringDemo extends Demo
 		$to_xhtml->content = ob_get_clean();
 	}
 
-	// }}}
-	// {{{ protected function createLayout()
-
 	protected function createLayout()
 	{
 		return new SiteLayout($this->app,
 			'../include/layouts/xhtml/no-source.php');
 	}
-
-	// }}}
-	// {{{ private function testEllipsizeRight()
 
 	private function testEllipsizeRight($length = 20)
 	{
@@ -107,9 +97,6 @@ class StringDemo extends Demo
 		echo '</ol>';
 	}
 
-	// }}}
-	// {{{ private function testEllipsizeMIddle()
-
 	private function testEllipsizeMiddle($length = 20)
 	{
 		echo '<ol class="string-demo">';
@@ -121,9 +108,6 @@ class StringDemo extends Demo
 		}
 		echo '</ol>';
 	}
-
-	// }}}
-	// {{{ private function testCondense()
 
 	private function testCondense()
 	{
@@ -138,9 +122,6 @@ class StringDemo extends Demo
 		}
 	}
 
-	// }}}
-	// {{{ private function testCondenseToName()
-
 	private function testCondenseToName()
 	{
 		echo '<p>Condense to name can be used to condense a title into a name identifier.</p>';
@@ -154,9 +135,6 @@ class StringDemo extends Demo
 		}
 		echo '</ol>';
 	}
-
-	// }}}
-	// {{{ private function testToXHTML()
 
 	private function testToXHTML()
 	{
@@ -173,7 +151,6 @@ class StringDemo extends Demo
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/TableViewDemo.php
+++ b/demo/include/demos/TableViewDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class TableViewDemo extends Demo
 {
-	// {{{ public function buildDemoUI();
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -54,7 +53,6 @@ class TableViewDemo extends Demo
 		$table_view->model = $table_store;
 	}
 
-	// }}}
 }
 
 /**
@@ -66,7 +64,6 @@ class TableViewDemo extends Demo
  */
 class FruitObject
 {
-	// {{{ public properties
 
 	public $image = '';
 	public $image_width = 0;
@@ -78,7 +75,6 @@ class FruitObject
 	public $harvest_date = null;
 	public $cost = 0;
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/TableViewInputRowDemo.php
+++ b/demo/include/demos/TableViewInputRowDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class TableViewInputRowDemo extends Demo
 {
-	// {{{ public function buildDemoUI();
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -45,7 +44,6 @@ class TableViewInputRowDemo extends Demo
 		$table_view->model = $table_store;
 	}
 
-	// }}}
 }
 
 /**
@@ -57,13 +55,11 @@ class TableViewInputRowDemo extends Demo
  */
 class FruitObject
 {
-	// {{{ public properties
 
 	public $title = '';
 	public $makes_jam = false;
 	public $makes_pie = false;
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/TileViewDemo.php
+++ b/demo/include/demos/TileViewDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class TileViewDemo extends Demo
 {
-	// {{{ public function buildDemoUI();
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -106,7 +105,6 @@ class TileViewDemo extends Demo
 		$tile_view->model = $table_store;
 	}
 
-	// }}}
 }
 
 /**
@@ -118,7 +116,6 @@ class TileViewDemo extends Demo
  */
 class FruitObject
 {
-	// {{{ public properties
 
 	public $image = '';
 	public $image_width = 0;
@@ -130,7 +127,6 @@ class FruitObject
 	public $harvest_date = null;
 	public $cost = 0;
 
-	// }}}
 }
 
 ?>

--- a/demo/include/demos/ViewSelectorDemo.php
+++ b/demo/include/demos/ViewSelectorDemo.php
@@ -11,7 +11,6 @@ require_once 'Demo.php';
  */
 class ViewSelectorDemo extends Demo
 {
-	// {{{ public function buildDemoUI();
 
 	public function buildDemoUI(SwatUI $ui)
 	{
@@ -48,7 +47,6 @@ class ViewSelectorDemo extends Demo
 		$table_view->model = $table_store;
 	}
 
-	// }}}
 }
 
 /**
@@ -60,7 +58,6 @@ class ViewSelectorDemo extends Demo
  */
 class FruitObject
 {
-	// {{{ public properties
 
 	public $image = '';
 	public $image_width = 0;
@@ -72,7 +69,6 @@ class FruitObject
 	public $harvest_date = null;
 	public $cost = 0;
 
-	// }}}
 }
 
 ?>

--- a/demo/include/ui-objects/DemoDocumentationMenuBar.php
+++ b/demo/include/ui-objects/DemoDocumentationMenuBar.php
@@ -14,7 +14,6 @@ require_once 'DemoMenuBar.php';
  */
 class DemoDocumentationMenuBar extends DemoMenuBar
 {
-	// {{{ public function display()
 
 	public function display()
 	{
@@ -42,7 +41,6 @@ class DemoDocumentationMenuBar extends DemoMenuBar
 		}
 	}
 
-	// }}}
 }
 
 ?>

--- a/demo/include/ui-objects/DemoMenuBar.php
+++ b/demo/include/ui-objects/DemoMenuBar.php
@@ -12,13 +12,9 @@
  */
 class DemoMenuBar extends SwatControl
 {
-	// {{{ protected properties
 
 	protected $entries = array();
 	protected $selected_entry;
-
-	// }}}
-	// {{{ public function display()
 
 	public function display()
 	{
@@ -53,23 +49,16 @@ class DemoMenuBar extends SwatControl
 		$ul_tag->close();
 	}
 
-	// }}}
-	// {{{ public function setEntries()
-
 	public function setEntries(array $entries)
 	{
 		$this->entries = $entries;
 	}
-
-	// }}}
-	// {{{ public function setSelectedEntry()
 
 	public function setSelectedEntry($entry)
 	{
 		$this->selected_entry = $entry;
 	}
 
-	// }}}
 }
 
 ?>


### PR DESCRIPTION
Following commands were used to create this diff:

```
find . -type f -name '*.php' | xargs sed -i '\:^[\t]*// [{}]\{3\}.*$:d'
find . -type f -name '*.php' -exec ex -s -c '%s/\n\{3,}/\r\r/g' -cwq {} \;
```