### PR TITLE
Add the ability to not collapse single-item SwatFlydown and SwatRadioList

### DIFF
--- a/Swat/SwatFlydown.php
+++ b/Swat/SwatFlydown.php
@@ -39,6 +39,16 @@ class SwatFlydown extends SwatOptionControl implements SwatState
      */
     public $blank_title = '';
 
+    /**
+     * Collapse single
+     *
+     * Whether to collapse a list/flydown with only one option down to a hidden field (default),
+     * or display it as a list/flydown with just one option.
+     *
+     * @var bool
+     */
+    public bool $collapse_single = true;
+
     // }}}
     // {{{ public function display()
 
@@ -70,8 +80,11 @@ class SwatFlydown extends SwatOptionControl implements SwatState
             $options = array_merge([$this->getBlankOption()], $options);
         }
 
-        // only show a select if there is more than one option
-        if (count($options) > 1) {
+        // if there is only one element and it should be collapsed
+        if (count($options) === 1 && $this->collapse_single) {
+            // get first and only element
+            $this->displaySingle(current($options));
+        } elseif (count($options) !== 0) {
             $flydown_value = $this->serialize_values
                 ? $this->value
                 : (string) $this->value;
@@ -150,9 +163,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
             }
 
             $select_tag->close();
-        } elseif (count($options) === 1) {
-            // get first and only element
-            $this->displaySingle(current($options));
         }
 
         $wrapper->close();

--- a/Swat/SwatRadioList.php
+++ b/Swat/SwatRadioList.php
@@ -9,6 +9,18 @@
  */
 class SwatRadioList extends SwatFlydown
 {
+    // {{{ public properties
+
+    /**
+     * Whether to collapse a list with only one option down to a hidden field (default),
+     * or display it as a list with just one option.
+     *
+     * @var bool
+     */
+    public bool $collapse_single = true;
+
+    // }}}
+
     // {{{ private properties
 
     /**
@@ -65,7 +77,7 @@ class SwatRadioList extends SwatFlydown
         // the process step
         $this->getForm()->addHiddenField($this->id . '_submitted', 1);
 
-        if (count($options) === 1) {
+        if (count($options) === 1 && $this->collapse_single) {
             // get first and only element
             $this->displaySingle(current($options));
             return;

--- a/Swat/SwatRadioList.php
+++ b/Swat/SwatRadioList.php
@@ -9,18 +9,6 @@
  */
 class SwatRadioList extends SwatFlydown
 {
-    // {{{ public properties
-
-    /**
-     * Whether to collapse a list with only one option down to a hidden field (default),
-     * or display it as a list with just one option.
-     *
-     * @var bool
-     */
-    public bool $collapse_single = true;
-
-    // }}}
-
     // {{{ private properties
 
     /**


### PR DESCRIPTION
By default, `SwatRadioList`s that only have a single option will be displayed differently than a list with multiple options.

By passing in a `collapse_single` property in the XML, this can be overloaded so that single-option lists are rendered the same as mutli-option lists:

```diff
  <widget class="SwatRadioList" id="subscription_type">
+     <property name="collapse_single" type="boolean">false</property>
      ....
  </widget>
```