### PR TITLE
SwatTextareaEditor: remove white backgrounds by default when pasting

### DIFF
--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -386,64 +386,65 @@ class SwatTextareaEditor extends SwatTextarea
 
         $this->displayColorMap();
 
-        $remove_white_background =
-            $this->remove_white_background ? 'true' : 'false';
+        $remove_white_background = $this->remove_white_background
+            ? 'true'
+            : 'false';
 
         // Post process the pasted nodes to remove extra styling while preserving
         // highlighted text. Also removes extra br tags
         echo "\tpaste_postprocess: function(pluginApi, data) {
-				const toRemove = [];
-				function execOnChildren(elem, fn) {
-					fn(elem);
-					for (let i = 0; i < elem.children.length; i++) {
-						execOnChildren(elem.children[i], fn);
-					}
-				}
-				function removeStyle(elem) {
-					if (!elem || !elem.hasAttribute('style')) return;
-					const match = elem.getAttribute('style').match(/background(-color)?:[^\"]*;/g);
-					if (match) {
+                const toRemove = [];
+                function execOnChildren(elem, fn) {
+                    fn(elem);
+                    for (let i = 0; i < elem.children.length; i++) {
+                        execOnChildren(elem.children[i], fn);
+                    }
+                }
+                function removeStyle(elem) {
+                    if (!elem || !elem.hasAttribute('style')) return;
+                    const match = elem.getAttribute('style').match(/background(-color)?:[^\"]*;/g);
+                    if (match) {
                         // check if the color is 255, 255, 255, and if so, remove it
                         const color = window.getComputedStyle(elem, null)
                                             .getPropertyValue('background-color');
                         const is_white = (color === 'rgb(255, 255, 255)');
                         if ({$remove_white_background} && is_white) {
-						    elem.removeAttribute('style');
+                            elem.removeAttribute('style');
                         } else {
-    						elem.setAttribute('style', match[0]);
+                            elem.setAttribute('style', match[0]);
                         }
-					} else {
-						elem.removeAttribute('style');
-					}
-				}
-				function removeNestedP(elem) {
-					if (!elem || !elem.children[0]) return;
-					if (elem.nodeName === 'LI' && elem.children[0].nodeName === 'P') {
-						const p = elem.removeChild(elem.children[0]);
-						const children = [];
-						for (let i = 0; i < p.children.length; i++) {
-							children.push(p.children[i]);
-						}
-						for (let i = 0; i < elem.children.length; i++) {
-							children.push(elem.children[i]);
-						}
-						elem.replaceChildren(...children);
-					}
-				}
-				function clean(elem) {
-					removeStyle(elem);
-					removeNestedP(elem);
-				}
-				for (let i = 0; i < data.node.children.length; i++) {
-					const child = data.node.children[i];
-					if (child.nodeName === 'BR') {
-						toRemove.push(child);
-					} else {
-						execOnChildren(child, clean);
-					}
-				}
-				toRemove.forEach(r => data.node.removeChild(r));
-			},\n" .
+                    } else {
+                        elem.removeAttribute('style');
+                    }
+                }
+                function removeNestedP(elem) {
+                    if (!elem || !elem.children[0]) return;
+                    if (elem.nodeName === 'LI' && elem.children[0].nodeName === 'P') {
+                        const p = elem.removeChild(elem.children[0]);
+                        const children = [];
+                        for (let i = 0; i < p.children.length; i++) {
+                            children.push(p.children[i]);
+                        }
+                        for (let i = 0; i < elem.children.length; i++) {
+                            children.push(elem.children[i]);
+                        }
+                        elem.replaceChildren(...children);
+                    }
+                }
+                function clean(elem) {
+                    removeStyle(elem);
+                    removeNestedP(elem);
+                }
+                for (let i = 0; i < data.node.children.length; i++) {
+                    const child = data.node.children[i];
+                    if (child.nodeName === 'BR') {
+                        toRemove.push(child);
+                    } else {
+                        execOnChildren(child, clean);
+                    }
+                }
+                toRemove.forEach(r => data.node.removeChild(r));
+            },\n" .
             "\tmenubar: false,\n" .
             "\tformats: {\n" .
             "\t\tremoveformat : [\n" .

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -404,7 +404,8 @@ class SwatTextareaEditor extends SwatTextarea
 					const match = elem.getAttribute('style').match(/background(-color)?:[^\"]*;/g);
 					if (match) {
                         // check if the color is 255, 255, 255, and if so, remove it
-                        const color = window.getComputedStyle(elem, null).getPropertyValue('background-color');
+                        const color = window.getComputedStyle(elem, null)
+                                            .getPropertyValue('background-color');
                         const is_white = (color === 'rgb(255, 255, 255)');
                         if ({$remove_white_background} && is_white) {
 						    elem.removeAttribute('style');

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -368,12 +368,6 @@ class SwatTextareaEditor extends SwatTextarea
                 ";\n";
         }
 
-        printf(
-            "\tconst %s_remove_white_background = %s;\n",
-            $this->id,
-            $this->remove_white_background ? 'true' : 'false',
-        );
-
         echo "tinyMCE.init({\n";
 
         $lines = [];

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -371,7 +371,7 @@ class SwatTextareaEditor extends SwatTextarea
         printf(
             "\tconst %s_remove_white_background = %s;\n",
             $this->id,
-            $this->remove_white_background ? 'true' : 'false'
+            $this->remove_white_background ? 'true' : 'false',
         );
 
         echo "tinyMCE.init({\n";

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -392,6 +392,9 @@ class SwatTextareaEditor extends SwatTextarea
 
         $this->displayColorMap();
 
+        $remove_white_background =
+            $this->remove_white_background ? 'true' : 'false';
+
         // Post process the pasted nodes to remove extra styling while preserving
         // highlighted text. Also removes extra br tags
         echo "\tpaste_postprocess: function(pluginApi, data) {
@@ -408,7 +411,7 @@ class SwatTextareaEditor extends SwatTextarea
 					if (match) {
                         // check if the color is 255, 255, 255, and if so, remove it
                         const is_white = match[0].match(/255/g).length === 3;
-                        if ({$this->id}_remove_white_background && is_white) {
+                        if ({$remove_white_background} && is_white) {
 						    elem.removeAttribute('style');
                         } else {
     						elem.setAttribute('style', match[0]);

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -335,7 +335,8 @@ class SwatTextareaEditor extends SwatTextarea
         if (self::$color_map !== null) {
             echo "    color_map: [\n";
             foreach (self::$color_map as $elem) {
-                echo "        " . SwatString::quoteJavaScriptString($elem) .
+                echo '        ' .
+                    SwatString::quoteJavaScriptString($elem) .
                     ",\n";
             }
             echo "    ],\n";
@@ -376,7 +377,7 @@ class SwatTextareaEditor extends SwatTextarea
             } elseif (is_bool($value)) {
                 $value = $value ? 'true' : 'false';
             }
-            $lines[] = "    " . $name . ': ' . $value;
+            $lines[] = '    ' . $name . ': ' . $value;
         }
 
         $lines[] = "    document_base_url: {$base_href},\n";
@@ -394,108 +395,108 @@ class SwatTextareaEditor extends SwatTextarea
         // Post process the pasted nodes to remove extra styling while preserving
         // highlighted text. Also removes extra br tags
         echo <<<JAVASCRIPT
-            tinyMCE.init({
-            {$config}
-            {$color_map}
-                paste_postprocess: function(pluginApi, data) {
-                    const toRemove = [];
-                    function execOnChildren(elem, fn) {
-                        fn(elem);
-                        for (let i = 0; i < elem.children.length; i++) {
-                            execOnChildren(elem.children[i], fn);
-                        }
+        tinyMCE.init({
+        {$config}
+        {$color_map}
+            paste_postprocess: function(pluginApi, data) {
+                const toRemove = [];
+                function execOnChildren(elem, fn) {
+                    fn(elem);
+                    for (let i = 0; i < elem.children.length; i++) {
+                        execOnChildren(elem.children[i], fn);
                     }
-                    function removeStyle(elem) {
-                        if (!elem || !elem.hasAttribute('style')) {
-                            return;
-                        }
-                        const match = elem.getAttribute('style').match(/background(-color)?:[^;]+;/g);
-                        if (match !== null) {
-                            // check if the color is 255, 255, 255, and if so, remove it
-                            const color = window.getComputedStyle(elem, null)
-                                                .getPropertyValue('background-color');
-                            const is_white = (color === 'rgb(255, 255, 255)');
-                            if ({$remove_white_background} && is_white) {
-                                elem.removeAttribute('style');
-                            } else {
-                                elem.setAttribute('style', match[0]);
-                            }
-                        } else {
-                            elem.removeAttribute('style');
-                        }
-                    }
-                    function removeNestedP(elem) {
-                        if (!elem || !elem.children[0]) {
-                            return;
-                        }
-                        if (elem.nodeName === 'LI' && elem.children[0].nodeName === 'P') {
-                            const p = elem.removeChild(elem.children[0]);
-                            const children = [];
-                            for (let i = 0; i < p.children.length; i++) {
-                                children.push(p.children[i]);
-                            }
-                            for (let i = 0; i < elem.children.length; i++) {
-                                children.push(elem.children[i]);
-                            }
-                            elem.replaceChildren(...children);
-                        }
-                    }
-                    function clean(elem) {
-                        removeStyle(elem);
-                        removeNestedP(elem);
-                    }
-                    for (let i = 0; i < data.node.children.length; i++) {
-                        const child = data.node.children[i];
-                        if (child.nodeName === 'BR') {
-                            toRemove.push(child);
-                        } else {
-                            execOnChildren(child, clean);
-                        }
-                    }
-                    toRemove.forEach(r => data.node.removeChild(r));
-                },
-                menubar: false,
-                formats: {
-                    removeformat : [
-                        {
-                            selector     : 'b,strong,em,i,font,u,strike',
-                            remove       : 'all',
-                            split        : true,
-                            expand       : false,
-                            block_expand : true,
-                            deep         : true
-                        },
-                        {
-                            selector     : 'span',
-                            attributes   : [
-                                'style',
-                                'class',
-                                'align',
-                                'color',
-                                'background'
-                            ],
-                            remove       : 'empty',
-                            split        : true,
-                            expand       : false,
-                            deep         : true
-                        },
-                        {
-                            selector     : '*',
-                            attributes   : [
-                                'style',
-                                'class',
-                                'align',
-                                'color',
-                                'background'
-                            ],
-                            split        : false,
-                            expand       : false,
-                            deep         : true
-                        }
-                    ]
                 }
-            });
-            JAVASCRIPT;
+                function removeStyle(elem) {
+                    if (!elem || !elem.hasAttribute('style')) {
+                        return;
+                    }
+                    const match = elem.getAttribute('style').match(/background(-color)?:[^;]+;/g);
+                    if (match !== null) {
+                        // check if the color is 255, 255, 255, and if so, remove it
+                        const color = window.getComputedStyle(elem, null)
+                                            .getPropertyValue('background-color');
+                        const is_white = (color === 'rgb(255, 255, 255)');
+                        if ({$remove_white_background} && is_white) {
+                            elem.removeAttribute('style');
+                        } else {
+                            elem.setAttribute('style', match[0]);
+                        }
+                    } else {
+                        elem.removeAttribute('style');
+                    }
+                }
+                function removeNestedP(elem) {
+                    if (!elem || !elem.children[0]) {
+                        return;
+                    }
+                    if (elem.nodeName === 'LI' && elem.children[0].nodeName === 'P') {
+                        const p = elem.removeChild(elem.children[0]);
+                        const children = [];
+                        for (let i = 0; i < p.children.length; i++) {
+                            children.push(p.children[i]);
+                        }
+                        for (let i = 0; i < elem.children.length; i++) {
+                            children.push(elem.children[i]);
+                        }
+                        elem.replaceChildren(...children);
+                    }
+                }
+                function clean(elem) {
+                    removeStyle(elem);
+                    removeNestedP(elem);
+                }
+                for (let i = 0; i < data.node.children.length; i++) {
+                    const child = data.node.children[i];
+                    if (child.nodeName === 'BR') {
+                        toRemove.push(child);
+                    } else {
+                        execOnChildren(child, clean);
+                    }
+                }
+                toRemove.forEach(r => data.node.removeChild(r));
+            },
+            menubar: false,
+            formats: {
+                removeformat : [
+                    {
+                        selector     : 'b,strong,em,i,font,u,strike',
+                        remove       : 'all',
+                        split        : true,
+                        expand       : false,
+                        block_expand : true,
+                        deep         : true
+                    },
+                    {
+                        selector     : 'span',
+                        attributes   : [
+                            'style',
+                            'class',
+                            'align',
+                            'color',
+                            'background'
+                        ],
+                        remove       : 'empty',
+                        split        : true,
+                        expand       : false,
+                        deep         : true
+                    },
+                    {
+                        selector     : '*',
+                        attributes   : [
+                            'style',
+                            'class',
+                            'align',
+                            'color',
+                            'background'
+                        ],
+                        split        : false,
+                        expand       : false,
+                        deep         : true
+                    }
+                ]
+            }
+        });
+        JAVASCRIPT;
 
         return ob_get_clean();
     }

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -333,11 +333,12 @@ class SwatTextareaEditor extends SwatTextarea
     protected function displayColorMap()
     {
         if (self::$color_map !== null) {
-            echo "\tcolor_map: [\n";
+            echo "    color_map: [\n";
             foreach (self::$color_map as $elem) {
-                echo "\t\t" . SwatString::quoteJavaScriptString($elem) . ",\n";
+                echo "        " . SwatString::quoteJavaScriptString($elem) .
+                    ",\n";
             }
-            echo "\t],\n";
+            echo "    ],\n";
         }
     }
 
@@ -368,8 +369,6 @@ class SwatTextareaEditor extends SwatTextarea
                 ";\n";
         }
 
-        echo "tinyMCE.init({\n";
-
         $lines = [];
         foreach ($this->getConfig() as $name => $value) {
             if (is_string($value)) {
@@ -377,14 +376,16 @@ class SwatTextareaEditor extends SwatTextarea
             } elseif (is_bool($value)) {
                 $value = $value ? 'true' : 'false';
             }
-            $lines[] = "\t" . $name . ': ' . $value;
+            $lines[] = "    " . $name . ': ' . $value;
         }
 
-        $lines[] = "\tdocument_base_url: {$base_href},\n";
+        $lines[] = "    document_base_url: {$base_href},\n";
 
-        echo implode(",\n", $lines);
+        $config = implode(",\n", $lines);
 
+        ob_start();
         $this->displayColorMap();
+        $color_map = ob_get_clean();
 
         $remove_white_background = $this->remove_white_background
             ? 'true'
@@ -392,101 +393,109 @@ class SwatTextareaEditor extends SwatTextarea
 
         // Post process the pasted nodes to remove extra styling while preserving
         // highlighted text. Also removes extra br tags
-        echo "\tpaste_postprocess: function(pluginApi, data) {
-                const toRemove = [];
-                function execOnChildren(elem, fn) {
-                    fn(elem);
-                    for (let i = 0; i < elem.children.length; i++) {
-                        execOnChildren(elem.children[i], fn);
-                    }
-                }
-                function removeStyle(elem) {
-                    if (!elem || !elem.hasAttribute('style')) return;
-                    const match = elem.getAttribute('style').match(/background(-color)?:[^\"]*;/g);
-                    if (match) {
-                        // check if the color is 255, 255, 255, and if so, remove it
-                        const color = window.getComputedStyle(elem, null)
-                                            .getPropertyValue('background-color');
-                        const is_white = (color === 'rgb(255, 255, 255)');
-                        if ({$remove_white_background} && is_white) {
-                            elem.removeAttribute('style');
-                        } else {
-                            elem.setAttribute('style', match[0]);
-                        }
-                    } else {
-                        elem.removeAttribute('style');
-                    }
-                }
-                function removeNestedP(elem) {
-                    if (!elem || !elem.children[0]) return;
-                    if (elem.nodeName === 'LI' && elem.children[0].nodeName === 'P') {
-                        const p = elem.removeChild(elem.children[0]);
-                        const children = [];
-                        for (let i = 0; i < p.children.length; i++) {
-                            children.push(p.children[i]);
-                        }
+        echo <<<JAVASCRIPT
+            tinyMCE.init({
+            {$config}
+            {$color_map}
+                paste_postprocess: function(pluginApi, data) {
+                    const toRemove = [];
+                    function execOnChildren(elem, fn) {
+                        fn(elem);
                         for (let i = 0; i < elem.children.length; i++) {
-                            children.push(elem.children[i]);
+                            execOnChildren(elem.children[i], fn);
                         }
-                        elem.replaceChildren(...children);
                     }
-                }
-                function clean(elem) {
-                    removeStyle(elem);
-                    removeNestedP(elem);
-                }
-                for (let i = 0; i < data.node.children.length; i++) {
-                    const child = data.node.children[i];
-                    if (child.nodeName === 'BR') {
-                        toRemove.push(child);
-                    } else {
-                        execOnChildren(child, clean);
+                    function removeStyle(elem) {
+                        if (!elem || !elem.hasAttribute('style')) {
+                            return;
+                        }
+                        const match = elem.getAttribute('style').match(/background(-color)?:[^\"]*;/g);
+                        if (match !== null) {
+                            // check if the color is 255, 255, 255, and if so, remove it
+                            const color = window.getComputedStyle(elem, null)
+                                                .getPropertyValue('background-color');
+                            const is_white = (color === 'rgb(255, 255, 255)');
+                            if ({$remove_white_background} && is_white) {
+                                elem.removeAttribute('style');
+                            } else {
+                                elem.setAttribute('style', match[0]);
+                            }
+                        } else {
+                            elem.removeAttribute('style');
+                        }
                     }
+                    function removeNestedP(elem) {
+                        if (!elem || !elem.children[0]) {
+                            return;
+                        }
+                        if (elem.nodeName === 'LI' && elem.children[0].nodeName === 'P') {
+                            const p = elem.removeChild(elem.children[0]);
+                            const children = [];
+                            for (let i = 0; i < p.children.length; i++) {
+                                children.push(p.children[i]);
+                            }
+                            for (let i = 0; i < elem.children.length; i++) {
+                                children.push(elem.children[i]);
+                            }
+                            elem.replaceChildren(...children);
+                        }
+                    }
+                    function clean(elem) {
+                        removeStyle(elem);
+                        removeNestedP(elem);
+                    }
+                    for (let i = 0; i < data.node.children.length; i++) {
+                        const child = data.node.children[i];
+                        if (child.nodeName === 'BR') {
+                            toRemove.push(child);
+                        } else {
+                            execOnChildren(child, clean);
+                        }
+                    }
+                    toRemove.forEach(r => data.node.removeChild(r));
+                },
+                menubar: false,
+                formats: {
+                    removeformat : [
+                        {
+                            selector     : 'b,strong,em,i,font,u,strike',
+                            remove       : 'all',
+                            split        : true,
+                            expand       : false,
+                            block_expand : true,
+                            deep         : true
+                        },
+                        {
+                            selector     : 'span',
+                            attributes   : [
+                                'style',
+                                'class',
+                                'align',
+                                'color',
+                                'background'
+                            ],
+                            remove       : 'empty',
+                            split        : true,
+                            expand       : false,
+                            deep         : true
+                        },
+                        {
+                            selector     : '*',
+                            attributes   : [
+                                'style',
+                                'class',
+                                'align',
+                                'color',
+                                'background'
+                            ],
+                            split        : false,
+                            expand       : false,
+                            deep         : true
+                        }
+                    ]
                 }
-                toRemove.forEach(r => data.node.removeChild(r));
-            },\n" .
-            "\tmenubar: false,\n" .
-            "\tformats: {\n" .
-            "\t\tremoveformat : [\n" .
-            "\t\t\t{\n" .
-            "\t\t\t\tselector     : 'b,strong,em,i,font,u,strike',\n" .
-            "\t\t\t\tremove       : 'all',\n" .
-            "\t\t\t\tsplit        : true,\n" .
-            "\t\t\t\texpand       : false,\n" .
-            "\t\t\t\tblock_expand : true,\n" .
-            "\t\t\t\tdeep         : true\n" .
-            "\t\t\t},\n" .
-            "\t\t\t{\n" .
-            "\t\t\t\tselector     : 'span',\n" .
-            "\t\t\t\tattributes   : [\n" .
-            "\t\t\t\t\t'style',\n" .
-            "\t\t\t\t\t'class',\n" .
-            "\t\t\t\t\t'align',\n" .
-            "\t\t\t\t\t'color',\n" .
-            "\t\t\t\t\t'background'\n" .
-            "\t\t\t\t],\n" .
-            "\t\t\t\tremove       : 'empty',\n" .
-            "\t\t\t\tsplit        : true,\n" .
-            "\t\t\t\texpand       : false,\n" .
-            "\t\t\t\tdeep         : true\n" .
-            "\t\t\t},\n" .
-            "\t\t\t{\n" .
-            "\t\t\t\tselector     : '*',\n" .
-            "\t\t\t\tattributes   : [\n" .
-            "\t\t\t\t\t'style',\n" .
-            "\t\t\t\t\t'class',\n" .
-            "\t\t\t\t\t'align',\n" .
-            "\t\t\t\t\t'color',\n" .
-            "\t\t\t\t\t'background'\n" .
-            "\t\t\t\t],\n" .
-            "\t\t\t\tsplit        : false,\n" .
-            "\t\t\t\texpand       : false,\n" .
-            "\t\t\t\tdeep         : true\n" .
-            "\t\t\t}\n" .
-            "\t\t]\n" .
-            "\t}";
-
-        echo "\n});";
+            });
+            JAVASCRIPT;
 
         return ob_get_clean();
     }

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -409,7 +409,7 @@ class SwatTextareaEditor extends SwatTextarea
                         if (!elem || !elem.hasAttribute('style')) {
                             return;
                         }
-                        const match = elem.getAttribute('style').match(/background(-color)?:[^\"]*;/g);
+                        const match = elem.getAttribute('style').match(/background(-color)?:[^;]+;/g);
                         if (match !== null) {
                             // check if the color is 255, 255, 255, and if so, remove it
                             const color = window.getComputedStyle(elem, null)

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -8,7 +8,7 @@
  * details.
  *
  * @package   Swat
- * @copyright 2022 silverorange
+ * @copyright 2022-2023 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class SwatTextareaEditor extends SwatTextarea
@@ -118,6 +118,13 @@ class SwatTextareaEditor extends SwatTextarea
      * @var string
      */
     public $image_server;
+
+    /**
+     * Remove white backgrounds?
+     *
+     * @var boolean
+     */
+    public $remove_white_background = true;
 
     /**
      * Base-Href
@@ -361,6 +368,12 @@ class SwatTextareaEditor extends SwatTextarea
                 ";\n";
         }
 
+        printf(
+            "\tconst %s_remove_white_background = %s;\n",
+            $this->id,
+            $this->remove_white_background ? 'true' : 'false'
+        );
+
         echo "tinyMCE.init({\n";
 
         $lines = [];
@@ -393,7 +406,13 @@ class SwatTextareaEditor extends SwatTextarea
 					if (!elem || !elem.hasAttribute('style')) return;
 					const match = elem.getAttribute('style').match(/background(-color)?:[^\"]*;/g);
 					if (match) {
-						elem.setAttribute('style', match[0]);
+                        // check if the color is 255, 255, 255, and if so, remove it
+                        const is_white = match[0].match(/255/g).length === 3;
+                        if ({$this->id}_remove_white_background && is_white) {
+						    elem.removeAttribute('style');
+                        } else {
+    						elem.setAttribute('style', match[0]);
+                        }
 					} else {
 						elem.removeAttribute('style');
 					}

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -404,7 +404,8 @@ class SwatTextareaEditor extends SwatTextarea
 					const match = elem.getAttribute('style').match(/background(-color)?:[^\"]*;/g);
 					if (match) {
                         // check if the color is 255, 255, 255, and if so, remove it
-                        const is_white = match[0].match(/255/g).length === 3;
+                        const color = window.getComputedStyle(elem, null).getPropertyValue('background-color');
+                        const is_white = (color === 'rgb(255, 255, 255)');
                         if ({$remove_white_background} && is_white) {
 						    elem.removeAttribute('style');
                         } else {


### PR DESCRIPTION
White backgrounds are super hard to see in the editor, and copy/pasting from some programs like Word, Google Docs, or Airtable can cause these to appear unexpectedly. This checks to see if there's a white background, and if so removes it. There's a class property to turn this off if that white backgrounds are desired.

## To Test:

1.  go to any editor with the SwatTextAreaEditor, go into the "source editing" mode and enter some code like:

```
<div style="background: #fff;">White</div>
<div style="background: #ff9900;">Orange</div>
```

2. go back to the normal visual editing mode and copy the contents, then paste them
3. now go back to the "source editing" mode and confirm that the white background style was removed, and the orange one was not.

![remove-white](https://github.com/silverorange/swat/assets/1284966/090c3629-4b40-4280-9ff8-5f5a8de82ad0)

