### PR TITLE
Fix invalid locale parameter to IntlDateFormatter

### DIFF
--- a/Swat/SwatDate.php
+++ b/Swat/SwatDate.php
@@ -388,10 +388,6 @@ class SwatDate extends DateTime implements Serializable
             $format = self::getFormatLikeIntlById($format);
         }
 
-        if ($locale == '') {
-            $locale = setlocale(LC_TIME, 0);
-        }
-
         static $formatters = [];
 
         if (!isset($formatters[$locale])) {


### PR DESCRIPTION
Since `Fixed bug GH-12282` in php 8.1.25 exceptions are thrown when passing an invalid locale string to IntlDateFormatter().

The setlocale(LC_TIME, 0) function call returns string `C` (the contextless locale OS default) which is invalid in php's IntlDateFormatter method.

The first parameter of IntlDateFormatter (which is $local) can be null, and if null there's no exception and the locale appears to be `en` by default which is the desired behavour.

Removing block that reassigned $locale to `C` if $local parameter is  null.


# Testing

1. `cd /so/packages/swat/work-USERNAME/swat/Swat`
2. Checkout this PR
3. cd /so/sites/course-host/work-USERNAME 
4. Run `yarn start --symlinks=swat`
5. cd `/so/sites/course-host/work-USERNAME/system/contact-mailer`
6. https://berna.silverorange.com/course-host-ccme/work-USERNAME/www/contact#contact_form
7. Fill in contact form and submit
8. Run `php contact-mailer.php -i ccme` - should produce no exceptions/errors