### PR TITLE
Make URI entry errors more consistent

### DIFF
--- a/Swat/SwatUriEntry.php
+++ b/Swat/SwatUriEntry.php
@@ -139,18 +139,27 @@ class SwatUriEntry extends SwatEntry
     {
         switch ($id) {
             case 'scheme-required':
-                $text = sprintf(
-                    Swat::_('“%s” must include a prefix (i.e. %s).'),
-                    $this->value,
-                    $this->default_scheme
-                );
+                $text = $this->show_field_title_in_messages
+                    ? sprintf(
+                        Swat::_(
+                            'The %%s field must include a prefix (e.g. %s).'
+                        ),
+                        $this->default_scheme
+                    )
+                    : sprintf(
+                        Swat::_('This field must include a prefix (e.g. %s).'),
+                        $this->default_scheme
+                    );
 
                 break;
             case 'invalid-uri':
-                $text = sprintf(
-                    Swat::_('“%s” is not a properly formatted address.'),
-                    $this->value
-                );
+                $text = $this->show_field_title_in_messages
+                    ? Swat::_(
+                        'The %s field is not a properly formatted address.'
+                    )
+                    : Swat::_(
+                        'This field is not a properly formatted address.'
+                    );
 
                 break;
             default:


### PR DESCRIPTION
https://airtable.com/tblHi2RES2ktb1XG9/viwmb7dI2vU5xjG6r/recWpAqZOzs3eY6UY?blocks=hide

Other entries reference the field name, not the value, and some values were causing the page to crash.

I tested the new errors using Hippo-EM and the Residency Website field on the resident checkout.

To trigger `invalid_uri`, enter `file:///C:/Users/calki/Downloads/Emergency%20Medicine%20Current%20Residents%202018%20-%20Wake%20Forest%20SOM%20(3).pdf`

To trigger `scheme_required`: in `hippo`, find `./pages/checkout-resident.xml` and remove line 37 (`<property name="scheme_required" type="boolean">false</property>`). Then enter `example.com`. 