### PR TITLE
select all list-items in the tree, and not just the first branch

### DIFF
--- a/www/javascript/swat-checkbox-tree.js
+++ b/www/javascript/swat-checkbox-tree.js
@@ -25,7 +25,7 @@ function SwatCheckboxTree(id, maybeEffect) {
      * for each node in the tree.
      */
     function walk(container, parents, chain, effect) {
-        return Array.from(container.querySelectorAll(':scope > ul > li'))
+        return Array.from(container.querySelectorAll(':scope > ul li'))
             .map(function(item) {
                 return {
                     item,


### PR DESCRIPTION
## To Test:
 - Run `yarn start --symlinks=swat`
 - Go to https://berna.silverorange.com/emrap/work-nick/www/admin/Group/Purchase?group=549
 - Make to shift-refresh to use the latest JS
 - Try selecting all of the accounts. Before, none would select because the tree has two levels. Now they should all select.