### PR TITLE
Add SwatDBClassMap::new() helper method

### DIFF
--- a/SwatDB/SwatDBClassMap.php
+++ b/SwatDB/SwatDBClassMap.php
@@ -120,6 +120,28 @@ class SwatDBClassMap
     }
 
     // }}}
+
+    /**
+     * Resolves a class name from the class map and returns a new instance of
+     * that class.
+     *
+     * @template T
+     * @param class-string<T> $from_class_name the name of the class to resolve
+     * @param mixed ...$params extra parameters to pass to the new class constructor
+     * @return T a new instance of the resolved class
+     *
+     * @throws SwatInvalidClassException if a mapped class is not a subclass of
+     *                                   its original class
+     */
+    public static function new(
+        string $from_class_name,
+        mixed ...$params,
+    ): string {
+        $class = self::get($from_class_name);
+
+        return new $class(...$params);
+    }
+
     // {{{ private function __construct()
 
     /**


### PR DESCRIPTION
There are lots of cases of this in our code:

```php
$class_name = SwatDBClassMap::get(SomeClass::class);
$foo = new $class_name();
$bar = new $class_name($some, $args);
```

Adding this new helper allows us to shorten it to the following (and removing the necessity of the intermediate variable:

```php
$foo = SwatDBClassMap::new(SomeClass::class);
$bar = SwatDBClassMap::new(SomeClass::class, $some, $args);
```