### PR TITLE
Helpful return types

### DIFF
--- a/SwatDB/SwatDBClassMap.php
+++ b/SwatDB/SwatDBClassMap.php
@@ -57,14 +57,12 @@ class SwatDBClassMap
     public static function add(
         string $from_class_name,
         string $to_class_name,
-    ): void
-    {
+    ): void {
         // check for subclass
         if (!is_subclass_of($to_class_name, $from_class_name)) {
             throw new SwatInvalidClassException(
                 sprintf(
-                    'Invalid ' .
-                    'class-mapping detected. %s is not a subclass of %s.',
+                    'Invalid class-mapping detected. %s is not a subclass of %s.',
                     $to_class_name,
                     $from_class_name,
                 ),
@@ -126,9 +124,8 @@ class SwatDBClassMap
      */
     public static function new(
         string $from_class_name,
-        mixed  ...$params,
-    ): object
-    {
+        mixed ...$params,
+    ): object {
         $class = self::get($from_class_name);
 
         return new $class(...$params);
@@ -137,5 +134,7 @@ class SwatDBClassMap
     /**
      * The class map is a static object and should not be instantiated
      */
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 }

--- a/SwatDB/SwatDBClassMap.php
+++ b/SwatDB/SwatDBClassMap.php
@@ -6,12 +6,14 @@
  * This is a static class and should not be instantiated.
  *
  * @package   SwatDB
- * @copyright 2006-2016 silverorange
+ * @copyright 2006-2024 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
+ * @template TParent of object
+ * @template TChild of TParent
  */
 class SwatDBClassMap
 {
-    // {{{ private properties
 
     /**
      * An associative array of class-mappings
@@ -19,12 +21,10 @@ class SwatDBClassMap
      * The array has keys of the 'from class name' and values of the
      * 'to class name'.
      *
-     * @var array<class-string, class-string>
+     * @var array<class-string<TParent>, class-string<TChild>>
      */
     private static array $map = [];
 
-    // }}}
-    // {{{ public static function add()
 
     /**
      * Maps a class name to another class name
@@ -43,20 +43,22 @@ class SwatDBClassMap
      * <i>$from_class_name</i> is already mapped to another class the old
      * mapping is overwritten.
      *
-     * @param class-string $from_class_name the class name to map from.
-     * @param class-string $to_class_name the class name to map to. The mapped
-     *                                    class must be a subclass of the
-     *                                    <i>$from_class_name</i> otherwise
-     *                                    class resolution using
-     *                                    {@link SwatDBClassMap::get()} will
-     *                                    throw an exception.
+     * @param class-string<TParent> $from_class_name the class name to map from.
+     * @param class-string<TChild> $to_class_name the class name to map to.
+     *                                             The mapped class must be a
+     *                                             subclass of the
+     *                                             <i>$from_class_name</i> otherwise
+     *                                             class resolution using
+     *                                             {@link SwatDBClassMap::get()}
+     *                                             will throw an exception.
      *
      * @throws SwatException if the added mapping creates a circular dependency.
      */
     public static function add(
         string $from_class_name,
         string $to_class_name,
-    ): void {
+    ): void
+    {
         // check for circular dependency
         if (array_key_exists($to_class_name, self::$map)) {
             $class_name = $to_class_name;
@@ -80,20 +82,18 @@ class SwatDBClassMap
         self::$map[$from_class_name] = $to_class_name;
     }
 
-    // }}}
-    // {{{ public static function get()
 
     /**
      * Resolves a class name from the class map
      *
-     * @param class-string $from_class_name the name of the class to resolve.
+     * @param class-string<TParent> $from_class_name the name of the class to resolve.
      *
-     * @return class-string the resolved class name. If no class mapping exists
-     *                      for the given class name, the same class name is
-     *                      returned.
+     * @return class-string<TChild> the resolved class name. If no class mapping
+     *                              exists for the given class name, the same
+     *                              class name is returned.
      *
      * @throws SwatInvalidClassException if a mapped class is not a subclass of
-     *                                    its original class.
+     *                                   its original class.
      */
     public static function get(string $from_class_name): string
     {
@@ -106,7 +106,7 @@ class SwatDBClassMap
                 throw new SwatInvalidClassException(
                     sprintf(
                         'Invalid ' .
-                            'class-mapping detected. %s is not a subclass of %s.',
+                        'class-mapping detected. %s is not a subclass of %s.',
                         $to_class_name,
                         $from_class_name,
                     ),
@@ -119,30 +119,28 @@ class SwatDBClassMap
         return $to_class_name;
     }
 
-    // }}}
 
     /**
      * Resolves a class name from the class map and returns a new instance of
      * that class.
      *
-     * @template T
-     * @param class-string<T> $from_class_name the name of the class to resolve
+     * @param class-string<TParent> $from_class_name the name of the class to resolve
      * @param mixed ...$params extra parameters to pass to the new class constructor
-     * @return T a new instance of the resolved class
+     * @return object<TChild> a new instance of the resolved class
      *
      * @throws SwatInvalidClassException if a mapped class is not a subclass of
      *                                   its original class
      */
     public static function new(
         string $from_class_name,
-        mixed ...$params,
-    ): object {
+        mixed  ...$params,
+    ): object
+    {
         $class = self::get($from_class_name);
 
         return new $class(...$params);
     }
 
-    // {{{ private function __construct()
 
     /**
      * The class map is a static object and should not be instantiated
@@ -150,6 +148,4 @@ class SwatDBClassMap
     private function __construct()
     {
     }
-
-    // }}}
 }

--- a/SwatDB/SwatDBDataObject.php
+++ b/SwatDB/SwatDBDataObject.php
@@ -431,9 +431,9 @@ class SwatDBDataObject extends SwatObject implements
      * database as a new row. This method recursively duplicates
      * sub-dataobjects which were registered with <i>$autosave</i> set to true.
      *
-     * @return SwatDBDataobject a duplicate of this object.
+     * @return static a duplicate of this object.
      */
-    public function duplicate()
+    public function duplicate(): static
     {
         $class = get_class($this);
         $new_object = new $class();

--- a/package.json
+++ b/package.json
@@ -9,6 +9,5 @@
 	"devDependencies": {
 		"@prettier/plugin-php": "^0.19.0",
 		"prettier": "^2.8.3"
-	},
-	"packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -9,5 +9,6 @@
 	"devDependencies": {
 		"@prettier/plugin-php": "^0.19.0",
 		"prettier": "^2.8.3"
-	}
+	},
+	"packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }


### PR DESCRIPTION
A few type improvements to make IDE's more helpful:

### SwatDBDataObject

- fix return type of `duplicate()` method so it returns the actual implementation class

### SwatDBClassMap

- add type hints for properties and methods
- move logic that checks that _TO_CLASS_ is a subclass of _FROM_CLASS_ from `get()` method to `set()` method

### General

- remove vim block comments