### PR TITLE
Allow for list items with no checkbox to be walked

### DIFF
--- a/www/javascript/swat-checkbox-tree.js
+++ b/www/javascript/swat-checkbox-tree.js
@@ -25,7 +25,7 @@ function SwatCheckboxTree(id, maybeEffect) {
      * for each node in the tree.
      */
     function walk(container, parents, chain, effect) {
-        return Array.from(container.querySelectorAll(':scope > ul li'))
+        return Array.from(container.querySelectorAll(':scope > ul > li'))
             .map(function(item) {
                 return {
                     item,
@@ -34,27 +34,27 @@ function SwatCheckboxTree(id, maybeEffect) {
                     )
                 };
             })
-            .filter(function(obj) {
-                return obj.input !== null;
-            })
             .map(function(obj) {
                 const item = obj.item;
                 const input = obj.input;
+                const link = input !== null ? chain(input) : identity;
 
                 const children = walk(
                     item,
                     compose(
                         parents,
-                        chain(input)
+                        link
                     ),
                     chain,
                     effect
                 );
 
-                effect(input, parents, children);
+                if (input !== null) {
+                    effect(input, parents, children);
+                }
 
                 return compose(
-                    chain(input),
+                    link,
                     children
                 );
             })


### PR DESCRIPTION
## Change Summary

Before this change any item that didn’t have a checkbox would be
completely ignored by the walk function. As a result the function
returned by walk would not be able to manipulate that item or any of
that item’s decedents.

When a node with no checkbox was at the top of the tree all of that
node's children weren’t being walked over. This meant that widgets that
used the function built by walk would not work as expected. For example
the check all widget was not checking any item that lived below a node
with no checkbox. Instead of ignoring these items we now allow them to
be chained like regular nodes.

The previous fix selected all decedents of a node instead of the direct
children. This would cause the same nodes to be walked over and over
and over again which worked but is both inefficient and incongruent with
the rest of the code in SwatCheckboxTree. The walk function is recursive
so these decedents will be reached by subsequent recursive calls.