### PR TITLE
Allow setting data-attributes on elements

### DIFF
--- a/Swat/SwatButton.php
+++ b/Swat/SwatButton.php
@@ -301,6 +301,7 @@ class SwatButton extends SwatInputControl
         $tag->class = $this->getCSSClassString();
         $tag->tabindex = $this->tab_index;
         $tag->accesskey = $this->access_key;
+        $tag->addAttributes($this->getDataAttributes());
 
         if (!$this->isSensitive()) {
             $tag->disabled = 'disabled';

--- a/Swat/SwatUI.php
+++ b/Swat/SwatUI.php
@@ -657,6 +657,10 @@ class SwatUI extends SwatObject
             $array_property = true;
             $name = $regs[1];
             $array_key = $regs[2] == '' ? null : $regs[2];
+        } elseif (preg_match('/^data\-(.*)$/u', $name, $regs)) {
+            $array_property = true;
+            $name = 'data';
+            $array_key = $regs[1];
         }
 
         if (!array_key_exists($name, $class_properties)) {

--- a/Swat/SwatUI.php
+++ b/Swat/SwatUI.php
@@ -659,7 +659,7 @@ class SwatUI extends SwatObject
             $array_key = $regs[2] == '' ? null : $regs[2];
         } elseif (preg_match('/^data\-(.*)$/u', $name, $regs)) {
             $array_property = true;
-            $name = 'data';
+            $name = 'data_attributes';
             $array_key = $regs[1];
         }
 

--- a/Swat/SwatUIObject.php
+++ b/Swat/SwatUIObject.php
@@ -57,7 +57,7 @@ abstract class SwatUIObject extends SwatObject
      *
      * @var array
      */
-    public $data = [];
+    public $data_attributes = [];
 
     // }}}
     // {{{ protected properties
@@ -350,27 +350,31 @@ abstract class SwatUIObject extends SwatObject
      * object
      *
      * User-interface objects aggregate the list of user-specified classes and
-     * may add static CSS classes of their own in this method.
+     * may add static CSS classes of their own in this method.  Child classes
+     * pass their values up and, unless `clear_default_classes` is true, they
+     * are merged together and returned.
      *
      * @return array the array of CSS classes that are applied to this
      *                user-interface object.
      *
      * @see SwatUIObject::getCSSClassString()
      */
-    protected function getCSSClassNames()
+    protected function getCSSClassNames(array $child_classes = []): array
     {
-        return $this->classes;
+        return $this->clear_default_classes
+            ? $this->classes
+            : array_merge($child_classes, $this->classes);
     }
 
     protected function getDataAttributes()
     {
-        $data_attributes = [];
+        $data = [];
 
-        foreach ($this->data as $key => $value) {
-            $data_attributes["data-{$key}"] = $value;
+        foreach ($this->data_attributes as $key => $value) {
+            $data["data-{$key}"] = $value;
         }
 
-        return $data_attributes;
+        return $data;
     }
 
     // }}}

--- a/Swat/SwatUIObject.php
+++ b/Swat/SwatUIObject.php
@@ -43,6 +43,14 @@ abstract class SwatUIObject extends SwatObject
      */
     public $classes = [];
 
+    /**
+     * A user-specified key-value array of data attributes that are applied 
+     * to this user-interface object.
+     * 
+     * @var array
+     */
+    public $data = [];
+
     // }}}
     // {{{ protected properties
 
@@ -344,6 +352,17 @@ abstract class SwatUIObject extends SwatObject
     protected function getCSSClassNames()
     {
         return $this->classes;
+    }
+
+    protected function getDataAttributes()
+    {
+        $data_attributes = [];
+        
+        foreach ($this->data as $key => $value) {
+            $data_attributes["data-{$key}"] = $value;
+        }
+
+        return $data_attributes;
     }
 
     // }}}

--- a/Swat/SwatUIObject.php
+++ b/Swat/SwatUIObject.php
@@ -342,23 +342,19 @@ abstract class SwatUIObject extends SwatObject
      * object
      *
      * User-interface objects aggregate the list of user-specified classes and
-     * may add static CSS classes of their own in this method.  Child classes
-     * pass their values up and, unless `clear_default_classes` is true, they
-     * are merged together and returned.
+     * may add static CSS classes of their own in this method.
      *
      * @return array the array of CSS classes that are applied to this
      *                user-interface object.
      *
      * @see SwatUIObject::getCSSClassString()
      */
-    protected function getCSSClassNames(array $child_classes = []): array
+    protected function getCSSClassNames()
     {
-        return $this->clear_default_classes
-            ? $this->classes
-            : array_merge($child_classes, $this->classes);
+        return $this->classes;
     }
 
-    protected function getDataAttributes()
+    protected function getDataAttributes(): array
     {
         $data = [];
 

--- a/Swat/SwatUIObject.php
+++ b/Swat/SwatUIObject.php
@@ -44,14 +44,6 @@ abstract class SwatUIObject extends SwatObject
     public $classes = [];
 
     /**
-     * Whether to clear out any Swat-defined classes (and only use those
-     * supplied via the <property name="classes[]">...</property> tag).
-     *
-     * @var bool
-     */
-    public bool $clear_default_classes = false;
-
-    /**
      * A user-specified key-value array of data attributes that are applied
      * to this user-interface object.
      *

--- a/Swat/SwatUIObject.php
+++ b/Swat/SwatUIObject.php
@@ -44,9 +44,17 @@ abstract class SwatUIObject extends SwatObject
     public $classes = [];
 
     /**
-     * A user-specified key-value array of data attributes that are applied 
+     * Whether to clear out any Swat-defined classes (and only use those
+     * supplied via the <property name="classes[]">...</property> tag).
+     *
+     * @var bool
+     */
+    public bool $clear_default_classes = false;
+
+    /**
+     * A user-specified key-value array of data attributes that are applied
      * to this user-interface object.
-     * 
+     *
      * @var array
      */
     public $data = [];
@@ -357,7 +365,7 @@ abstract class SwatUIObject extends SwatObject
     protected function getDataAttributes()
     {
         $data_attributes = [];
-        
+
         foreach ($this->data as $key => $value) {
             $data_attributes["data-{$key}"] = $value;
         }


### PR DESCRIPTION
This allows adding `data-*` attributes on SwatUI elements, e.g.:

```xml
<widget class="SwatButton" id="submit_button">
	<property name="data-variant">primary</property>
	<property name="title" translatable="yes">Sign up for an account</property>
</widget>
```

It will require adding something like this to every element that requires it:

```php
$tag = new SwatHtmlTag('button');
...
$tag->addAttributes($this->getDataAttributes());
```

For now, I'm just adding it to the SwatButton element, so that we can test adding `data-variant` attributes to test React styling within PHP-rendered output.
