### PR TITLE
Increase the size of the Change Order widget

### DIFF
--- a/Swat/SwatChangeOrder.php
+++ b/Swat/SwatChangeOrder.php
@@ -32,14 +32,14 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
      *
      * @var string
      */
-    public $width = '300px';
+    public $width = '600px';
 
     /**
      * Height of the order box (in stylesheet units)
      *
      * @var string
      */
-    public $height = '180px';
+    public $height = '300px';
 
     // }}}
     // {{{ public function __construct()


### PR DESCRIPTION
This reduces text wrapping on items with long titles (horizontal) and reduces scrolling on long list (vertical) and still fits easily on most common desktop browser sizes.