### PR TITLE
Fix getISO8601 regression

### DIFF
--- a/Swat/SwatDate.php
+++ b/Swat/SwatDate.php
@@ -987,8 +987,7 @@ class SwatDate extends DateTime implements Serializable
      * @return string this date formatted as an ISO 8601 timestamp.
      */
     public function getISO8601(
-        $options =
-            self::ISO_EXTENDED | self::ISO_MICROTIME | self::ISO_TIME_ZONE,
+        $options = self::ISO_EXTENDED | self::ISO_TIME_ZONE,
     ): string {
         if (($options & self::ISO_EXTENDED) === self::ISO_EXTENDED) {
             $format = self::DF_ISO_8601_EXTENDED;


### PR DESCRIPTION
Recent merge changed default $options parameter from 5 to a bitwise expression equivalent to 7 which trigger an unused/low usage code path with another bug ($format .= '.SSSS'; will cause exception in getFormattedOffsetById method).

Bitwise expression self::ISO_EXTENDED | self::ISO_TIME_ZONE return the default to integer 5.