### PR TITLE
Remove more YUI code from Swat and replace with modern CSS or JS features

### DIFF
--- a/www/javascript/swat-abstract-overlay.js
+++ b/www/javascript/swat-abstract-overlay.js
@@ -172,7 +172,6 @@ class SwatAbstractOverlay {
   }
 
   showCloseDiv() {
-    this.close_div.style.height = YAHOO.util.Dom.getDocumentHeight() + 'px';
     this.close_div.style.display = 'block';
     SwatZIndexManager.raiseElement(this.close_div);
   }

--- a/www/javascript/swat-accordion.js
+++ b/www/javascript/swat-accordion.js
@@ -120,7 +120,7 @@ class SwatAccordion {
 
     // old_page === null means we're opening from a completely closed state
     if (old_page !== null) {
-      var old_region = YAHOO.util.Dom.getRegion(old_page.animation);
+      var old_region = old_page.animation.getBoundingClientRect();
       var old_from_height = old_region.height;
       var old_to_height = 0;
       old_page.animation.style.overflow = 'hidden';
@@ -151,7 +151,7 @@ class SwatAccordion {
 
       new_page.animation.style.display = 'block';
 
-      var new_region = YAHOO.util.Dom.getRegion(new_page.content);
+      var new_region = new_page.content.getBoundingClientRect();
       var new_to_height = new_region.height;
 
       var anim = new YAHOO.util.Anim(

--- a/www/javascript/swat-accordion.js
+++ b/www/javascript/swat-accordion.js
@@ -124,19 +124,29 @@ class SwatAccordion {
       var old_from_height = old_region.height;
       var old_to_height = 0;
       old_page.animation.style.overflow = 'hidden';
+
+      old_page.animation
+        .animate(
+          [
+            { height: old_from_height + 'px' },
+            { height: old_to_height + 'px' }
+          ],
+          {
+            duration: SwatAccordion.resize_period * 1000,
+            easing: 'ease-in-out'
+          }
+        )
+        .finished.then(() => {
+          this.semaphore = false;
+          old_page.animation.style.height = old_to_height;
+        });
+
+      old_page.setStatus('closed');
     }
 
     // new_page === null means we're closing to a completely closed state
-    if (new_page === null) {
-      var new_to_height = 0;
-
-      var anim = new YAHOO.util.Anim(
-        old_page.animation,
-        {},
-        SwatAccordion.resize_period,
-        YAHOO.util.Easing.easeBoth
-      );
-    } else {
+    if (new_page !== null) {
+      var new_from_height;
       new_page.animation.style.overflow = 'hidden';
 
       if (
@@ -144,9 +154,9 @@ class SwatAccordion {
         new_page.animation.style.height == 'auto'
       ) {
         new_page.animation.style.height = '0';
-        var new_from_height = 0;
+        new_from_height = 0;
       } else {
-        var new_from_height = parseInt(new_page.animation.style.height);
+        new_from_height = parseInt(new_page.animation.style.height);
       }
 
       new_page.animation.style.display = 'block';
@@ -154,55 +164,22 @@ class SwatAccordion {
       var new_region = new_page.content.getBoundingClientRect();
       var new_to_height = new_region.height;
 
-      var anim = new YAHOO.util.Anim(
-        new_page.animation,
-        {},
-        SwatAccordion.resize_period,
-        YAHOO.util.Easing.easeBoth
-      );
-    }
-
-    anim.onTween.subscribe(
-      function(name, data) {
-        if (old_page !== null) {
-          var old_height = Math.ceil(
-            anim.doMethod('height', old_from_height, old_to_height)
-          );
-
-          old_page.animation.style.height = old_height + 'px';
-        }
-
-        if (new_page !== null) {
-          var new_height = Math.floor(
-            anim.doMethod('height', new_from_height, new_to_height)
-          );
-
-          new_page.animation.style.height = new_height + 'px';
-        }
-      },
-      this,
-      true
-    );
-
-    anim.onComplete.subscribe(
-      function() {
-        if (new_page !== null) {
+      new_page.animation
+        .animate(
+          [
+            { height: new_from_height + 'px' },
+            { height: new_to_height + 'px' }
+          ],
+          {
+            duration: SwatAccordion.resize_period * 1000,
+            easing: 'ease-in-out'
+          }
+        )
+        .finished.then(() => {
+          this.semaphore = false;
           new_page.animation.style.height = 'auto';
-        }
+        });
 
-        this.semaphore = false;
-      },
-      this,
-      true
-    );
-
-    anim.animate();
-
-    if (old_page !== null) {
-      old_page.setStatus('closed');
-    }
-
-    if (new_page !== null) {
       new_page.setStatus('opened');
     }
 

--- a/www/javascript/swat-actions.js
+++ b/www/javascript/swat-actions.js
@@ -128,14 +128,14 @@ class SwatActions {
       this.message_span.style.opacity = 0;
       this.message_span.style.visibility = 'visible';
 
-      var animation = new YAHOO.util.Anim(
-        this.message_span,
-        { opacity: { from: 0, to: 1 } },
-        0.3,
-        YAHOO.util.Easing.easeInStrong
-      );
-
-      animation.animate();
+      this.message_span
+        .animate([{ opacity: 0 }, { opacity: 1 }], {
+          duration: 300,
+          easing: 'ease-in'
+        })
+        .finished.then(() => {
+          this.message_span.style.opacity = 1;
+        });
 
       this.message_shown = true;
     }
@@ -143,23 +143,16 @@ class SwatActions {
 
   hideMessage() {
     if (this.message_shown) {
-      var animation = new YAHOO.util.Anim(
-        this.message_span,
-        { opacity: { from: 1, to: 0 } },
-        0.3,
-        YAHOO.util.Easing.easeOutStrong
-      );
-
-      animation.onComplete.subscribe(
-        function() {
+      this.message_span
+        .animate([{ opacity: 1 }, { opacity: 0 }], {
+          duration: 300,
+          easing: 'ease-out'
+        })
+        .finished.then(() => {
+          this.message_span.style.opacity = 0;
           this.message_span.style.visibility = 'hidden';
           this.message_shown = false;
-        },
-        this,
-        true
-      );
-
-      animation.animate();
+        });
     }
   }
 }

--- a/www/javascript/swat-actions.js
+++ b/www/javascript/swat-actions.js
@@ -26,7 +26,8 @@ class SwatActions {
       document.createTextNode(SwatActions.dismiss_text)
     );
 
-    message_dismiss.addEventListener('click', () => {
+    message_dismiss.addEventListener('click', e => {
+      e.preventDefault();
       this.handleMessageClose();
     });
 
@@ -110,8 +111,7 @@ class SwatActions {
     }
   }
 
-  handleMessageClose(e) {
-    e.preventDefault();
+  handleMessageClose() {
     this.hideMessage();
   }
 

--- a/www/javascript/swat-button.js
+++ b/www/javascript/swat-button.js
@@ -59,14 +59,13 @@ class SwatButton {
   }
 
   showThrobber() {
-    var animation = new YAHOO.util.Anim(
-      this.throbber_container,
-      { opacity: { to: 0.5 } },
-      1,
-      YAHOO.util.Easing.easingNone
-    );
-
-    animation.animate();
+    this.throbber_container
+      .animate([{ opacity: 0.5 }], {
+        duration: 1000
+      })
+      .finished.then(() => {
+        this.throbber_container.style.opacity = 0.5;
+      });
   }
 
   setProcessingMessage(message) {

--- a/www/javascript/swat-change-order.js
+++ b/www/javascript/swat-change-order.js
@@ -99,7 +99,7 @@ class SwatChangeOrder {
 
         grippy = document.createElement('span');
         grippy.className = 'swat-change-order-item-grippy';
-        height = YAHOO.util.Dom.getRegion(node).height - 4;
+        height = node.getBoundingClientRect().height - 4;
         grippy.style.height = height + 'px';
         node.insertBefore(grippy, node.firstChild);
       }

--- a/www/javascript/swat-change-order.js
+++ b/www/javascript/swat-change-order.js
@@ -138,6 +138,14 @@ class SwatChangeOrder {
   static dragging_item = null;
   static is_dragging = false;
 
+  static getPageX(rect) {
+    return Math.floor(rect.left + window.scrollX);
+  }
+
+  static getPageY(rect) {
+    return Math.floor(rect.top + window.scrollY);
+  }
+
   /**
    * Handles moving a dragged item
    *
@@ -231,10 +239,12 @@ class SwatChangeOrder {
     var shadow_item = SwatChangeOrder.dragging_item;
     var list_div = shadow_item.original_item.parentNode;
 
-    var list_div_top = YAHOO.util.Dom.getY(list_div);
-    var middle =
-      YAHOO.util.Dom.getY(shadow_item) +
-      Math.floor(shadow_item.offsetHeight / 2);
+    var list_rect = list_div.getBoundingClientRect();
+    var shadow_rect = shadow_item.getBoundingClientRect();
+
+    var list_div_top = SwatChangeOrder.getPageY(list_rect);
+    var shadow_div_top = SwatChangeOrder.getPageY(shadow_rect);
+    var middle = shadow_div_top + Math.floor(shadow_rect.height / 2);
 
     // top hot spot scrolls list up
     if (
@@ -288,16 +298,19 @@ class SwatChangeOrder {
     var drop_marker = SwatChangeOrder.dragging_drop_marker;
     var list_div = shadow_item.original_item.parentNode;
 
+    var list_rect = list_div.getBoundingClientRect();
+    var shadow_rect = shadow_item.getBoundingClientRect();
+
     var y_middle =
-      YAHOO.util.Dom.getY(shadow_item) +
-      Math.floor(shadow_item.offsetHeight / 2) -
-      YAHOO.util.Dom.getY(list_div) +
+      SwatChangeOrder.getPageY(shadow_rect) +
+      Math.floor(shadow_rect.height / 2) -
+      SwatChangeOrder.getPageY(list_rect) +
       list_div.scrollTop;
 
     var x_middle =
-      YAHOO.util.Dom.getX(shadow_item) +
-      Math.floor(shadow_item.offsetWidth / 2) -
-      YAHOO.util.Dom.getX(list_div) +
+      SwatChangeOrder.getPageX(shadow_rect) +
+      Math.floor(shadow_rect.width / 2) -
+      SwatChangeOrder.getPageX(list_rect) +
       list_div.scrollLeft;
 
     var is_grid = shadow_item.original_item.controller.isGrid();
@@ -460,11 +473,13 @@ class SwatChangeOrder {
     shadow_item.className += ' swat-change-order-item-shadow';
     shadow_item.style.width = this.offsetWidth - 4 + 'px';
 
+    var item_rect = this.getBoundingClientRect();
+
     shadow_item.mouse_offset_x =
-      YAHOO.util.Event.getPageX(event) - YAHOO.util.Dom.getX(this);
+      YAHOO.util.Event.getPageX(event) - SwatChangeOrder.getPageX(item_rect);
 
     shadow_item.mouse_offset_y =
-      YAHOO.util.Event.getPageY(event) - YAHOO.util.Dom.getY(this);
+      YAHOO.util.Event.getPageY(event) - SwatChangeOrder.getPageY(item_rect);
 
     var drop_marker = document.createElement('div');
 

--- a/www/javascript/swat-check-all.js
+++ b/www/javascript/swat-check-all.js
@@ -40,17 +40,15 @@ class SwatCheckAll {
     }
 
     if (this.check_all.checked) {
-      var in_attributes = { opacity: { from: 0, to: 1 } };
-      var in_animation = new YAHOO.util.Anim(
-        container,
-        in_attributes,
-        0.5,
-        YAHOO.util.Easing.easeIn
-      );
-
-      container.style.opacity = 0;
+      container
+        .animate([{ opacity: 0 }, { opacity: 1 }], {
+          duration: 500,
+          easing: 'ease-in'
+        })
+        .finished.then(() => {
+          container.style.opacity = 1;
+        });
       container.style.display = 'block';
-      in_animation.animate();
     } else {
       container.style.display = 'none';
       container.getElementsByTagName('input')[0].checked = false;

--- a/www/javascript/swat-disclosure.js
+++ b/www/javascript/swat-disclosure.js
@@ -128,18 +128,19 @@ class SwatDisclosure {
 
     this.animate_div.style.overflow = 'hidden';
     this.animate_div.style.height = 'auto';
-    var attributes = { height: { to: 0 } };
-    var animation = new YAHOO.util.Anim(
-      this.animate_div,
-      attributes,
-      0.25,
-      YAHOO.util.Easing.easeOut
-    );
+    this.animate_div
+      .animate(
+        [{ height: this.animate_div.offsetHeight + 'px' }, { height: 0 }],
+        {
+          duration: 250,
+          easing: 'ease-out'
+        }
+      )
+      .finished.then(() => {
+        this.handleClose();
+      });
 
     this.semaphore = true;
-    animation.onComplete.subscribe(this.handleClose, this, true);
-    animation.animate();
-
     this.input.value = 'closed';
     this.opened = false;
   }
@@ -180,24 +181,23 @@ class SwatDisclosure {
     this.animate_div.style.visibility = 'visible';
     this.animate_div.parentNode.style.height = '';
     this.animate_div.parentNode.style.overflow = 'visible';
-
-    var attributes = { height: { to: height, from: 0 } };
-    var animation = new YAHOO.util.Anim(
-      this.animate_div,
-      attributes,
-      0.5,
-      YAHOO.util.Easing.easeOut
-    );
+    this.animate_div
+      .animate([{ height: 0 }, { height: height + 'px' }], {
+        duration: 500,
+        easing: 'ease-out'
+      })
+      .finished.then(() => {
+        this.handleOpen();
+      });
 
     this.semaphore = true;
-    animation.onComplete.subscribe(this.handleOpen, this, true);
-    animation.animate();
-
     this.input.value = 'opened';
     this.opened = true;
   }
 
   handleClose() {
+    this.animate_div.style.height = 0;
+
     this.div.classList.remove('swat-disclosure-control-opened');
     this.div.classList.add('swat-disclosure-control-closed');
 

--- a/www/javascript/swat-image-preview-display.js
+++ b/www/javascript/swat-image-preview-display.js
@@ -74,7 +74,6 @@ class SwatImagePreviewDisplay {
   open() {
     document.addEventListener('keydown', this.handleKeyDown);
     this.showOverlay();
-    this.preview_container.style.display = 'flex';
     this.opened = true;
   }
 

--- a/www/javascript/swat-image-preview-display.js
+++ b/www/javascript/swat-image-preview-display.js
@@ -27,13 +27,6 @@ class SwatImagePreviewDisplay {
 
   static close_text = 'Close';
 
-  /**
-   * Padding of preview image
-   *
-   * @var {number}
-   */
-  static padding = 16;
-
   init() {
     this.drawOverlay();
 
@@ -80,61 +73,9 @@ class SwatImagePreviewDisplay {
 
   open() {
     document.addEventListener('keydown', this.handleKeyDown);
-
-    // get approximate max height and width excluding close text
-    var padding = SwatImagePreviewDisplay.padding;
-    var max_width = YAHOO.util.Dom.getViewportWidth() - padding * 2;
-    var max_height = YAHOO.util.Dom.getViewportHeight() - padding * 2;
-
     this.showOverlay();
-
-    this.scaleImage(max_width, max_height);
-
-    this.preview_container.style.visibility = 'hidden';
-    this.preview_container.style.display = 'block';
-
-    // now that is it displayed, adjust height for the close text
-    var region = YAHOO.util.Dom.getRegion(this.preview_header);
-    max_height -= region.bottom - region.top;
-    this.scaleImage(max_width, max_height);
-
-    this.preview_container.style.visibility = 'visible';
-
-    // x is relative to center of page
-    var scroll_top = YAHOO.util.Dom.getDocumentScrollTop();
-    var x = -Math.round((this.preview_image.width + padding) / 2);
-    var y =
-      Math.round((max_height - this.preview_image.height + padding) / 2) +
-      scroll_top;
-
-    this.preview_container.style.top = y + 'px';
-
-    // set x
-    this.preview_container.style.left = '50%';
-    this.preview_container.style.marginLeft = x + 'px';
-
+    this.preview_container.style.display = 'flex';
     this.opened = true;
-  }
-
-  scaleImage(max_width, max_height) {
-    // if preview image is larger than viewport width, scale down
-    if (this.preview_image.width > max_width) {
-      this.preview_image.height =
-        this.preview_image.height * (max_width / this.preview_image.width);
-
-      this.preview_image.width = max_width;
-    }
-
-    // if preview image is larger than viewport height, scale down
-    if (this.preview_image.height > max_height) {
-      this.preview_image.width =
-        this.preview_image.width * (max_height / this.preview_image.height);
-
-      this.preview_image.height = max_height;
-    }
-
-    // For IE 6 & 7
-    this.preview_container.style.width = this.preview_image.width + 'px';
   }
 
   drawOverlay() {
@@ -213,12 +154,8 @@ class SwatImagePreviewDisplay {
     this.preview_container = document.createElement('a');
     this.preview_container.href = '#close';
     this.preview_container.className = 'swat-image-preview-container';
-    this.preview_container.style.display = 'none';
     this.preview_container.appendChild(this.preview_header);
     this.preview_container.appendChild(this.preview_image);
-
-    // For IE6 & 7
-    this.preview_container.style.width = this.preview_width + 'px';
 
     SwatZIndexManager.raiseElement(this.preview_container);
 
@@ -253,8 +190,7 @@ class SwatImagePreviewDisplay {
   }
 
   showOverlay() {
-    this.overlay.style.height = YAHOO.util.Dom.getDocumentHeight() + 'px';
-    this.overlay.style.display = 'block';
+    this.overlay.style.display = 'flex';
   }
 
   hideOverlay() {
@@ -264,7 +200,6 @@ class SwatImagePreviewDisplay {
   close() {
     document.removeEventListener('keydown', this.handleKeyDown);
     this.hideOverlay();
-    this.preview_container.style.display = 'none';
     this.opened = false;
   }
 

--- a/www/javascript/swat-message-display.js
+++ b/www/javascript/swat-message-display.js
@@ -63,40 +63,41 @@ class SwatMessageDisplayMessage {
    */
   hide() {
     if (this.message_div !== null) {
-      // fade out message
-      var fade_animation = new YAHOO.util.Anim(
-        this.message_div,
-        { opacity: { to: 0 } },
-        SwatMessageDisplayMessage.fade_duration,
-        YAHOO.util.Easing.easingOut
-      );
-
-      // after fading out, shrink the empty space away
-      fade_animation.onComplete.subscribe(this.shrink, this, true);
-      fade_animation.animate();
+      this.message_div
+        .animate([{ opacity: 1 }, { opacity: 0 }], {
+          duration: SwatMessageDisplayMessage.fade_duration * 1000,
+          easing: 'ease-out'
+        })
+        .finished.then(() => {
+          this.message_div.style.opacity = 0;
+          this.shrink();
+        });
     }
   }
 
   shrink() {
-    var duration = SwatMessageDisplayMessage.shrink_duration;
-    var easing = YAHOO.util.Easing.easeInStrong;
+    var duration = SwatMessageDisplayMessage.shrink_duration * 1000;
+    var easing = 'ease-in';
 
-    var attributes = {
-      height: { to: 0 },
-      marginBottom: { to: 0 }
+    var endKeyframeAttributes = {
+      height: 0,
+      marginBottom: 0
     };
+
+    var height = this.message_div.firstElementChild.getBoundingClientRect()
+      .height;
 
     // collapse margins
     if (this.message_div.nextSibling) {
       // shrink top margin of next message in message display
-      var next_message_animation = new YAHOO.util.Anim(
-        this.message_div.nextSibling,
-        { marginTop: { to: 0 } },
-        duration,
-        easing
-      );
-
-      next_message_animation.animate();
+      this.message_div.nextSibling
+        .animate([{ marginTop: 0 }], {
+          duration,
+          easing
+        })
+        .finished.then(() => {
+          this.message_div.nextSibling.style.marginTop = 0;
+        });
     } else {
       // shrink top margin of element directly below message display
       // find first element node
@@ -107,43 +108,45 @@ class SwatMessageDisplayMessage {
       }
 
       if (node) {
-        var previous_message_animation = new YAHOO.util.Anim(
-          node,
-          { marginTop: { to: 0 } },
-          duration,
-          easing
-        );
-
-        previous_message_animation.animate();
+        node
+          .animate([{ marginTop: 0 }], {
+            duration,
+            easing
+          })
+          .finished.then(() => {
+            node.style.marginTop = 0;
+          });
       }
     }
 
     // if this is the last message in the display, shrink the message display
     // top margin to zero.
-    if (this.message_div.parentNode.childNodes.length == 1) {
+    if (this.message_div.parentNode.childNodes.length === 1) {
       // collapse top margin of last message
-      attributes.marginTop = { to: 0 };
+      endKeyframeAttributes.marginTop = 0;
 
-      var message_display_animation = new YAHOO.util.Anim(
-        this.message_div.parentNode,
-        { marginTop: { to: 0 } },
-        duration,
-        easing
-      );
-
-      message_display_animation.animate();
+      this.message_div.parentNode
+        .animate([{ marginTop: 0 }], {
+          duration,
+          easing
+        })
+        .finished.then(() => {
+          this.message_div.parentNode.style.marginTop = 0;
+        });
     }
 
     // disappear this message
-    var shrink_animation = new YAHOO.util.Anim(
-      this.message_div,
-      attributes,
-      duration,
-      easing
-    );
-
-    shrink_animation.onComplete.subscribe(this.remove, this, true);
-    shrink_animation.animate();
+    this.message_div
+      .animate([{ height: height + 'px' }, endKeyframeAttributes], {
+        duration,
+        easing
+      })
+      .finished.then(() => {
+        Object.entries(endKeyframeAttributes).forEach(([key, value]) => {
+          this.message_div.style[key] = value;
+        });
+        this.remove();
+      });
   }
 
   remove() {

--- a/www/javascript/swat-radio-note-book.js
+++ b/www/javascript/swat-radio-note-book.js
@@ -79,32 +79,23 @@ class SwatRadioNoteBook {
     var region = page.firstChild.getBoundingClientRect();
     var height = region.height;
 
-    var anim = new YAHOO.util.Anim(
-      page,
-      { height: { to: height } },
-      SwatRadioNoteBook.SLIDE_DURATION,
-      YAHOO.util.Easing.easeIn
-    );
-
-    anim.onComplete.subscribe(
-      function() {
+    page
+      .animate([{ height: 0 }, { height: height + 'px' }], {
+        duration: SwatRadioNoteBook.SLIDE_DURATION * 1000,
+        easing: 'ease-in'
+      })
+      .finished.then(() => {
         page.style.height = 'auto';
         this.restorePageFocusability(page);
-
-        var anim = new YAHOO.util.Anim(
-          page,
-          { opacity: { to: 1 } },
-          SwatRadioNoteBook.FADE_DURATION,
-          YAHOO.util.Easing.easeIn
-        );
-
-        anim.animate();
-      },
-      this,
-      true
-    );
-
-    anim.animate();
+        page
+          .animate([{ opacity: 0 }, { opacity: 1 }], {
+            duration: SwatRadioNoteBook.FADE_DURATION * 1000,
+            easing: 'ease-in'
+          })
+          .finished.then(() => {
+            page.style.opacity = 1;
+          });
+      });
   }
 
   closePage(page) {
@@ -115,32 +106,31 @@ class SwatRadioNoteBook {
   }
 
   closePageWithAnimation(page) {
-    var anim = new YAHOO.util.Anim(
-      page,
-      { opacity: { to: 0 } },
-      SwatRadioNoteBook.FADE_DURATION,
-      YAHOO.util.Easing.easeOut
-    );
+    if (page === null) {
+      return;
+    }
 
-    anim.onComplete.subscribe(
-      function() {
+    var region = page.firstChild.getBoundingClientRect();
+    var height = region.height;
+
+    page
+      .animate([{ opacity: 1 }, { opacity: 0 }], {
+        duration: SwatRadioNoteBook.FADE_DURATION * 1000,
+        easing: 'ease-out'
+      })
+      .finished.then(() => {
+        page.style.opacity = 0;
         page.style.overflow = 'hidden';
         this.removePageFocusability(page);
-
-        var anim = new YAHOO.util.Anim(
-          page,
-          { height: { to: 0 } },
-          SwatRadioNoteBook.SLIDE_DURATION,
-          YAHOO.util.Easing.easeOut
-        );
-
-        anim.animate();
-      },
-      this,
-      true
-    );
-
-    anim.animate();
+        page
+          .animate([{ height: height + 'px' }, { height: 0 }], {
+            duration: SwatRadioNoteBook.SLIDE_DURATION * 1000,
+            easing: 'ease-out'
+          })
+          .finished.then(() => {
+            page.style.height = 0;
+          });
+      });
   }
 
   removePageFocusability(page) {

--- a/www/javascript/swat-radio-note-book.js
+++ b/www/javascript/swat-radio-note-book.js
@@ -76,7 +76,7 @@ class SwatRadioNoteBook {
     page.firstChild.style.visibility = 'visible';
     page.firstChild.style.height = 'auto';
 
-    var region = YAHOO.util.Dom.getRegion(page.firstChild);
+    var region = page.firstChild.getBoundingClientRect();
     var height = region.height;
 
     var anim = new YAHOO.util.Anim(

--- a/www/javascript/swat-table-view-input-row.js
+++ b/www/javascript/swat-table-view-input-row.js
@@ -140,24 +140,13 @@ class SwatTableViewInputRow {
     dest_tr.className = 'swat-table-view-input-row';
     dest_tr.id = this.id + '_row_' + replicator_id;
 
-    var node = dest_tr;
-    var dest_color = 'transparent';
-    while (dest_color == 'transparent' && node) {
-      dest_color = getComputedStyle(node).backgroundColor;
-      node = node.parentNode;
-    }
-    if (dest_color == 'transparent') {
-      dest_color = '#ffffff';
-    }
-
-    var animation = new YAHOO.util.ColorAnim(
-      dest_tr,
-      { backgroundColor: { from: '#fffbc9', to: dest_color } },
-      1,
-      YAHOO.util.Easing.easeOut
+    dest_tr.animate(
+      [
+        { backgroundColor: 'rgba(255,251,201,1)' },
+        { backgroundColor: 'rgba(255,251,201,0)' }
+      ],
+      { duration: 1000, easing: 'ease-out' }
     );
-
-    animation.animate();
 
     /*
      * Run scripts

--- a/www/styles/swat-actions.css
+++ b/www/styles/swat-actions.css
@@ -4,23 +4,24 @@
 }
 
 .swat-actions .swat-actions-message {
+	display: inline-flex;
+	align-items: center;
+	justify-content: space-between;
 	border: 1px solid #f0dca1;
 	background-color: #fffbc9;
 	color: #7b4b09;
 	margin: 0 0 0 7px;
-	padding: 5px 25px 5px 5px;
+	padding: 5px;
 	border-radius: 4px;
-	position: relative;
 }
 
 .swat-actions .swat-actions-message-dismiss-link,
 .swat-actions .swat-actions-message-dismiss-link:link,
 .swat-actions .swat-actions-message-dismiss-link:visited {
 	display: block;
+	margin-left: 4px;
+	flex: 0 0 auto;
 	font-size: 85%;
-	position: absolute;
-	top: 5px;
-	right: 10px;
 	height: 14px;
 	width: 14px;
 	background: url(../images/dismiss.png) 0 0 no-repeat;

--- a/www/styles/swat-image-preview-display.css
+++ b/www/styles/swat-image-preview-display.css
@@ -21,21 +21,25 @@ a.swat-image-preview-display-link-plain:hover img {
 }
 
 .swat-image-preview-overlay {
-	position: absolute;
+	position: fixed;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	top: 0;
 	left: 0;
 	width: 100%;
+	height: 100vh;
 }
 
 .swat-image-preview-mask {
-	position: relative;
+	position: fixed;
 	cursor: default;
 	display: block;
 	background: #000;
+	top: 0;
+	left: 0;
 	width: 100%;
 	height: 100%;
-	-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=75)";
-	filter:alpha(opacity = 75);
 	opacity: 0.75;
 }
 .swat-image-preview-mask:focus,
@@ -57,18 +61,17 @@ a.swat-image-preview-display-link-plain:hover img {
 	float: right;
 	display: block;
 	outline: none;
-	cursor: pointer; /* For IE6 & 7 */
 }
 
 .swat-image-preview-container {
+	flex: 0 1 auto;
 	text-decoration: none;
-	position: absolute;
 	text-align: left;
 	border: 1px solid #dcceb2;
 	background: #fff;
 	padding: 8px;
-
 	border-radius: 8px;
+	max-width: calc(100% - 32px);
 }
 
 .swat-image-preview-container:focus,
@@ -78,4 +81,6 @@ a.swat-image-preview-display-link-plain:hover img {
 
 .swat-image-preview-container img {
 	display: block;
+	width: 100%;
+	height: 100%;
 }

--- a/www/styles/swat.css
+++ b/www/styles/swat.css
@@ -298,6 +298,7 @@ blockquote.swat-db-debug {
 	top: 0;
 	left: 0;
 	width: 100%;
+	height: 100vh;
 }
 
 .swat-overlay .hd {


### PR DESCRIPTION
#Description 

- remove compatibility calls to get scroll height, document height, viewport height, etc
- use CSS calc, vh units and flexbox to size and position overlays and modals
- use element.getBoundingClient() instead of Dom.getRegion(), Dom.getPageX(), and Dom.getPageY()
- Replace `YAHOO.util.Anim` and `YAHOO.util.ColorAnim` with modern web animations using `Element.animate()`

Scrolling behaviour of image preview display is changed slightly. Old implementation fixed the preview image on the page when opened and allowed scrolling it off the page while the modal remained open. The new implementation keeps the preview image centered on the viewport if you scroll content when the modal is open.

# Testing

1. go to https://berna.silverorange.com/swat/work-gauthierm/demo/www/index.php
2. make sure
  - Accordion,
  - Actions,
  - Button (throbber animation),
  - NoteBook,
  - ChangeOrder,
  - Disclosure,
  - ImagePreviewDisplay,
  - MessageDisplay
  - ProgressBar,
  - TableView (actions warning messages)
  - TableViewInputRow,
  - SimpleColorEntry all work as before