### PR TITLE
Add class name to tree node list items

### DIFF
--- a/Swat/SwatCheckboxTree.php
+++ b/Swat/SwatCheckboxTree.php
@@ -266,7 +266,7 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
             // index of other nodes is a combination of parent indexes
             $index = $parent_index . '.' . $node->getIndex();
 
-            echo '<li>';
+            echo '<li class="swat-checkbox-tree-node">';
 
             if (isset($node->value)) {
                 $this->input_tag->id = $this->id . '_' . $index;


### PR DESCRIPTION
Adds a class to the `<li>` items in a checkbox tree, so that we can better target them in CSS.
Required for https://github.com/silverorange/emrap/pull/1984