### PR TITLE
Fix handling of disabled input options - should also be per-option, not just per list

### DIFF
--- a/Swat/SwatCheckboxList.php
+++ b/Swat/SwatCheckboxList.php
@@ -306,7 +306,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 
         $sensitive = $this->getOptionMetadata($option, 'sensitive');
         if (!$this->isSensitive() || !$sensitive) {
-            echo 'test';
             $input_tag->disabled = 'disabled';
         }
 

--- a/Swat/SwatCheckboxList.php
+++ b/Swat/SwatCheckboxList.php
@@ -4,7 +4,7 @@
  * A checkbox list widget
  *
  * @package   Swat
- * @copyright 2005-2016 silverorange
+ * @copyright 2005-2021 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class SwatCheckboxList extends SwatOptionControl implements SwatState
@@ -304,7 +304,9 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
             $input_tag->checked = 'checked';
         }
 
-        if (!$this->isSensitive()) {
+        $sensitive = $this->getOptionMetadata($option, 'sensitive');
+        if (!$this->isSensitive() || !$sensitive) {
+            echo 'test';
             $input_tag->disabled = 'disabled';
         }
 


### PR DESCRIPTION
We correctly do this with the li-tag https://github.com/silverorange/swat/blob/master/Swat/SwatCheckboxList.php#L359-L366

But for the input, it appears disabled with styles, but is still clickable