### PR TITLE
Use htmlspecialchars in PHP 8.1 as pre-8.1

### DIFF
--- a/Swat/SwatTextarea.php
+++ b/Swat/SwatTextarea.php
@@ -247,7 +247,7 @@ class SwatTextarea extends SwatInputControl implements SwatState
 
         // escape value for display because we actually want to show entities
         // for editing
-        $value = htmlspecialchars($value);
+        $value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
 
         $textarea_tag = new SwatHtmlTag('textarea');
         $textarea_tag->name = $this->id;

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -177,7 +177,7 @@ class SwatTextareaEditor extends SwatTextarea
 
         // escape value for display because we actually want to show entities
         // for editing
-        $value = htmlspecialchars($value);
+        $value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
 
         $div_tag = new SwatHtmlTag('div');
         $div_tag->class = 'swat-textarea-editor-container';


### PR DESCRIPTION
Default flags changed in PHP 8.1. Call with ENT_COMPAT flag to resume behaviour of pre-8.1 function.