### PR TITLE
Use consistent return type for loadAllSubDataObjects

### DIFF
--- a/SwatDB/SwatDBRecordsetWrapper.php
+++ b/SwatDB/SwatDBRecordsetWrapper.php
@@ -786,7 +786,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject
 		$wrapper,
 		$type = 'integer'
 	) {
-		$sub_data_objects = null;
+		$sub_data_objects = new $wrapper();
 
 		$values = $this->getInternalValues($name);
 		$values = array_filter($values,


### PR DESCRIPTION
This fixes a warning that appears where the result of `loadAllSubDataObjects` is assumed to be of type `$wrapper`, such as:

- The Kos admin account profile of anyone who has no referral rewards (eg https://hippostage.silverorange.com/pcrap/work-[me]/www/admin/Account/Details?id=3967fc88-d430-4774-974c-b8ee687ff3f4 )
- The Hippo admin dashboard page (eg https://hippostage.silverorange.com/hippo/work-[me]/www/admin/ )

Instead of returning `null`, returns an empty wrapper of the type provided.

<img width="1595" alt="screen shot 2018-10-19 at 2 44 00 pm" src="https://user-images.githubusercontent.com/169674/47245269-72957300-d3ad-11e8-84c6-fa5d9c69b86c.png">
