### PR TITLE
Fix handling of error_reporting() with @ operator:

### DIFF
--- a/Swat/SwatError.php
+++ b/Swat/SwatError.php
@@ -471,7 +471,7 @@ class SwatError
     public static function handle($errno, $errstr, $errfile, $errline)
     {
         // only handle error if error reporting is not suppressed
-        if (error_reporting() != 0) {
+        if (error_reporting() & $errno) {
             $error = new SwatError($errno, $errstr, $errfile, $errline);
             $error->process();
         }


### PR DESCRIPTION
Per https://www.php.net/manual/en/migration80.incompatible.php :
"The @ operator will no longer silence fatal errors (E_ERROR, E_CORE_ERROR,
E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR, E_PARSE). Error handlers
that expect error_reporting to be 0 when @ is used, should be adjusted to use a
mask check instead"

SwatError handle method updated to check state of error_reporting and $errno so
"error reporting is not suppressed" continues to logically work the same in
php8.