### PR TITLE
Validate widget ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 # misc
 .DS_Store
 .env
+.idea/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/Swat/SwatUI.php
+++ b/Swat/SwatUI.php
@@ -544,7 +544,7 @@ class SwatUI extends SwatObject
                 // for JS variables and CSS identifiers
                 if (
                     !preg_match(
-                        '/^[a-zA-Z]+[a-zA-Z0-9-]*$/',
+                        '/^[a-zA-Z]+[a-zA-Z0-9_]*$/',
                         $parsed_object->id,
                     )
                 ) {

--- a/Swat/SwatUI.php
+++ b/Swat/SwatUI.php
@@ -166,12 +166,17 @@ class SwatUI extends SwatObject
      *                           validation mode set by the static method
      *                           {@link SwatUI::setValidateMode()}.
      *
-     * @throws SwatFileNotFoundException, SwatInvalidSwatMLException,
-     *         SwatDuplicateIdException, SwatInvalidClassException,
-     *         SwatInvalidPropertyException, SwatInvalidPropertyTypeException,
-     *         SwatDoesNotImplementException, SwatClassNotFoundException,
-     *         SwatInvalidConstantExpressionException,
-     *         SwatUndefinedConstantException
+     * @throws SwatClassNotFoundException
+     * @throws SwatDoesNotImplementException
+     * @throws SwatDuplicateIdException
+     * @throws SwatException
+     * @throws SwatFileNotFoundException
+     * @throws SwatInvalidClassException
+     * @throws SwatInvalidConstantExpressionException
+     * @throws SwatInvalidPropertyException
+     * @throws SwatInvalidPropertyTypeException
+     * @throws SwatInvalidSwatMLException
+     * @throws SwatUndefinedConstantException
      */
     public function loadFromXML($filename, $container = null, $validate = null)
     {
@@ -444,7 +449,7 @@ class SwatUI extends SwatObject
     // {{{ private function parseUI()
 
     /**
-     * Recursivly parses an XML node into a widget tree
+     * Recursively parses an XML node into a widget tree
      *
      * Calls self on all node children.
      *
@@ -452,11 +457,14 @@ class SwatUI extends SwatObject
      * @param SwatUIObject $parent the parent object (usually a SwatContainer)
      *                              to add parsed objects to.
      *
-     * @throws SwatDuplicateIdException, SwatInvalidClassException,
-     *         SwatInvalidPropertyException, SwatInvalidPropertyTypeException,
-     *         SwatDoesNotImplementException, SwatClassNotFoundException,
-     *         SwatInvalidConstantExpressionException,
-     *         SwatUndefinedConstantException
+     * @throws SwatClassNotFoundException
+     * @throws SwatDoesNotImplementException
+     * @throws SwatDuplicateIdException
+     * @throws SwatInvalidClassException
+     * @throws SwatInvalidConstantExpressionException
+     * @throws SwatInvalidPropertyException
+     * @throws SwatInvalidPropertyTypeException
+     * @throws SwatUndefinedConstantException
      */
     private function parseUI($node, SwatUIObject $parent)
     {
@@ -509,7 +517,9 @@ class SwatUI extends SwatObject
      * @param string $element_name the name of the XML element node the object
      *                              was parsed from.
      *
-     * @throws SwatDuplicateIdException, SwatInvalidClassException
+     * @throws SwatDuplicateIdException
+     * @throws SwatInvalidClassException
+     * @throws SwatInvalidPropertyException
      */
     private function checkParsedObject(
         SwatUIObject $parsed_object,
@@ -532,13 +542,18 @@ class SwatUI extends SwatObject
                 }
                 // make sure id only contains characters valid
                 // for JS variables and CSS identifiers
-                if (!preg_match('/^[a-zA-Z]+[a-zA-Z0-9-]*$/', $parsed_object->id)) {
+                if (
+                    !preg_match(
+                        '/^[a-zA-Z]+[a-zA-Z0-9-]*$/',
+                        $parsed_object->id,
+                    )
+                ) {
                     throw new SwatInvalidPropertyException(
-                        "A widget has an invalid value for its id: " .
+                        'A widget has an invalid value for its id: ' .
                             "'{$parsed_object->id}'",
                         0,
                         $parsed_object,
-                        'id'
+                        'id',
                     );
                 }
             } elseif (
@@ -609,6 +624,7 @@ class SwatUI extends SwatObject
      * @return SwatUIObject a reference to the object created.
      *
      * @throws SwatClassNotFoundException
+     * @throws SwatInvalidClassException
      */
     private function parseObject($node)
     {
@@ -650,9 +666,10 @@ class SwatUI extends SwatObject
      * @param array $property_node the XML property node to parse.
      * @param SwatUIObject $object the object to apply the property to.
      *
-     * @throws SwatInvalidPropertyException, SwatInvalidPropertyTypeException,
-     *         SwatInvalidConstantExpressionException,
-     *         SwatUndefinedConstantException
+     * @throws SwatInvalidConstantExpressionException
+     * @throws SwatInvalidPropertyException
+     * @throws SwatInvalidPropertyTypeException
+     * @throws SwatUndefinedConstantException
      */
     private function parseProperty($property_node, SwatUIObject $object)
     {
@@ -744,14 +761,13 @@ class SwatUI extends SwatObject
      * @param string $name the name of the property.
      * @param string $value the value of the property.
      * @param string $type the type of the value.
-     * @param boolean translatable whether the property is translatable.
+     * @param boolean $translatable whether the property is translatable.
      * @param SwatUIObject $object the object the property applies to.
      *
      * @return mixed the value of the property as an appropriate PHP datatype.
      *
-     * @throws SwatInvalidPropertyTypeException,
-     *         SwatInvalidConstantExpressionException,
-     *         SwatUndefinedConstantException
+     * @throws SwatInvalidPropertyTypeException
+     * @throws SwatInvalidConstantExpressionException
      */
     private function parseValue(
         $name,
@@ -891,8 +907,8 @@ class SwatUI extends SwatObject
      *
      * @return string the value of the class constant.
      *
-     * @throws SwatInvalidConstantExpressionException,
-     *         SwatUndefinedConstantException
+     * @throws SwatInvalidConstantExpressionException
+     * @throws SwatUndefinedConstantException
      */
     private function parseConstantExpression($expression, SwatUIObject $object)
     {

--- a/Swat/SwatUI.php
+++ b/Swat/SwatUI.php
@@ -530,6 +530,17 @@ class SwatUI extends SwatObject
                         $parsed_object->id,
                     );
                 }
+                // make sure id only contains characters valid
+                // for JS variables and CSS identifiers
+                if (!preg_match('/^[a-zA-Z]+[a-zA-Z0-9-]*$/', $parsed_object->id)) {
+                    throw new SwatInvalidPropertyException(
+                        "A widget has an invalid value for its id: " .
+                            "'{$parsed_object->id}'",
+                        0,
+                        $parsed_object,
+                        'id'
+                    );
+                }
             } elseif (
                 !class_exists('SwatWidget') ||
                 !$parsed_object instanceof SwatWidget


### PR DESCRIPTION
Ensures that if you have a widget with an `id` property, that property's value is valid for JS variable names.

In the case of `SwatFieldset`s, when the widget is rendered, the `getInlineJavascript` method is triggered, with the following code:

```php
protected function getInlineJavaScript()
{
    return sprintf(
        "var %s_obj = new SwatFieldset('%s');",
        $this->id,
        $this->id,
    );
}
```

If the `id` is, for example, `my-widget` (which is valid in CSS), then the output will be:

```js
var my-widget_obj = new SwatFieldset('my-widget');
```

... which is not a valid JS variable name.
