### PR TITLE
SwatMessage Fix set primary_content / sprintf error

### DIFF
--- a/Swat/SwatControl.php
+++ b/Swat/SwatControl.php
@@ -14,44 +14,18 @@ abstract class SwatControl extends SwatWidget
     /**
      * Adds a message to this control
      *
-     * Before the message is added, the content is updated with the name of
-     * this controls's parent title field if the parent implements the
-     * {@link SwatTitleable} interface.
-     *
      * @param SwatMessage $message the message to add.
      *
      * @see SwatWidget::addMessage()
      */
     public function addMessage(SwatMessage $message)
     {
-        if ($this->parent instanceof SwatTitleable) {
-            $title = $this->parent->getTitle();
-            if ($title === null) {
-                $field_title = '';
-            } else {
-                if ($this->parent->getTitleContentType() === 'text/xml') {
-                    $field_title =
-                        '<strong>' . $this->parent->getTitle() . '</strong>';
-                } else {
-                    $field_title =
-                        '<strong>' .
-                        SwatString::minimizeEntities(
-                            $this->parent->getTitle(),
-                        ) .
-                        '</strong>';
-                }
-            }
-        } else {
-            $field_title = '';
-        }
-
         if ($message->content_type === 'text/plain') {
-            $content = SwatString::minimizeEntities($message->primary_content);
-        } else {
-            $content = $message->primary_content;
+            $message->primary_content = SwatString::minimizeEntities(
+                $message->primary_content,
+            );
         }
 
-        $message->primary_content = sprintf($content, $field_title);
         $message->content_type = 'text/xml';
 
         parent::addMessage($message);


### PR DESCRIPTION
Fix to prevent sprintf function called with a primary message string which may have a substring that can be unintentionally parsed as an sprintf format specifier (for example numerous promo codes have % followed by characters that will cause a parsing error).

Remove code that attempts (and fails) to append, in a SwatTitleable case, the title string to the primary_content string. Calling code exists that expects a primary_content value addMessage() to not add anything to the primary_content value (example: Evaluation question fields which should show just `This field is required.`, not with anything prepended) .