### PR TITLE
Stop converting absolute links to relative

### DIFF
--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -268,7 +268,8 @@ class SwatTextareaEditor extends SwatTextarea
             'swat_modes_enabled' => $modes,
             'swat_image_server' => $image_server,
             'paste_remove_spans' => true,
-            'paste_remove_styles' => true
+            'paste_remove_styles' => true,
+            'convert_urls' => false
         );
 
         return $config;


### PR DESCRIPTION
https://airtable.com/tblHi2RES2ktb1XG9/viwmb7dI2vU5xjG6r/recu1CwLUxOhCk1vG?blocks=hide

I don't think we ever want to have the relative URLs so I changed the default behavior rather than making it a flag. Currently, any links that have the same `base_href` as the page that the editor is on is converted from an absolute link to a relative one. Since the editors are (almost always?) embedded in the admin and the content is (almost always?) displayed on the user-facing site, this breaks the links as they will be relative to the admin pages. E.g., `../episode/hippoercast/lrinecandthe` when the correct link would be `./episode/hippoercast/lrinecandthe`.

This patch changes the behavior of the TinyMCE editor to use the link as it is pasted in. This will allow the links to continue working regardless of where the content is ultimately displayed. 

To test, I used ERcast as an example and ran `gulp --symlinks=site`. Edit a chapter summary and paste a link sharing the same base URL. Then switch to the Source tab and verify that the full URL is shown. 