### PR TITLE
Fix enum handling

### DIFF
--- a/SwatDB/SwatDBDataObject.php
+++ b/SwatDB/SwatDBDataObject.php
@@ -1011,8 +1011,6 @@ class SwatDBDataObject extends SwatObject implements
      */
     public function setDatabase(MDB2_Driver_Common $db, array $set = [])
     {
-        $this->setEnumCallbackMapping($db);
-
         $key = spl_object_hash($this);
 
         if (isset($set[$key])) {
@@ -1296,10 +1294,6 @@ class SwatDBDataObject extends SwatObject implements
 
             if ($type == 'date') {
                 $value = $value->getDate();
-            } elseif ($type == 'enum') {
-                $type = 'text';
-                $value =
-                    $value instanceof BackedEnum ? $value->value : $value->name;
             }
 
             $fields[] = sprintf('%s:%s', $type, $name);

--- a/SwatDB/SwatDBEnumMapper.php
+++ b/SwatDB/SwatDBEnumMapper.php
@@ -47,7 +47,7 @@ class SwatDBEnumMapper
      *
      * @var TEnumMap
      */
-    static array $map = [];
+    protected static array $map = [];
 
     /**
      * Load the mapping into the static class.
@@ -108,7 +108,10 @@ class SwatDBEnumMapper
     /**
      * Main entry point used by MDB2 to manage custom field types and data mapping.
      *
-     * @return ($method is 'convertResult' ? TEnumClass : ($method is 'compareDefinition' ? array : string))
+     * @return ($method is 'convertResult'
+     *      ? TEnumClass
+     *      : ($method is 'compareDefinition' ? array : string)
+     *  )
      *
      * @throws SwatDBException
      */

--- a/SwatDB/SwatDBEnumMapper.php
+++ b/SwatDB/SwatDBEnumMapper.php
@@ -1,0 +1,234 @@
+<?php
+
+/**
+ * Class to help map database enum columns to PHP enum classes.
+ *
+ * Once a connection to the database has been created, use the
+ * SwatDBEnumMapper::initialize() method to set up mapping of database enum
+ * column types to PHP enum classes. This should happen once, as early
+ * as possible in your application.
+ *
+ * Example code:
+ *
+ *     $db = SwatDB::connect('...dsn...');
+ *     $map = [
+ *         'status_type' => MyStatusEnum::class
+ *     ];
+ *     SwatDBEnumMapper::initialize($db, $map);
+ *
+ * From here on, any queries against tables with columns of the `status_type` type
+ * will map those columns to MyStatusEnum classes.
+ *
+ * You should also quote these values using the "enum" type when using them in queries:
+ *
+ *     $status = MyStatusEnum::IN_PROGRESS;
+ *     $sql = sprintf(
+ *         'UPDATE table SET status = '%s' WHERE ...',
+ *         $db->quote($status, 'enum')
+ *     );
+ *     $db->query($sql);
+ *
+ * Enum classes can be simple unit enums (in which case the enum case _names_
+ * should exactly match the possible values coming from the database), or they
+ * can be backed enums (in which case the enum case _values_ should exactly match).
+ *
+ * @package   SwatDB
+ * @copyright 2025 silverorange
+ * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
+ * @template TEnumClass of \UnitEnum
+ * @template TEnumClassString of class-string<TEnumClass>
+ * @template TEnumMap of array<string, TEnumClassString>
+ */
+class SwatDBEnumMapper
+{
+    /**
+     * The map of database column types to PHP enum classes.
+     *
+     * @var TEnumMap
+     */
+    static array $map = [];
+
+    /**
+     * Load the mapping into the static class.
+     *
+     * @param TEnumMap $map
+     */
+    public static function setMap(array $map): static
+    {
+        self::$map = $map;
+        return new static();
+    }
+
+    /**
+     * Set up the database drive to automagically handle the enum mapping.
+     *
+     * @param MDB2_Driver_Common &$db
+     * @param TEnumMap $map
+     *
+     * @return void
+     */
+    public static function initialize(MDB2_Driver_Common &$db, array $map): void
+    {
+        self::$map = $map;
+
+        // set up the callback mapping
+        $db->loadModule('Datatype', null, true);
+
+        // map the DB column types to custom MDB2 types (using the PHP class name)
+        $datatype_map = [
+            ...$map,
+            // add one more entry to make db->quote()ing enum values easier
+            'enum' => 'enum',
+        ];
+
+        // tell MDB2 to use the EnumMapper::handle() method to do the enum conversion
+        $datatype_map_callback = array_fill_keys(
+            array_values($datatype_map),
+            self::handle(...),
+        );
+
+        // tells MDB2 to treat DB enum columns as their own type
+        $nativetype_map_callback = array_fill_keys(
+            array_keys($map),
+            fn(MDB2_Driver_Common $db, array $field) => [
+                [$field['type']],
+                null,
+                null,
+                false,
+            ],
+        );
+
+        // set the options on the database
+        $db->setOption('datatype_map', $datatype_map);
+        $db->setOption('datatype_map_callback', $datatype_map_callback);
+        $db->setOption('nativetype_map_callback', $nativetype_map_callback);
+    }
+
+    /**
+     * Main entry point used by MDB2 to manage custom field types and data mapping.
+     *
+     * @return ($method is 'convertResult' ? TEnumClass : ($method is 'compareDefinition' ? array : string))
+     *
+     * @throws SwatDBException
+     */
+    public static function handle(
+        MDB2_Driver_Common $db,
+        string $method,
+        array $parameters,
+    ): \UnitEnum|array|string {
+        return match ($method) {
+            'quote' => self::quote($db, $parameters['value']),
+            'convertResult' => self::convertResult(
+                $parameters['type'],
+                $parameters['value'],
+            ),
+            'getDeclaration' => $db->datatype->getDeclaration(
+                'text',
+                $parameters['name'],
+                $parameters['field'],
+            ),
+            'mapPrepareDatatype' => $db->datatype->mapPrepareDatatype('text'),
+            'compareDefinition' => self::compareDefinition($db, $parameters),
+            'getValidTypes' => '',
+            default => throw new SwatDBException(
+                "EnumMapper::handle() does not support method: $method",
+            ),
+        };
+    }
+
+    /**
+     * Converts an enum to a string value for storing in the database.
+     *
+     * Backed enums use the `->value` property; unit enums use the `->name` property.
+     * The resulting string is quoted normally.
+     *
+     * @param TEnumClass $value
+     */
+    protected static function quote(
+        MDB2_Driver_Common $db,
+        \UnitEnum $value,
+    ): string {
+        $string = $value instanceof \BackedEnum ? $value->value : $value->name;
+        return $db->datatype->quote($string, 'text');
+    }
+
+    /**
+     * Converts a string value from the database into a PHP enum class of the given type.
+     *
+     * For backed enums, the `::from()` method is used.  For unit enums, the string value
+     * is assumed to be the actual enum case name.
+     *
+     * @param TEnumClassString $classname
+     *
+     * @return TEnumClass
+     *
+     * @throws SwatDBException
+     */
+    protected static function convertResult(
+        string $classname,
+        mixed $value,
+    ): \UnitEnum {
+        try {
+            $reflection = new \ReflectionEnum($classname);
+        } catch (\ReflectionException $e) {
+            throw new SwatDBException(
+                sprintf('"%s" does not appear to be a PHP enum', $classname),
+            );
+        }
+
+        // handle backed enums
+        if ($reflection->isBacked()) {
+            try {
+                return $classname::from($value);
+            } catch (\ValueError $e) {
+                throw new SwatDBException(
+                    sprintf(
+                        'Can not create a backed enum instance of "%s" from the value "%s"',
+                        $classname,
+                        $value,
+                    ),
+                );
+            }
+        }
+
+        // handle unit enums
+        try {
+            return $reflection->getCase($value)->getValue();
+        } catch (\ReflectionException $e) {
+            throw new SwatDBException(
+                sprintf(
+                    'Can not create a unit enum instance of "%s" from the value "%s"',
+                    $classname,
+                    $value,
+                ),
+            );
+        }
+    }
+
+    /**
+     * @see MDB2_Driver_Datatype_Common::compareDefinition
+     */
+    protected static function compareDefinition(
+        MDB2_Driver_Common $db,
+        array $parameters,
+    ): array {
+        $parameters['current']['type'] = 'text';
+
+        if ($parameters['previous']['type'] === 'enum') {
+            $parameters['previous']['type'] = 'text';
+        }
+
+        return $db->datatype->compareDefinition(
+            $parameters['current'],
+            $parameters['previous'],
+        );
+    }
+
+    /**
+     * Static class should not be instantiated.
+     */
+    final private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
A correction/improvement on the handling of enums originally added in #168 .  The issue there is that the automatic conversion only happened when you loaded a SwatDBDataObject directly.  If you used SQL to load an object or group of objects, the mapping failed.

This fix does the following:
- lets you set up the mapping once, during DB initialization, rather than adding properties and code to each data object
- because you can set it up globally, columns in different tables in the database that use the same native enum field type only need to be configured once

## Configuration

Assume the same DB structure as before:

```sql
CREATE TYPE subscription_type AS ENUM ('RENEWAL', 'ADDITION', 'NEW_GROUP');

CREATE TABLE subscription (
    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
    "created_at" timestamp NOT NULL,
    "type" subscription_type NOT NULL,
    ...
);
```

And the same PHP class you want to map the column to:

```php
enum SubscriptionType {
    // case names need to match the possible enum values from the database
    case RENEWAL;
    case ADDITION;
    case NEW_GROUP;
}
```

The DAO only needs to look like this (note, there is no explicit mapping or registering of properties; only setting the types on the properties):

```php
class Subscription extends SwatDBDataObject
{
    public ?string $id = null;
    public ?SwatDate $created_at = null;

    public ?SubscriptionType $type = null;     // <== THIS IS ALL THAT'S NEEDED

    protected function init()
    {
        parent::init();

        $this->table = 'group_subscription';
        $this->id_field = 'uuid:id';

        $this->registerDateProperty('created_at');
    }
}
```

The actual mapping will be set up in your application, ideally as soon as you create a connection to the database. E.g.:

```php
$db = SwatDB::connect('...DSN String...');

/**
 * The mapping of DB type to PHP class
 * @var array<string, class-string<UnitEnum>>
 */
$map = [
    'subscription_type' => SubscriptionType::class
];

// Set it up
SwatDBEnumMapper::initialize($db, $map);
```

This will be handled automagically in a PR to the Site package, once a new version of Swat has been tagged and released: https://github.com/silverorange/site/pull/341