### PR TITLE
Bump MDB2 package version

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -41,4 +41,6 @@ jobs:
         timeout-minutes: 5
         run: |
           pnpm prettier
-          composer run phpcs
+          composer run phpcs:ci
+          composer run phpstan:ci
+

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -43,4 +43,3 @@ jobs:
           pnpm prettier
           composer run phpcs:ci
           composer run phpstan:ci
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,11 +20,17 @@ pipeline {
 
         stage('Check PHP Coding Style') {
             steps {
-                sh 'composer run phpcs'
+                sh 'composer run phpcs:ci'
             }
         }
 
-        stage('Check Formatting') {
+        stage('Check PHP Static Analysis') {
+            steps {
+                sh 'composer run phpstan:ci'
+            }
+        }
+
+        stage('Check Formating') {
             steps {
                 sh 'n -d exec engine pnpm prettier'
             }

--- a/Swat/Swat.php
+++ b/Swat/Swat.php
@@ -8,8 +8,6 @@
  */
 class Swat
 {
-    // {{{ constants
-
     /**
      * The gettext domain for Swat.
      *
@@ -17,18 +15,12 @@ class Swat
      */
     public const GETTEXT_DOMAIN = 'swat';
 
-    // }}}
-    // {{{ private properties
-
     /**
      * Whether or not this package is initialized.
      *
      * @var bool
      */
     private static $is_initialized = false;
-
-    // }}}
-    // {{{ public static function _()
 
     /**
      * Translates a phrase.
@@ -44,9 +36,6 @@ class Swat
         return self::gettext($message);
     }
 
-    // }}}
-    // {{{ public static function gettext()
-
     /**
      * Translates a phrase.
      *
@@ -61,9 +50,6 @@ class Swat
     {
         return dgettext(self::GETTEXT_DOMAIN, $message);
     }
-
-    // }}}
-    // {{{ public static function ngettext()
 
     /**
      * Translates a plural phrase.
@@ -95,17 +81,11 @@ class Swat
         );
     }
 
-    // }}}
-    // {{{ public static function setupGettext()
-
     public static function setupGettext()
     {
         bindtextdomain(self::GETTEXT_DOMAIN, __DIR__ . '/../locale');
         bind_textdomain_codeset(self::GETTEXT_DOMAIN, 'UTF-8');
     }
-
-    // }}}
-    // {{{ public static function displayMethods()
 
     /**
      * Displays the methods of an object.
@@ -125,9 +105,6 @@ class Swat
 
         echo '</ul>';
     }
-
-    // }}}
-    // {{{ public static function displayProperties()
 
     /**
      * Displays the properties of an object.
@@ -151,9 +128,6 @@ class Swat
         echo '</ul>';
     }
 
-    // }}}
-    // {{{ public static function printObject()
-
     /**
      * Displays an object's properties and values recursively.
      *
@@ -168,9 +142,6 @@ class Swat
     {
         echo '<pre>' . print_r($object, true) . '</pre>';
     }
-
-    // }}}
-    // {{{ public static function displayInlineJavaScript()
 
     /**
      * Displays inline JavaScript properly encapsulating the script in a CDATA
@@ -188,9 +159,6 @@ class Swat
         }
     }
 
-    // }}}
-    // {{{ public static function init()
-
     public static function init()
     {
         if (self::$is_initialized) {
@@ -202,20 +170,13 @@ class Swat
         self::$is_initialized = true;
     }
 
-    // }}}
-    // {{{ private function __construct()
-
     /**
      * Don't allow instantiation of the Swat object.
      *
      * This class contains only static methods and should not be instantiated.
      */
     private function __construct() {}
-
-    // }}}
 }
-
-// {{{ dummy dngettext()
 
 // Define a dummy dngettext() for when gettext is not available.
 if (!function_exists('dngettext')) {
@@ -246,9 +207,6 @@ if (!function_exists('dngettext')) {
     }
 }
 
-// }}}
-// {{{ dummy dgettext()
-
 // Define a dummy dgettext() for when gettext is not available.
 if (!function_exists('dgettext')) {
     /**
@@ -268,5 +226,3 @@ if (!function_exists('dgettext')) {
         return $messageid;
     }
 }
-
-// }}}

--- a/Swat/SwatAbstractOverlay.php
+++ b/Swat/SwatAbstractOverlay.php
@@ -17,8 +17,6 @@
  */
 abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
 {
-    // {{{ public properties
-
     /**
      * Access key.
      *
@@ -34,9 +32,6 @@ abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
      * @var string
      */
     public $value;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new overlay widget.
@@ -62,9 +57,6 @@ abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
             'packages/swat/javascript/swat-z-index-manager.js',
         );
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this overlay widget.
@@ -96,9 +88,6 @@ abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ public function getState()
-
     /**
      * Gets the current state of this simple color selector widget.
      *
@@ -110,9 +99,6 @@ abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
     {
         return $this->value;
     }
-
-    // }}}
-    // {{{ public function setState()
 
     /**
      * Sets the current state of this simple color selector widget.
@@ -126,9 +112,6 @@ abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
         $this->value = $state;
     }
 
-    // }}}
-    // {{{ abstract protected function getInlineJavaScript()
-
     /**
      * Gets inline JavaScript.
      *
@@ -141,6 +124,4 @@ abstract class SwatAbstractOverlay extends SwatInputControl implements SwatState
             SwatString::quoteJavaScriptString(Swat::_('Close')),
         );
     }
-
-    // }}}
 }

--- a/Swat/SwatAccordion.php
+++ b/Swat/SwatAccordion.php
@@ -14,8 +14,6 @@
  */
 class SwatAccordion extends SwatNoteBook
 {
-    // {{{ public properties
-
     /**
      * Whether or not to animate the opening/closing of the accordion.
      *
@@ -31,9 +29,6 @@ class SwatAccordion extends SwatNoteBook
      * @var bool
      */
     public $always_open = false;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new accordion view.
@@ -52,9 +47,6 @@ class SwatAccordion extends SwatNoteBook
         $this->addStyleSheet('packages/swat/styles/swat-accordion.css');
         $this->addJavaScript('packages/swat/javascript/swat-accordion.js');
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this notebook.
@@ -127,9 +119,6 @@ class SwatAccordion extends SwatNoteBook
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ protected function getInlineJavaScript()
-
     /**
      * Gets the inline JavaScript used by this accordion view.
      *
@@ -159,13 +148,8 @@ class SwatAccordion extends SwatNoteBook
         return $javascript;
     }
 
-    // }}}
-    // {{{ protected function getJavaScriptClassName()
-
     protected function getJavaScriptClassName()
     {
         return 'SwatAccordion';
     }
-
-    // }}}
 }

--- a/Swat/SwatActionItem.php
+++ b/Swat/SwatActionItem.php
@@ -10,8 +10,6 @@
  */
 class SwatActionItem extends SwatControl implements SwatUIParent
 {
-    // {{{ public properties
-
     /**
      * A unique identifier for this action item.
      *
@@ -33,9 +31,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
      */
     public $widget;
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this action item.
      *
@@ -50,9 +45,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
             $this->widget->init();
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this item.
@@ -69,9 +61,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 
         $this->widget->display();
     }
-
-    // }}}
-    // {{{ public function setWidget()
 
     /**
      * Sets the widget to use for this item.
@@ -95,9 +84,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
         $this->widget = $widget;
         $widget->parent = $this;
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Adds a child object.
@@ -128,9 +114,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this action item.
      *
@@ -150,9 +133,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this action item.
      *
@@ -171,9 +151,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -222,9 +199,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -254,9 +228,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -277,9 +248,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
         return $states;
     }
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -297,9 +265,6 @@ class SwatActionItem extends SwatControl implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -324,6 +289,4 @@ class SwatActionItem extends SwatControl implements SwatUIParent
 
         return $copy;
     }
-
-    // }}}
 }

--- a/Swat/SwatActions.php
+++ b/Swat/SwatActions.php
@@ -8,8 +8,6 @@
  */
 class SwatActions extends SwatControl implements SwatUIParent
 {
-    // {{{ public properties
-
     /**
      * Selected action.
      *
@@ -38,9 +36,6 @@ class SwatActions extends SwatControl implements SwatUIParent
      */
     public $auto_reset = true;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * The available actions for this actions selector indexed by id.
      *
@@ -49,9 +44,6 @@ class SwatActions extends SwatControl implements SwatUIParent
      * @var array
      */
     protected $action_items_by_id = [];
-
-    // }}}
-    // {{{ private properties
 
     /**
      * The available actions for this actions selector.
@@ -78,9 +70,6 @@ class SwatActions extends SwatControl implements SwatUIParent
      */
     private $selector;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new actions list.
      *
@@ -98,9 +87,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         $this->addStyleSheet('packages/swat/styles/swat-actions.css');
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this action item.
      *
@@ -114,9 +100,6 @@ class SwatActions extends SwatControl implements SwatUIParent
             $action_item->init();
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this list of actions.
@@ -205,9 +188,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Figures out what action item is selected.
      *
@@ -233,9 +213,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function addActionItem()
-
     /**
      * Adds an action item.
      *
@@ -254,9 +231,6 @@ class SwatActions extends SwatControl implements SwatUIParent
             $this->action_items_by_id[$item->id] = $item;
         }
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Adds a child object.
@@ -287,9 +261,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this actions list.
      *
@@ -308,9 +279,6 @@ class SwatActions extends SwatControl implements SwatUIParent
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this actions
@@ -332,9 +300,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         return $set;
     }
 
-    // }}}
-    // {{{ public function getActionItems()
-
     /**
      * Gets the array of current SwatActions.
      *
@@ -346,9 +311,6 @@ class SwatActions extends SwatControl implements SwatUIParent
     {
         return $this->action_items;
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -397,9 +359,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -435,9 +394,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -458,9 +414,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         return $states;
     }
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -478,9 +431,6 @@ class SwatActions extends SwatControl implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ public function setViewSelector()
 
     /**
      * Sets the optional view and selector of this actions control.
@@ -522,9 +472,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         $this->selector = $selector;
     }
 
-    // }}}
-    // {{{ public function copy()
-
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
      *
@@ -555,9 +502,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         return $copy;
     }
 
-    // }}}
-    // {{{ public function hasMessage()
-
     /**
      * Checks for the presence of messages.
      *
@@ -581,9 +525,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         return $has_message;
     }
 
-    // }}}
-    // {{{ protected function displayButton()
-
     /**
      * Displays the button for this action list.
      *
@@ -595,9 +536,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         $button->setFromStock('apply');
         $button->display();
     }
-
-    // }}}
-    // {{{ protected function createCompositeWidgets()
 
     /**
      * Creates and the composite flydown and button widgets of this actions
@@ -613,9 +551,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         $button = new SwatButton($this->id . '_apply_button');
         $this->addCompositeWidget($button, 'apply_button');
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets inline JavaScript required to show and hide selected action items.
@@ -670,9 +605,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         return $javascript;
     }
 
-    // }}}
-    // {{{ protected function getInlineJavaScriptTranslations()
-
     /**
      * Gets translatable string resources for the JavaScript object for
      * this widget.
@@ -700,9 +632,6 @@ class SwatActions extends SwatControl implements SwatUIParent
         );
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this actions list.
      *
@@ -715,6 +644,4 @@ class SwatActions extends SwatControl implements SwatUIParent
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatBooleanCellRenderer.php
+++ b/Swat/SwatBooleanCellRenderer.php
@@ -8,8 +8,6 @@
  */
 class SwatBooleanCellRenderer extends SwatCellRenderer
 {
-    // {{{ public properties
-
     /**
      * Value of this cell.
      *
@@ -53,9 +51,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
      * @see SwatBooleanCellRenderer::setFromStock()
      */
     public $stock_id;
-
-    // }}}
-    // {{{ public function setFromStock()
 
     /**
      * Sets the values of this boolean cell renderer to a stock type.
@@ -114,9 +109,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
         }
     }
 
-    // }}}
-    // {{{ public function render()
-
     /**
      * Renders the contents of this cell.
      *
@@ -147,9 +139,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
         }
     }
 
-    // }}}
-    // {{{ public function getDataSpecificCSSClassNames()
-
     /**
      * Gets the data specific CSS class names for this cell renderer.
      *
@@ -168,9 +157,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
         return [];
     }
 
-    // }}}
-    // {{{ protected function renderTrue()
-
     /**
      * Renders a true value for this boolean cell renderer.
      */
@@ -183,9 +169,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
         }
     }
 
-    // }}}
-    // {{{ protected function renderFalse()
-
     /**
      * Renders a false value for this boolean cell renderer.
      */
@@ -197,9 +180,6 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
             echo $this->false_content;
         }
     }
-
-    // }}}
-    // {{{ protected function displayCheck()
 
     /**
      * Renders a checkmark image for this boolean cell renderer.
@@ -216,6 +196,4 @@ class SwatBooleanCellRenderer extends SwatCellRenderer
         $image_tag->width = '14';
         $image_tag->display();
     }
-
-    // }}}
 }

--- a/Swat/SwatButton.php
+++ b/Swat/SwatButton.php
@@ -11,8 +11,6 @@
  */
 class SwatButton extends SwatInputControl
 {
-    // {{{ public properties
-
     /**
      * The visible text on this button.
      *
@@ -81,9 +79,6 @@ class SwatButton extends SwatInputControl
      */
     public $confirmation_message;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * A CSS class set by the stock_id of this button.
      *
@@ -101,9 +96,6 @@ class SwatButton extends SwatInputControl
      * @var bool
      */
     protected $clicked = false;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new button.
@@ -123,9 +115,6 @@ class SwatButton extends SwatInputControl
         $this->requires_id = true;
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this widget.
      *
@@ -144,9 +133,6 @@ class SwatButton extends SwatInputControl
             $this->setFromStock($this->stock_id, false);
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this button.
@@ -172,9 +158,6 @@ class SwatButton extends SwatInputControl
         }
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Does button processing.
      *
@@ -194,9 +177,6 @@ class SwatButton extends SwatInputControl
         }
     }
 
-    // }}}
-    // {{{ public function hasBeenClicked()
-
     /**
      * Returns whether this button has been clicked.
      *
@@ -206,9 +186,6 @@ class SwatButton extends SwatInputControl
     {
         return $this->clicked;
     }
-
-    // }}}
-    // {{{ public function setFromStock()
 
     /**
      * Sets the values of this button to a stock type.
@@ -276,9 +253,6 @@ class SwatButton extends SwatInputControl
         $this->stock_class = $class;
     }
 
-    // }}}
-    // {{{ protected function getInputTag()
-
     /**
      * Get the HTML tag to display for this button.
      *
@@ -309,9 +283,6 @@ class SwatButton extends SwatInputControl
         return $tag;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this button.
      *
@@ -336,9 +307,6 @@ class SwatButton extends SwatInputControl
         return array_merge($classes, parent::getCSSClassNames());
     }
 
-    // }}}
-    // {{{ protected function getJavaScriptClass()
-
     /**
      * Gets the name of the JavaScript class to instantiate for this button.
      *
@@ -352,9 +320,6 @@ class SwatButton extends SwatInputControl
     {
         return 'SwatButton';
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript required for this control.
@@ -395,6 +360,4 @@ class SwatButton extends SwatInputControl
 
         return $javascript;
     }
-
-    // }}}
 }

--- a/Swat/SwatByteCellRenderer.php
+++ b/Swat/SwatByteCellRenderer.php
@@ -11,17 +11,12 @@
  */
 class SwatByteCellRenderer extends SwatCellRenderer
 {
-    // {{{ public properties
-
     /**
      * Value in bytes.
      *
      * @var float
      */
     public $value;
-
-    // }}}
-    // {{{ public function render()
 
     /**
      * Renders the contents of this cell.
@@ -38,6 +33,4 @@ class SwatByteCellRenderer extends SwatCellRenderer
 
         echo SwatString::minimizeEntities(SwatString::byteFormat($this->value));
     }
-
-    // }}}
 }

--- a/Swat/SwatCalendar.php
+++ b/Swat/SwatCalendar.php
@@ -11,8 +11,6 @@
  */
 class SwatCalendar extends SwatControl
 {
-    // {{{ public properties
-
     /**
      * Start date of the valid range (inclusive).
      *
@@ -26,9 +24,6 @@ class SwatCalendar extends SwatControl
      * @var SwatDate
      */
     public $valid_range_end;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new calendar.
@@ -52,9 +47,6 @@ class SwatCalendar extends SwatControl
             'packages/swat/javascript/swat-z-index-manager.js',
         );
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this calendar widget.
@@ -93,9 +85,6 @@ class SwatCalendar extends SwatControl
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this calendar widget.
      *
@@ -108,9 +97,6 @@ class SwatCalendar extends SwatControl
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets inline calendar JavaScript.
@@ -155,9 +141,6 @@ class SwatCalendar extends SwatControl
 
         return $javascript;
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScriptTranslations()
 
     /**
      * Gets translatable string resources for the JavaScript object for
@@ -211,6 +194,4 @@ class SwatCalendar extends SwatControl
             . "SwatCalendar.open_toggle_text = '{$open_toggle_text}';\n"
             . "SwatCalendar.close_toggle_text = '{$close_toggle_text}';\n";
     }
-
-    // }}}
 }

--- a/Swat/SwatCascadeFlydown.php
+++ b/Swat/SwatCascadeFlydown.php
@@ -13,8 +13,6 @@
  */
 class SwatCascadeFlydown extends SwatFlydown
 {
-    // {{{ public properties
-
     /**
      * Flydown options.
      *
@@ -41,9 +39,6 @@ class SwatCascadeFlydown extends SwatFlydown
      */
     public $cascade_from;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new calendar.
      *
@@ -63,9 +58,6 @@ class SwatCascadeFlydown extends SwatFlydown
         $this->addJavaScript('packages/swat/javascript/swat-cascade.js');
     }
 
-    // }}}
-    // {{{ public function display()
-
     /**
      * Displays this cascading flydown.
      *
@@ -80,9 +72,6 @@ class SwatCascadeFlydown extends SwatFlydown
         parent::display();
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
-
-    // }}}
-    // {{{ public function addOption()
 
     /**
      * Adds an option to this option control.
@@ -116,9 +105,6 @@ class SwatCascadeFlydown extends SwatFlydown
         $this->options[$parent][] = $option;
     }
 
-    // }}}
-    // {{{ public function addOptionsByArray()
-
     /**
      * Adds options to this option control using an associative array.
      *
@@ -139,9 +125,6 @@ class SwatCascadeFlydown extends SwatFlydown
             }
         }
     }
-
-    // }}}
-    // {{{ protected function getOptions()
 
     /**
      * Gets the options of this flydown as a flat array.
@@ -189,18 +172,12 @@ class SwatCascadeFlydown extends SwatFlydown
         return $options;
     }
 
-    // }}}
-    // {{{ protected function getParentValue()
-
     protected function getParentValue()
     {
         return $this->cascade_from instanceof SwatFlydown
             ? $this->cascade_from->value
             : null;
     }
-
-    // }}}
-    // {{{ protected function getParentOptions()
 
     protected function getParentOptions()
     {
@@ -209,25 +186,16 @@ class SwatCascadeFlydown extends SwatFlydown
             : [];
     }
 
-    // }}}
-    // {{{ protected function hasEmptyParent()
-
     protected function hasEmptyParent()
     {
         return count($this->getParentOptions()) === 0;
     }
-
-    // }}}
-    // {{{ protected function hasSingleParent()
 
     protected function hasSingleParent()
     {
         return count($this->getParentOptions()) === 1
             && $this->cascade_from->show_blank == false;
     }
-
-    // }}}
-    // {{{ protected function getBlankOption()
 
     protected function getBlankOption()
     {
@@ -238,9 +206,6 @@ class SwatCascadeFlydown extends SwatFlydown
 
         return new SwatFlydownBlankOption(null, $blank_title);
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript that makes this control work.
@@ -326,6 +291,4 @@ class SwatCascadeFlydown extends SwatFlydown
 
         return $javascript;
     }
-
-    // }}}
 }

--- a/Swat/SwatCellRenderer.php
+++ b/Swat/SwatCellRenderer.php
@@ -10,8 +10,6 @@
  */
 abstract class SwatCellRenderer extends SwatUIObject
 {
-    // {{{ public properties
-
     /**
      * A non-visible unique id for this cell renderer, or null.
      *
@@ -30,9 +28,6 @@ abstract class SwatCellRenderer extends SwatUIObject
      * @var bool
      */
     public $sensitive = true;
-
-    // }}}
-    // {{{ private properties
 
     /**
      * An array containing the static properties of this cell renderer.
@@ -68,9 +63,6 @@ abstract class SwatCellRenderer extends SwatUIObject
      */
     private $composite_renderers_created = false;
 
-    // }}}
-    // {{{ public function render()
-
     /**
      * Renders this cell.
      *
@@ -84,9 +76,6 @@ abstract class SwatCellRenderer extends SwatUIObject
         $this->render_count++;
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Called during the init phase.
      *
@@ -99,9 +88,6 @@ abstract class SwatCellRenderer extends SwatUIObject
         }
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Called during processing phase.
      *
@@ -113,9 +99,6 @@ abstract class SwatCellRenderer extends SwatUIObject
             $renderer->process();
         }
     }
-
-    // }}}
-    // {{{ public function getMessages()
 
     /**
      * Gathers all messages from this cell renderer.
@@ -130,9 +113,6 @@ abstract class SwatCellRenderer extends SwatUIObject
         return [];
     }
 
-    // }}}
-    // {{{ public function hasMessage()
-
     /**
      * Gets whether or not this cell renderer has messages.
      *
@@ -146,9 +126,6 @@ abstract class SwatCellRenderer extends SwatUIObject
     {
         return false;
     }
-
-    // }}}
-    // {{{ public function getPropertyNameToMap()
 
     /**
      * Get a property name to use for mapping.
@@ -173,9 +150,6 @@ abstract class SwatCellRenderer extends SwatUIObject
         return $name;
     }
 
-    // }}}
-    // {{{ public function getInlineJavaScript()
-
     /**
      * Gets ths inline JavaScript required by this cell renderer.
      *
@@ -185,9 +159,6 @@ abstract class SwatCellRenderer extends SwatUIObject
     {
         return '';
     }
-
-    // }}}
-    // {{{ public function getBaseCSSClassNames()
 
     /**
      * Gets the base CSS class names for this cell renderer.
@@ -202,9 +173,6 @@ abstract class SwatCellRenderer extends SwatUIObject
         return [];
     }
 
-    // }}}
-    // {{{ public function getDataSpecificCSSClassNames()
-
     /**
      * Gets the data specific CSS class names for this cell renderer.
      *
@@ -218,9 +186,6 @@ abstract class SwatCellRenderer extends SwatUIObject
     {
         return [];
     }
-
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this cell renderer.
@@ -242,9 +207,6 @@ abstract class SwatCellRenderer extends SwatUIObject
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this cell
      * renderer.
@@ -256,9 +218,6 @@ abstract class SwatCellRenderer extends SwatUIObject
     {
         return new SwatHtmlHeadEntrySet($this->html_head_entry_set);
     }
-
-    // }}}
-    // {{{ public function isPropertyStatic()
 
     /**
      * Checks if a public property is static (can not be data-mapped).
@@ -277,9 +236,6 @@ abstract class SwatCellRenderer extends SwatUIObject
     {
         return in_array($property_name, $this->static_properties);
     }
-
-    // }}}
-    // {{{ public final function getInheritanceCSSClassNames()
 
     /**
      * Gets the CSS class names of this cell renderer based on the inheritance
@@ -326,9 +282,6 @@ abstract class SwatCellRenderer extends SwatUIObject
         return $css_class_names;
     }
 
-    // }}}
-    // {{{ protected function createCompositeRenderers()
-
     /**
      * Creates and adds composite renderers of this renderer.
      *
@@ -336,9 +289,6 @@ abstract class SwatCellRenderer extends SwatUIObject
      * {@link SwatCellRenderer::addCompositeRenderer()}.
      */
     protected function createCompositeRenderers() {}
-
-    // }}}
-    // {{{ protected final function addCompositeRenderer()
 
     /**
      * Adds a composite a renderer to this renderer.
@@ -381,9 +331,6 @@ abstract class SwatCellRenderer extends SwatUIObject
         $renderer->parent = $this;
     }
 
-    // }}}
-    // {{{ protected final function getCompositeRenderer()
-
     /**
      * Gets a composite renderer of this renderer by the composite renderer's
      * key.
@@ -420,9 +367,6 @@ abstract class SwatCellRenderer extends SwatUIObject
 
         return $this->composite_renderers[$key];
     }
-
-    // }}}
-    // {{{ protected final function getCompositeRenderers()
 
     /**
      * Gets all composite renderers added to this renderer.
@@ -464,9 +408,6 @@ abstract class SwatCellRenderer extends SwatUIObject
         return $out;
     }
 
-    // }}}
-    // {{{ protected final function confirmCompositeRenderers()
-
     /**
      * Confirms composite renderers have been created.
      *
@@ -487,9 +428,6 @@ abstract class SwatCellRenderer extends SwatUIObject
             $this->composite_renderers_created = true;
         }
     }
-
-    // }}}
-    // {{{ protected final function makePropertyStatic()
 
     /**
      * Make a public property static.
@@ -531,6 +469,4 @@ abstract class SwatCellRenderer extends SwatUIObject
             );
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatCellRendererContainer.php
+++ b/Swat/SwatCellRendererContainer.php
@@ -8,17 +8,12 @@
  */
 abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIParent
 {
-    // {{{ protected properties
-
     /**
      * The set of SwatCellRenderer objects contained in this container.
      *
      * @var SwatCellRendererSet
      */
     protected $renderers;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new cell renderer container.
@@ -28,9 +23,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
         parent::__construct();
         $this->renderers = new SwatCellRendererSet();
     }
-
-    // }}}
-    // {{{ public function addMappingToRenderer()
 
     /**
      * Links a data-field to a cell renderer property of a cell renderer
@@ -72,9 +64,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
         return $mapping;
     }
 
-    // }}}
-    // {{{ public function addRenderer()
-
     /**
      * Adds a cell renderer to this container's set of renderers.
      *
@@ -85,9 +74,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
         $this->renderers->addRenderer($renderer);
         $renderer->parent = $this;
     }
-
-    // }}}
-    // {{{ public function getRenderers()
 
     /**
      * Gets the cell renderers of this container.
@@ -104,9 +90,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
 
         return $out;
     }
-
-    // }}}
-    // {{{ public function getRenderer()
 
     /**
      * Gets a cell renderer of this container by its unique identifier.
@@ -126,9 +109,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
         return $this->renderers->getRenderer($renderer_id);
     }
 
-    // }}}
-    // {{{ public function getRendererByPosition()
-
     /**
      * Gets a cell renderer in this container based on its ordinal position.
      *
@@ -146,9 +126,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
         return $this->renderers->getRendererByPosition($position);
     }
 
-    // }}}
-    // {{{ public function getFirstRenderer()
-
     /**
      * Gets the first cell renderer in this container.
      *
@@ -160,9 +137,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
     {
         return $this->renderers->getFirst();
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Add a child object to this object.
@@ -188,9 +162,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
             );
         }
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -239,9 +210,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -277,9 +245,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
         return $out;
     }
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -300,9 +265,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
         return $states;
     }
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -320,9 +282,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
             }
         }
     }
-
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this cell renderer
@@ -345,9 +304,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this cell
      * renderer container.
@@ -367,9 +323,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getRendererInlineJavaScript()
 
     /**
      * Gets inline JavaScript used by all cell renderers within this cell
@@ -391,9 +344,6 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
 
         return $javascript;
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -430,6 +380,4 @@ abstract class SwatCellRendererContainer extends SwatUIObject implements SwatUIP
 
         return $copy;
     }
-
-    // }}}
 }

--- a/Swat/SwatCellRendererMapping.php
+++ b/Swat/SwatCellRendererMapping.php
@@ -8,8 +8,6 @@
  */
 class SwatCellRendererMapping extends SwatObject
 {
-    // {{{ public properties
-
     /**
      * The name of the property.
      *
@@ -38,9 +36,6 @@ class SwatCellRendererMapping extends SwatObject
      */
     public $array_key;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Create a new mapping object.
      *
@@ -52,6 +47,4 @@ class SwatCellRendererMapping extends SwatObject
         $this->property = $property;
         $this->field = $field;
     }
-
-    // }}}
 }

--- a/Swat/SwatCellRendererSet.php
+++ b/Swat/SwatCellRendererSet.php
@@ -10,17 +10,13 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 {
     /**
      * Cell renderers of this set indexed numerically.
-     *
-     * @var array
      */
-    private $renderers = [];
+    private array $renderers = [];
 
     /**
      * Cell renderers of this set indexed by id.
-     *
-     * @var array
      */
-    private $renderers_by_id = [];
+    private array $renderers_by_id = [];
 
     /**
      * Cell renderer data-mappings of the renderers of this set.
@@ -28,24 +24,18 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
      * This array is indexed by cell renderer object hashes for quick retrieval.
      * Array values are numerically indexed arrays of
      * {@link SwatCellRendererMapping} objects.
-     *
-     * @var array
      */
-    private $mappings = [];
+    private array $mappings = [];
 
     /**
      * The current index of the iterator interface.
-     *
-     * @var int
      */
-    private $current_index = 0;
+    private int $current_index = 0;
 
     /**
      * Whether or not data-mappings have been applied to this cell-renderer set.
-     *
-     * @var bool
      */
-    private $mappings_applied = false;
+    private bool $mappings_applied = false;
 
     /**
      * Adds a cell renderer to this set.
@@ -286,7 +276,7 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
      *
      * @return SwatCellRenderer the current renderer
      */
-    public function current()
+    public function current(): SwatCellRenderer
     {
         return $this->renderers[$this->current_index];
     }
@@ -296,7 +286,7 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
      *
      * @return int the key of the current renderer
      */
-    public function key()
+    public function key(): int
     {
         return $this->current_index;
     }
@@ -304,7 +294,7 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
     /**
      * Moves forward to the next renderer.
      */
-    public function next()
+    public function next(): void
     {
         $this->current_index++;
     }
@@ -312,7 +302,7 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
     /**
      * Rewinds this iterator to the first renderer.
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->current_index = 0;
     }
@@ -323,7 +313,7 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
      * @return bool true if there is a current renderer and false if there
      *              is not
      */
-    public function valid()
+    public function valid(): bool
     {
         return array_key_exists($this->current_index, $this->renderers);
     }
@@ -365,7 +355,7 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
      *
      * @return int the number of cell renderers in this set
      */
-    public function count()
+    public function count(): int
     {
         return count($this->renderers);
     }

--- a/Swat/SwatCellRendererSet.php
+++ b/Swat/SwatCellRendererSet.php
@@ -8,8 +8,6 @@
  */
 class SwatCellRendererSet extends SwatObject implements Iterator, Countable
 {
-    // {{{ private properties
-
     /**
      * Cell renderers of this set indexed numerically.
      *
@@ -49,9 +47,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
      */
     private $mappings_applied = false;
 
-    // }}}
-    // {{{ public function addRenderer()
-
     /**
      * Adds a cell renderer to this set.
      *
@@ -72,9 +67,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         }
     }
 
-    // }}}
-    // {{{ public function addRendererWithMappings()
-
     /**
      * Adds a cell renderer to this set with a predefined set of
      * datafield-property mappings.
@@ -92,9 +84,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         $this->addRenderer($renderer);
         $this->addMappingsToRenderer($renderer, $mappings);
     }
-
-    // }}}
-    // {{{ public function addMappingsToRenderer()
 
     /**
      * Adds a set of datafield-property mappings to a cell renderer already in
@@ -127,9 +116,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         }
     }
 
-    // }}}
-    // {{{ public function addMappingToRenderer()
-
     /**
      * Adds a single property-datafield mapping to a cell renderer already in
      * this set.
@@ -157,9 +143,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         $renderer_key = spl_object_hash($renderer);
         $this->mappings[$renderer_key][] = $mapping;
     }
-
-    // }}}
-    // {{{ public function applyMappingsToRenderer()
 
     /**
      * Applies the property-datafield mappings to a cell renderer already in
@@ -219,9 +202,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         $this->mappings_applied = true;
     }
 
-    // }}}
-    // {{{ public function getRendererByPosition()
-
     /**
      * Gets a cell renderer in this set by its ordinal position.
      *
@@ -245,9 +225,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
             $position,
         );
     }
-
-    // }}}
-    // {{{ public function getRenderer()
 
     /**
      * Gets a renderer in this set by its id.
@@ -274,9 +251,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         );
     }
 
-    // }}}
-    // {{{ public function getMappingsByRenderer()
-
     /**
      * Gets the mappings of a cell renderer already in this set.
      *
@@ -293,9 +267,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         return $this->mappings[$renderer_key];
     }
 
-    // }}}
-    // {{{ public function mappingsApplied()
-
     /**
      * Whether or not mappings have been applied to this cell-renderer set.
      *
@@ -310,9 +281,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         return $this->mappings_applied;
     }
 
-    // }}}
-    // {{{ public function current()
-
     /**
      * Returns the current renderer.
      *
@@ -322,9 +290,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
     {
         return $this->renderers[$this->current_index];
     }
-
-    // }}}
-    // {{{ public function key()
 
     /**
      * Returns the key of the current renderer.
@@ -336,9 +301,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         return $this->current_index;
     }
 
-    // }}}
-    // {{{ public function next()
-
     /**
      * Moves forward to the next renderer.
      */
@@ -347,9 +309,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         $this->current_index++;
     }
 
-    // }}}
-    // {{{ public function rewind()
-
     /**
      * Rewinds this iterator to the first renderer.
      */
@@ -357,9 +316,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
     {
         $this->current_index = 0;
     }
-
-    // }}}
-    // {{{ public function valid()
 
     /**
      * Checks is there is a current renderer after calls to rewind() and next().
@@ -371,9 +327,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
     {
         return array_key_exists($this->current_index, $this->renderers);
     }
-
-    // }}}
-    // {{{ public function getFirst()
 
     /**
      * Gets the first renderer in this set.
@@ -392,9 +345,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         return $first;
     }
 
-    // }}}
-    // {{{ public function getCount()
-
     /**
      * Gets the number of renderers in this set.
      *
@@ -408,9 +358,6 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         return count($this);
     }
 
-    // }}}
-    // {{{ public function count()
-
     /**
      * Gets the number of cell renderers in this set.
      *
@@ -422,6 +369,4 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
     {
         return count($this->renderers);
     }
-
-    // }}}
 }

--- a/Swat/SwatChangeOrder.php
+++ b/Swat/SwatChangeOrder.php
@@ -14,8 +14,6 @@
  */
 class SwatChangeOrder extends SwatOptionControl implements SwatState
 {
-    // {{{ public properties
-
     /**
      * Value ordered array.
      *
@@ -40,9 +38,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
      */
     public $height = '300px';
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new change-order widget.
      *
@@ -64,9 +59,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
             'packages/swat/javascript/swat-z-index-manager.js',
         );
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this change-order control.
@@ -133,9 +125,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ public function process()
-
     public function process()
     {
         parent::process();
@@ -156,9 +145,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
         }
     }
 
-    // }}}
-    // {{{ public function getNote()
-
     /**
      * Gets a note letting the user know drag-and-drop is available for
      * ordering items.
@@ -177,9 +163,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
         return new SwatMessage($message);
     }
 
-    // }}}
-    // {{{ public function getState()
-
     public function getState()
     {
         if ($this->values === null) {
@@ -189,16 +172,10 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
         return $this->values;
     }
 
-    // }}}
-    // {{{ public function setState()
-
     public function setState($state)
     {
         $this->values = $state;
     }
-
-    // }}}
-    // {{{ public function getOrderedOptions()
 
     /**
      * Gets the options of this change-order control ordered by the
@@ -237,9 +214,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
         return $ordered_options;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this change-order
      * widget.
@@ -253,9 +227,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript required by this change-order control.
@@ -272,9 +243,6 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
             $this->isSensitive() ? 'true' : 'false',
         );
     }
-
-    // }}}
-    // {{{ private function displayButtons()
 
     private function displayButtons()
     {
@@ -320,6 +288,4 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
 
         $buttons_div->close();
     }
-
-    // }}}
 }

--- a/Swat/SwatCheckAll.php
+++ b/Swat/SwatCheckAll.php
@@ -8,8 +8,6 @@
  */
 class SwatCheckAll extends SwatCheckbox
 {
-    // {{{ public properties
-
     /**
      * Optional checkbox label title.
      *
@@ -56,9 +54,6 @@ class SwatCheckAll extends SwatCheckbox
      */
     public $unit;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new check-all widget.
      *
@@ -77,9 +72,6 @@ class SwatCheckAll extends SwatCheckbox
         $this->addJavaScript('packages/swat/javascript/swat-check-all.js');
     }
 
-    // }}}
-    // {{{ public function isExtendedSelected()
-
     /**
      * Whether or not the extended-checkbox was checked.
      *
@@ -89,9 +81,6 @@ class SwatCheckAll extends SwatCheckbox
     {
         return $this->getCompositeWidget('extended_checkbox')->value;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this check-all widget.
@@ -137,9 +126,6 @@ class SwatCheckAll extends SwatCheckbox
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ protected function getExtendedTitle()
-
     protected function getExtendedTitle()
     {
         $locale = SwatI18NLocale::get();
@@ -175,9 +161,6 @@ class SwatCheckAll extends SwatCheckbox
         );
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this check-all widget.
      *
@@ -190,9 +173,6 @@ class SwatCheckAll extends SwatCheckbox
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript for this check-all widget.
@@ -208,14 +188,9 @@ class SwatCheckAll extends SwatCheckbox
         );
     }
 
-    // }}}
-    // {{{ protected function createCompositeWidgets()
-
     protected function createCompositeWidgets()
     {
         $extended_checkbox = new SwatCheckbox();
         $this->addCompositeWidget($extended_checkbox, 'extended_checkbox');
     }
-
-    // }}}
 }

--- a/Swat/SwatCheckbox.php
+++ b/Swat/SwatCheckbox.php
@@ -8,8 +8,6 @@
  */
 class SwatCheckbox extends SwatInputControl implements SwatState
 {
-    // {{{ public properties
-
     /**
      * Checkbox value.
      *
@@ -39,9 +37,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
      */
     public $tab_index;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new checkbox.
      *
@@ -54,9 +49,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
         parent::__construct($id);
         $this->requires_id = true;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this checkbox.
@@ -96,9 +88,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
         echo '</span>';
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this checkbox.
      *
@@ -118,9 +107,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
         $this->value = array_key_exists($this->id, $data);
     }
 
-    // }}}
-    // {{{ public function getState()
-
     /**
      * Gets the current state of this checkbox.
      *
@@ -133,9 +119,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
         return $this->value;
     }
 
-    // }}}
-    // {{{ public function setState()
-
     /**
      * Sets the current state of this checkbox.
      *
@@ -147,9 +130,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
     {
         $this->value = $state;
     }
-
-    // }}}
-    // {{{ public function getFocusableHtmlId()
 
     /**
      * Gets the id attribute of the XHTML element displayed by this widget
@@ -166,9 +146,6 @@ class SwatCheckbox extends SwatInputControl implements SwatState
         return $this->visible ? $this->id : null;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this checkbox.
      *
@@ -181,6 +158,4 @@ class SwatCheckbox extends SwatInputControl implements SwatState
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatCheckboxCellRenderer.php
+++ b/Swat/SwatCheckboxCellRenderer.php
@@ -10,8 +10,6 @@
  */
 class SwatCheckboxCellRenderer extends SwatCellRenderer implements SwatViewSelector
 {
-    // {{{ public properties
-
     /**
      * Identifier of this checkbox cell renderer.
      *
@@ -63,9 +61,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer implements SwatViewSelec
      */
     public $tab_index;
 
-    // }}}
-    // {{{ private properties
-
     /**
      * Array of selected values populated during the processing of this cell
      * renderer.
@@ -76,9 +71,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer implements SwatViewSelec
      * @var array
      */
     private $selected_values = [];
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new checkbox cell renderer.
@@ -99,9 +91,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer implements SwatViewSelec
         $this->id = $this->getUniqueId();
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this checkbox cell renderer.
      */
@@ -121,9 +110,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer implements SwatViewSelec
             }
         }
     }
-
-    // }}}
-    // {{{ public function render()
 
     /**
      * Renders this checkbox cell renderer.
@@ -173,9 +159,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer implements SwatViewSelec
         }
     }
 
-    // }}}
-    // {{{ public function getId()
-
     /**
      * Gets the identifier of this checkbox cell renderer.
      *
@@ -187,9 +170,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer implements SwatViewSelec
     {
         return $this->id;
     }
-
-    // }}}
-    // {{{ public function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript required by this checkbox cell renderer.
@@ -214,9 +194,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer implements SwatViewSelec
         return $javascript;
     }
 
-    // }}}
-    // {{{ public function copy()
-
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
      *
@@ -239,9 +216,6 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer implements SwatViewSelec
         return $copy;
     }
 
-    // }}}
-    // {{{ private function getForm()
-
     /**
      * Gets the form this checkbox cell renderer is contained in.
      *
@@ -263,6 +237,4 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer implements SwatViewSelec
 
         return $form;
     }
-
-    // }}}
 }

--- a/Swat/SwatCheckboxEntryList.php
+++ b/Swat/SwatCheckboxEntryList.php
@@ -18,8 +18,6 @@
  */
 class SwatCheckboxEntryList extends SwatCheckboxList
 {
-    // {{{ public properties
-
     /**
      * The size of all the embedded entry widgets.
      *
@@ -41,9 +39,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
      */
     public $entry_maxlength;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * The entry widgets used by this checkbox entry list.
      *
@@ -52,9 +47,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
      * @var array
      */
     protected $entry_widgets = [];
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new checkbox entry list.
@@ -78,9 +70,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
             'packages/swat/styles/swat-checkbox-entry-list.css',
         );
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this checkbox list.
@@ -165,9 +154,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this checkbox entry list.
      *
@@ -191,9 +177,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
         }
     }
 
-    // }}}
-    // {{{ public function getMessages()
-
     /**
      * Gets all messages.
      *
@@ -213,9 +196,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 
         return $messages;
     }
-
-    // }}}
-    // {{{ public function hasMessage()
 
     /**
      * Checks for the presence of messages.
@@ -242,9 +222,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
         return $has_message;
     }
 
-    // }}}
-    // {{{ public function getEntryValue()
-
     /**
      * Gets the value of an entry widget in this checkbox entry list.
      *
@@ -264,9 +241,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 
         return $entry_value;
     }
-
-    // }}}
-    // {{{ public function setEntryValue()
 
     /**
      * Sets the value of an entry widget in this checkbox entry list.
@@ -300,9 +274,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
         $this->getEntryWidget($option_value)->getFirst()->value = $entry_value;
     }
 
-    // }}}
-    // {{{ public function setEntryValuesByArray()
-
     /**
      * Sets the values of multiple entry widgets.
      *
@@ -325,9 +296,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
             $this->setEntryValue($option_value, $entry_value);
         }
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript for this checkbox entry list.
@@ -354,9 +322,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
         return $javascript;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this checkbox entry
      * list.
@@ -371,9 +336,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
         return array_merge($classes, parent::getCSSClassNames());
     }
 
-    // }}}
-    // {{{ protected function hasEntryWidget()
-
     /**
      * Checks if this checkbox entry list has an entry widget for a given
      * option value.
@@ -387,9 +349,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
     {
         return isset($this->entry_widgets[$option_value]);
     }
-
-    // }}}
-    // {{{ protected function getEntryWidget()
 
     /**
      * Gets a widget tree for the entry widget of this checkbox entry list.
@@ -419,9 +378,6 @@ class SwatCheckboxEntryList extends SwatCheckboxList
         return $this->entry_widgets[$option_value];
     }
 
-    // }}}
-    // {{{ protected function createEntryWidget()
-
     /**
      * Creates an entry widget of this checkbox entry list.
      *
@@ -440,6 +396,4 @@ class SwatCheckboxEntryList extends SwatCheckboxList
 
         return $widget;
     }
-
-    // }}}
 }

--- a/Swat/SwatCheckboxList.php
+++ b/Swat/SwatCheckboxList.php
@@ -8,17 +8,12 @@
  */
 class SwatCheckboxList extends SwatOptionControl implements SwatState
 {
-    // {{{ private properties
-
     /**
      * Used for displaying checkbox labels.
      *
      * @var SwatHtmlTag
      */
     private $label_tag;
-
-    // }}}
-    // {{{ public properties
 
     /**
      * List values.
@@ -51,9 +46,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
      */
     public $columns = 1;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new checkbox list.
      *
@@ -70,9 +62,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
         $this->addJavaScript('packages/swat/javascript/swat-checkbox-list.js');
         $this->addStyleSheet('packages/swat/styles/swat.css');
     }
-
-    // }}}
-    // {{{ public function init()
 
     /**
      * Initializes this checkbox list.
@@ -97,9 +86,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
             }
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this checkbox list.
@@ -187,9 +173,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this checkbox list widget.
      */
@@ -212,9 +195,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
         }
     }
 
-    // }}}
-    // {{{ public function reset()
-
     /**
      * Reset this checkbox list.
      *
@@ -225,9 +205,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
     {
         $this->values = [];
     }
-
-    // }}}
-    // {{{ public function setState()
 
     /**
      * Sets the current state of this checkbox list.
@@ -241,9 +218,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
         $this->values = $state;
     }
 
-    // }}}
-    // {{{ public function getState()
-
     /**
      * Gets the current state of this checkbox list.
      *
@@ -255,9 +229,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
     {
         return $this->values;
     }
-
-    // }}}
-    // {{{ protected function processValues()
 
     /**
      * Processes the values of this checkbox list from raw form data.
@@ -279,9 +250,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
             $this->values = [];
         }
     }
-
-    // }}}
-    // {{{ protected function displayOption()
 
     /**
      * Helper method to display a single option of this checkbox list.
@@ -319,9 +287,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
         $li_tag->close();
     }
 
-    // }}}
-    // {{{ protected function displayOptionLabel()
-
     /**
      * Displays an option in the checkbox list.
      *
@@ -340,9 +305,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
         $this->label_tag->setContent($option->title, $option->content_type);
         $this->label_tag->display();
     }
-
-    // }}}
-    // {{{ protected function getLiTag()
 
     protected function getLiTag(SwatOption $option)
     {
@@ -367,9 +329,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
 
         return $tag;
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript for this checkbox list.
@@ -398,9 +357,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
         return $javascript;
     }
 
-    // }}}
-    // {{{ protected function getJavaScriptClassName()
-
     /**
      * Get the name of the JavaScript class for this widget.
      *
@@ -410,9 +366,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
     {
         return 'SwatCheckboxList';
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this checkbox list.
@@ -427,9 +380,6 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
         return array_merge($classes, parent::getCSSClassNames());
     }
 
-    // }}}
-    // {{{ protected function createCompositeWidgets()
-
     /**
      * Creates and adds composite widgets of this widget.
      *
@@ -440,6 +390,4 @@ class SwatCheckboxList extends SwatOptionControl implements SwatState
     {
         $this->addCompositeWidget(new SwatCheckAll(), 'check_all');
     }
-
-    // }}}
 }

--- a/Swat/SwatCheckboxTree.php
+++ b/Swat/SwatCheckboxTree.php
@@ -8,8 +8,6 @@
  */
 class SwatCheckboxTree extends SwatCheckboxList implements SwatState
 {
-    // {{{ constants
-
     /**
      * A regular checkbox tree. Nothing speical is tracked.
      */
@@ -30,18 +28,12 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
      */
     public const DEPENDENT_CHILD = 'child';
 
-    // }}}
-    // {{{ public properties
-
     /**
      * Used to determine the type of dependency tracking.
      *
      * @var string
      */
     public $dependency_type = self::DEPENDENT_NONE;
-
-    // }}}
-    // {{{ protected properties
 
     /**
      * Checkbox tree structure.
@@ -71,9 +63,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
      */
     protected $input_tag;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new checkbox list.
      *
@@ -87,9 +76,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
         $this->addJavaScript('packages/swat/javascript/swat-checkbox-tree.js');
         $this->setTree(new SwatDataTreeNode(null, 'root'));
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this checkbox list widget.
@@ -110,9 +96,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
             }
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     public function display()
     {
@@ -153,9 +136,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ public function setTree()
-
     /**
      * Sets the tree to use for display.
      *
@@ -165,9 +145,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
     {
         $this->tree = $tree;
     }
-
-    // }}}
-    // {{{ public function getTree()
 
     /**
      * Gets the tree collection of {@link SwatTreeNode} objects for this
@@ -179,9 +156,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
     {
         return $this->tree;
     }
-
-    // }}}
-    // {{{ protected function validate()
 
     protected function validate(SwatDataTreeNode $node, $is_parent_selected)
     {
@@ -204,9 +178,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
         );
     }
 
-    // }}}
-    // {{{ protected function getJavaScriptClassName()
-
     /**
      * Get the name of the JavaScript class for this widget.
      *
@@ -226,9 +197,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
         }
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this checkbox tree.
      *
@@ -241,9 +209,6 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ private function displayNode()
 
     /**
      * Displays a node in a tree as a checkbox input.
@@ -323,6 +288,4 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
 
         return $nodes;
     }
-
-    // }}}
 }

--- a/Swat/SwatCommentHtmlHeadEntry.php
+++ b/Swat/SwatCommentHtmlHeadEntry.php
@@ -8,12 +8,7 @@
  */
 class SwatCommentHtmlHeadEntry extends SwatHtmlHeadEntry
 {
-    // {{{ protected properties
-
     protected $comment;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new HTML head entry.
@@ -26,9 +21,6 @@ class SwatCommentHtmlHeadEntry extends SwatHtmlHeadEntry
         $this->comment = $comment;
     }
 
-    // }}}
-    // {{{ protected function displayInternal()
-
     protected function displayInternal($uri_prefix = '', $tag = null)
     {
         // double dashes are not allowed in XML comments
@@ -36,13 +28,8 @@ class SwatCommentHtmlHeadEntry extends SwatHtmlHeadEntry
         printf('<!-- %s -->', $comment);
     }
 
-    // }}}
-    // {{{ protected function displayInlineInternal()
-
     protected function displayInlineInternal($path)
     {
         $this->displayInternal();
     }
-
-    // }}}
 }

--- a/Swat/SwatConfirmEmailEntry.php
+++ b/Swat/SwatConfirmEmailEntry.php
@@ -11,17 +11,12 @@
  */
 class SwatConfirmEmailEntry extends SwatEmailEntry
 {
-    // {{{ public properties
-
     /**
      * A reference to the matching email entry widget.
      *
      * @var SwatEmailEntry
      */
     public $email_widget;
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Checks to make sure email addresses match.
@@ -59,9 +54,6 @@ class SwatConfirmEmailEntry extends SwatEmailEntry
         }
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this entry.
      *
@@ -74,6 +66,4 @@ class SwatConfirmEmailEntry extends SwatEmailEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatConfirmPasswordEntry.php
+++ b/Swat/SwatConfirmPasswordEntry.php
@@ -11,17 +11,12 @@
  */
 class SwatConfirmPasswordEntry extends SwatPasswordEntry
 {
-    // {{{ public properties
-
     /**
      * A reference to the matching password widget.
      *
      * @var SwatPasswordEntry
      */
     public $password_widget;
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Checks to make sure passwords match.
@@ -54,9 +49,6 @@ class SwatConfirmPasswordEntry extends SwatPasswordEntry
         }
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this entry.
      *
@@ -69,6 +61,4 @@ class SwatConfirmPasswordEntry extends SwatPasswordEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatConfirmationButton.php
+++ b/Swat/SwatConfirmationButton.php
@@ -14,8 +14,6 @@
  */
 class SwatConfirmationButton extends SwatButton
 {
-    // {{{ public function __construct()
-
     /**
      * Creates a new confirmation button widget.
      *
@@ -31,6 +29,4 @@ class SwatConfirmationButton extends SwatButton
             'Are you sure you wish to continue?',
         );
     }
-
-    // }}}
 }

--- a/Swat/SwatContainer.php
+++ b/Swat/SwatContainer.php
@@ -10,8 +10,6 @@
  */
 class SwatContainer extends SwatWidget implements SwatUIParent
 {
-    // {{{ protected properties
-
     /**
      * Children widgets.
      *
@@ -31,9 +29,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
      */
     protected $children_by_id = [];
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this widget.
      *
@@ -50,9 +45,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function add()
-
     /**
      * Adds a widget.
      *
@@ -66,9 +58,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
     {
         $this->packEnd($widget);
     }
-
-    // }}}
-    // {{{ public function replace()
 
     /**
      * Replace a widget.
@@ -105,9 +94,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         return null;
     }
 
-    // }}}
-    // {{{ public function remove()
-
     /**
      * Removes a widget.
      *
@@ -139,9 +125,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         return null;
     }
 
-    // }}}
-    // {{{ public function packStart()
-
     /**
      * Adds a widget to start.
      *
@@ -166,9 +149,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
         $this->sendAddNotifySignal($widget);
     }
-
-    // }}}
-    // {{{ public function insertBefore()
 
     /**
      * Adds a widget to this container before another widget.
@@ -209,9 +189,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         $this->sendAddNotifySignal($widget);
     }
 
-    // }}}
-    // {{{ public function packEnd()
-
     /**
      * Adds a widget to end.
      *
@@ -237,9 +214,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         $this->sendAddNotifySignal($widget);
     }
 
-    // }}}
-    // {{{ public function getChild()
-
     /**
      * Gets a child widget.
      *
@@ -258,9 +232,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
         return null;
     }
-
-    // }}}
-    // {{{ public function getFirst()
 
     /**
      * Gets the first child widget.
@@ -281,9 +252,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
         return null;
     }
-
-    // }}}
-    // {{{ public function getChildren()
 
     /**
      * Gets all child widgets.
@@ -312,9 +280,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
         return $out;
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -363,9 +328,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -401,9 +363,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -424,9 +383,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         return $states;
     }
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -445,9 +401,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this container by calling {@link SwatWidget::process()} on all
      * children.
@@ -463,9 +416,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function display()
-
     /**
      * Displays this container by calling {@link SwatWidget::display()} on all
      * children.
@@ -480,9 +430,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
         $this->displayChildren();
     }
-
-    // }}}
-    // {{{ public function getMessages()
 
     /**
      * Gets all messages.
@@ -501,9 +448,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
         return $messages;
     }
-
-    // }}}
-    // {{{ public function hasMessage()
 
     /**
      * Checks for the presence of messages.
@@ -528,9 +472,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
         return $has_message;
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Adds a child object.
@@ -560,9 +501,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this container.
      *
@@ -582,9 +520,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this container.
      *
@@ -603,9 +538,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getFocusableHtmlId()
 
     /**
      * Gets the id attribute of the XHTML element displayed by this widget
@@ -633,9 +565,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         return $focus_id;
     }
 
-    // }}}
-    // {{{ public function printWidgetTree()
-
     public function printWidgetTree()
     {
         echo get_class($this), ' ', $this->id;
@@ -651,9 +580,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
             echo '</ul>';
         }
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -683,9 +609,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         return $copy;
     }
 
-    // }}}
-    // {{{ protected function displayChildren()
-
     /**
      * Displays the child widgets of this container.
      *
@@ -699,9 +622,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ protected function notifyOfAdd()
-
     /**
      * Notifies this widget that a widget was added.
      *
@@ -711,9 +631,6 @@ class SwatContainer extends SwatWidget implements SwatUIParent
      * @param SwatWidget $widget the widget that has been added
      */
     protected function notifyOfAdd($widget) {}
-
-    // }}}
-    // {{{ protected function sendAddNotifySignal()
 
     /**
      * Sends the notification signal up the widget tree.
@@ -731,6 +648,4 @@ class SwatContainer extends SwatWidget implements SwatUIParent
             $this->parent->sendAddNotifySignal($widget);
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatContentBlock.php
+++ b/Swat/SwatContentBlock.php
@@ -8,8 +8,6 @@
  */
 class SwatContentBlock extends SwatControl
 {
-    // {{{ public properties
-
     /**
      * User visible textual content of this widget.
      *
@@ -25,9 +23,6 @@ class SwatContentBlock extends SwatControl
      * @var string
      */
     public $content_type = 'text/plain';
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this content.
@@ -48,6 +43,4 @@ class SwatContentBlock extends SwatControl
             echo $this->content;
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatControl.php
+++ b/Swat/SwatControl.php
@@ -8,8 +8,6 @@
  */
 abstract class SwatControl extends SwatWidget
 {
-    // {{{ public function addMessage()
-
     /**
      * Adds a message to this control.
      *
@@ -56,16 +54,10 @@ abstract class SwatControl extends SwatWidget
         parent::addMessage($message);
     }
 
-    // }}}
-    // {{{ public function printWidgetTree()
-
     public function printWidgetTree()
     {
         echo get_class($this), ' ', $this->id;
     }
-
-    // }}}
-    // {{{ public function getNote()
 
     /**
      * Gets an informative note of how to use this control.
@@ -79,6 +71,4 @@ abstract class SwatControl extends SwatWidget
     {
         return null;
     }
-
-    // }}}
 }

--- a/Swat/SwatDataTreeNode.php
+++ b/Swat/SwatDataTreeNode.php
@@ -12,52 +12,44 @@ class SwatDataTreeNode extends SwatTreeNode
      * The value of this node.
      *
      * The value is used for processing. It is either a string or an integer.
-     *
-     * @var mixed
      */
-    public $value;
+    public int|string $value;
 
     /**
      * The title of this node.
      *
      * The title is used for display.
-     *
-     * @var string
      */
-    public $title;
+    public string $title;
 
     /**
      * Optional content type.
      *
      * Default text/plain, use text/xml for XHTML fragments.
-     *
-     * @var string
      */
-    public $content_type = 'text/plain';
+    public string $content_type = 'text/plain';
 
     /**
      * The sensitivity of this node.
      *
      * Used to mark this node as unselectable
-     *
-     * @var bool
      */
-    public $sensitive = true;
+    public bool $sensitive = true;
 
     /**
      * Creates a new data node.
      *
-     * @param mixed  $value        the value of the node. It is either a string or an
-     *                             integer.
-     * @param string $title        the title of the node
-     * @param string $content_type optional content-type
-     * @param mixed  $sensitive
+     * @param int|string $value        the value of the node. It is either a string or an
+     *                                 integer.
+     * @param string     $title        the title of the node
+     * @param string     $content_type optional content-type
+     * @param mixed      $sensitive
      */
     public function __construct(
-        $value,
-        $title,
-        $content_type = 'text/plain',
-        $sensitive = true,
+        int|string $value,
+        string $title,
+        string $content_type = 'text/plain',
+        bool $sensitive = true,
     ) {
         $this->value = $value;
         $this->title = $title;

--- a/Swat/SwatDataTreeNode.php
+++ b/Swat/SwatDataTreeNode.php
@@ -8,8 +8,6 @@
  */
 class SwatDataTreeNode extends SwatTreeNode
 {
-    // {{{ public properties
-
     /**
      * The value of this node.
      *
@@ -46,9 +44,6 @@ class SwatDataTreeNode extends SwatTreeNode
      */
     public $sensitive = true;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new data node.
      *
@@ -69,6 +64,4 @@ class SwatDataTreeNode extends SwatTreeNode
         $this->content_type = $content_type;
         $this->sensitive = $sensitive;
     }
-
-    // }}}
 }

--- a/Swat/SwatDate.php
+++ b/Swat/SwatDate.php
@@ -13,8 +13,6 @@
  */
 class SwatDate extends DateTime implements Stringable
 {
-    // {{{ time zone format constants
-
     /**
      * America/Halifax.
      */
@@ -60,9 +58,6 @@ class SwatDate extends DateTime implements Stringable
      * @deprecated
      */
     public const TZ_CURRENT_LONG = 8;
-
-    // }}}
-    // {{{ date format constants
 
     /**
      * 07/02/02.
@@ -149,9 +144,6 @@ class SwatDate extends DateTime implements Stringable
      */
     public const DF_RFC_2822 = 17;
 
-    // }}}
-    // {{{ ISO 8601 option constants
-
     /**
      * Value to use for no options.
      *
@@ -183,9 +175,6 @@ class SwatDate extends DateTime implements Stringable
      */
     public const ISO_TIME_ZONE = 4;
 
-    // }}}
-    // {{{ date interval part constants
-
     /**
      * A set of bitwise contants to control which parts of the interval we want
      * when returning a DateInterval.
@@ -199,9 +188,6 @@ class SwatDate extends DateTime implements Stringable
     public const DI_HOURS = 16;
     public const DI_MINUTES = 32;
     public const DI_SECONDS = 64;
-
-    // }}}
-    // {{{ protected properties
 
     protected static $tz_abbreviations;
     protected static $valid_tz_abbreviations = [
@@ -320,9 +306,6 @@ class SwatDate extends DateTime implements Stringable
         'yekt'  => true,
     ];
 
-    // }}}
-    // {{{ public function format()
-
     /**
      * Formats this date given either a format string or a format id.
      *
@@ -349,9 +332,6 @@ class SwatDate extends DateTime implements Stringable
 
         return $out;
     }
-
-    // }}}
-    // {{{ public function formatLikeIntl()
 
     /**
      * Formats this date using the ICU IntlDateFormater given either a format
@@ -398,9 +378,6 @@ class SwatDate extends DateTime implements Stringable
 
         return $out;
     }
-
-    // }}}
-    // {{{ public function formatTZ()
 
     /**
      * Formats the time zone part of this date.
@@ -466,9 +443,6 @@ class SwatDate extends DateTime implements Stringable
         return $out;
     }
 
-    // }}}
-    // {{{ public function clearTime() - deprecated
-
     /**
      * Clears the time portion of the date object.
      *
@@ -479,16 +453,10 @@ class SwatDate extends DateTime implements Stringable
         $this->setTime(0, 0, 0);
     }
 
-    // }}}
-    // {{{ public function __toString()
-
     public function __toString(): string
     {
         return $this->format('Y-m-d\TH:i:s');
     }
-
-    // }}}
-    // {{{ public function getHumanReadableDateDiff()
 
     /**
      * Get a human-readable string representing the difference between
@@ -517,9 +485,6 @@ class SwatDate extends DateTime implements Stringable
         return SwatString::toHumanReadableTimePeriod($seconds, true);
     }
 
-    // }}}
-    // {{{ public function getHumanReadableDateDiffWithWeeks()
-
     /**
      * Get a human-readable string representing the difference between
      * two dates.
@@ -547,9 +512,6 @@ class SwatDate extends DateTime implements Stringable
         return SwatString::toHumanReadableTimePeriodWithWeeks($seconds, true);
     }
 
-    // }}}
-    // {{{ public function getHumanReadableDateDiffWithWeeksAndDays()
-
     /**
      * Get a human-readable string representing the difference between
      * two dates.
@@ -576,9 +538,6 @@ class SwatDate extends DateTime implements Stringable
 
         return SwatString::toHumanReadableTimePeriodWithWeeksAndDays($seconds);
     }
-
-    // }}}
-    // {{{ public static function getFormatById()
 
     /**
      * Gets a date format string by id.
@@ -651,9 +610,6 @@ class SwatDate extends DateTime implements Stringable
         }
     }
 
-    // }}}
-    // {{{ public static function getFormatLikeIntlById()
-
     /**
      * Gets a IntlDateFormatter date format string by id.
      *
@@ -722,9 +678,6 @@ class SwatDate extends DateTime implements Stringable
         }
     }
 
-    // }}}
-    // {{{ public static function getTimeZoneAbbreviations()
-
     /**
      * Gets a mapping of time zone names to time zone abbreviations.
      *
@@ -768,9 +721,6 @@ class SwatDate extends DateTime implements Stringable
         return self::$tz_abbreviations;
     }
 
-    // }}}
-    // {{{ public static function getTimeZoneAbbreviation()
-
     /**
      * Gets an array of time zone abbreviations for a specific time zone.
      *
@@ -792,9 +742,6 @@ class SwatDate extends DateTime implements Stringable
 
         return $abbreviation;
     }
-
-    // }}}
-    // {{{ public static function compare()
 
     /**
      * Compares two SwatDates.
@@ -827,9 +774,6 @@ class SwatDate extends DateTime implements Stringable
 
         return 0;
     }
-
-    // }}}
-    // {{{ public static function getIntervalFromSeconds()
 
     /**
      * Gets a date interval with appropriate values for the specified
@@ -896,9 +840,6 @@ class SwatDate extends DateTime implements Stringable
         return new DateInterval($interval_spec);
     }
 
-    // }}}
-    // {{{ public function getYear()
-
     /**
      * Gets the year of this date.
      *
@@ -910,9 +851,6 @@ class SwatDate extends DateTime implements Stringable
     {
         return (int) $this->format('Y');
     }
-
-    // }}}
-    // {{{ public function getMonth()
 
     /**
      * Gets the month of this date as a number from 1-12.
@@ -926,9 +864,6 @@ class SwatDate extends DateTime implements Stringable
         return (int) $this->format('n');
     }
 
-    // }}}
-    // {{{ public function getDay()
-
     /**
      * Gets the day of this date as a number from 1-31.
      *
@@ -940,9 +875,6 @@ class SwatDate extends DateTime implements Stringable
     {
         return (int) $this->format('j');
     }
-
-    // }}}
-    // {{{ public function getHour()
 
     /**
      * Gets the hour of this date as a number from 0-23.
@@ -956,9 +888,6 @@ class SwatDate extends DateTime implements Stringable
         return (int) ltrim($this->format('H'), '0');
     }
 
-    // }}}
-    // {{{ public function getMinute()
-
     /**
      * Gets the minute of this date as a number from 0-59.
      *
@@ -971,9 +900,6 @@ class SwatDate extends DateTime implements Stringable
         return (int) ltrim($this->format('i'), '0');
     }
 
-    // }}}
-    // {{{ public function getSecond()
-
     /**
      * Gets the second of this date as a number from 0-59.
      *
@@ -985,9 +911,6 @@ class SwatDate extends DateTime implements Stringable
     {
         return (int) ltrim($this->format('s'), '0');
     }
-
-    // }}}
-    // {{{ public function getISO8601()
 
     /**
      * Gets this date formatted as an ISO 8601 timestamp.
@@ -1028,9 +951,6 @@ class SwatDate extends DateTime implements Stringable
         return $date;
     }
 
-    // }}}
-    // {{{ public function getRFC2822()
-
     /**
      * Gets this date formatted as required by RFC 2822.
      *
@@ -1042,9 +962,6 @@ class SwatDate extends DateTime implements Stringable
     {
         return $this->format(self::DF_RFC_2822);
     }
-
-    // }}}
-    // {{{ public function getFormattedOffsetById()
 
     /**
      * Returns this date's timezone offset from GMT using a format id.
@@ -1082,9 +999,6 @@ class SwatDate extends DateTime implements Stringable
         }
     }
 
-    // }}}
-    // {{{ public function getDaysInMonth()
-
     /**
      * Gets the number of days in the current month as a number from 28-21.
      *
@@ -1096,9 +1010,6 @@ class SwatDate extends DateTime implements Stringable
     {
         return (int) $this->format('t');
     }
-
-    // }}}
-    // {{{ public function getDayOfWeek()
 
     /**
      * Gets the day of the current week as a number from 0 to 6.
@@ -1113,9 +1024,6 @@ class SwatDate extends DateTime implements Stringable
         return (int) $this->format('w');
     }
 
-    // }}}
-    // {{{ public function getDayOfYear()
-
     /**
      * Gets the day of the year as a number from 1 to 365.
      *
@@ -1129,9 +1037,6 @@ class SwatDate extends DateTime implements Stringable
 
         return $day + 1; // the "z" format starts at 0
     }
-
-    // }}}
-    // {{{ public function getNextDay()
 
     /**
      * Gets a new date a day after this date.
@@ -1148,9 +1053,6 @@ class SwatDate extends DateTime implements Stringable
         return $date;
     }
 
-    // }}}
-    // {{{ public function getPrevDay()
-
     /**
      * Gets a new date a day before this date.
      *
@@ -1165,9 +1067,6 @@ class SwatDate extends DateTime implements Stringable
 
         return $date;
     }
-
-    // }}}
-    // {{{ public function getDate() - deprecated
 
     /**
      * Gets a PEAR-conanical formatted date.
@@ -1188,9 +1087,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->format('Y-m-d H:i:s');
     }
 
-    // }}}
-    // {{{ public function getTime() - deprecated
-
     /**
      * Gets the number of seconds since the UNIX epoch for this date.
      *
@@ -1204,9 +1100,6 @@ class SwatDate extends DateTime implements Stringable
     {
         return $this->getTimestamp();
     }
-
-    // }}}
-    // {{{ public function convertTZ() - deprecated
 
     /**
      * Sets the time zone for this date.
@@ -1224,9 +1117,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->setTimezone($time_zone);
     }
 
-    // }}}
-    // {{{ public function convertTZById() - deprecated
-
     /**
      * Sets the time zone for this date.
      *
@@ -1243,9 +1133,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->setTimezone(new DateTimeZone($time_zone_name));
     }
 
-    // }}}
-    // {{{ public function setTZ()
-
     /**
      * Sets the time zone for this date and updates this date's time so the
      * hours are the same as with the old time zone.
@@ -1261,9 +1148,6 @@ class SwatDate extends DateTime implements Stringable
             ->subtractSeconds($this->format('Z'));
     }
 
-    // }}}
-    // {{{ public function setTZById()
-
     /**
      * Sets the time zone for this date and updates this date's time so the
      * hours are the same as with the old time zone.
@@ -1277,9 +1161,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->setTZ(new DateTimeZone($time_zone_name));
     }
 
-    // }}}
-    // {{{ public function toUTC()
-
     /**
      * Sets the time zone of this date to UTC.
      *
@@ -1289,9 +1170,6 @@ class SwatDate extends DateTime implements Stringable
     {
         return $this->setTimezone(new DateTimeZone('UTC'));
     }
-
-    // }}}
-    // {{{ public function getMonthName()
 
     /**
      * Gets the full name of the current month of this date.
@@ -1305,9 +1183,6 @@ class SwatDate extends DateTime implements Stringable
     {
         return $this->formatLikeIntl('LLLL');
     }
-
-    // }}}
-    // {{{ public function addYears()
 
     /**
      * Adds the specified number of years to this date.
@@ -1328,9 +1203,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->add($interval);
     }
 
-    // }}}
-    // {{{ public function subtractYears()
-
     /**
      * Subtracts the specified number of years from this date.
      *
@@ -1345,9 +1217,6 @@ class SwatDate extends DateTime implements Stringable
 
         return $this->addYears($years);
     }
-
-    // }}}
-    // {{{ public function addMonths()
 
     /**
      * Adds the specified number of months to this date.
@@ -1368,9 +1237,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->add($interval);
     }
 
-    // }}}
-    // {{{ public function subtractMonths()
-
     /**
      * Subtracts the specified number of months from this date.
      *
@@ -1385,9 +1251,6 @@ class SwatDate extends DateTime implements Stringable
 
         return $this->addMonths($months);
     }
-
-    // }}}
-    // {{{ public function addDays()
 
     /**
      * Adds the specified number of days to this date.
@@ -1408,9 +1271,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->add($interval);
     }
 
-    // }}}
-    // {{{ public function subtractDays()
-
     /**
      * Subtracts the specified number of days from this date.
      *
@@ -1425,9 +1285,6 @@ class SwatDate extends DateTime implements Stringable
 
         return $this->addDays($days);
     }
-
-    // }}}
-    // {{{ public function addHours()
 
     /**
      * Adds the specified number of hours to this date.
@@ -1448,9 +1305,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->add($interval);
     }
 
-    // }}}
-    // {{{ public function subtractHours()
-
     /**
      * Subtracts the specified number of hours from this date.
      *
@@ -1465,9 +1319,6 @@ class SwatDate extends DateTime implements Stringable
 
         return $this->addHours($hours);
     }
-
-    // }}}
-    // {{{ public function addMinutes()
 
     /**
      * Adds the specified number of minutes to this date.
@@ -1488,9 +1339,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->add($interval);
     }
 
-    // }}}
-    // {{{ public function subtractMinutes()
-
     /**
      * Subtracts the specified number of minutes from this date.
      *
@@ -1505,9 +1353,6 @@ class SwatDate extends DateTime implements Stringable
 
         return $this->addMinutes($minutes);
     }
-
-    // }}}
-    // {{{ public function addSeconds()
 
     /**
      * Adds the specified number of seconds to this date.
@@ -1528,9 +1373,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->add($interval);
     }
 
-    // }}}
-    // {{{ public function subtractSeconds()
-
     /**
      * Subtracts the specified number of seconds from this date.
      *
@@ -1545,9 +1387,6 @@ class SwatDate extends DateTime implements Stringable
 
         return $this->addSeconds($seconds);
     }
-
-    // }}}
-    // {{{ public function setYear()
 
     /**
      * Sets the year of this date without affecting the other date parts.
@@ -1566,9 +1405,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->setCheckedDate($year, $this->getMonth(), $this->getDay());
     }
 
-    // }}}
-    // {{{ public function setMonth()
-
     /**
      * Sets the month of this date without affecting the other date parts.
      *
@@ -1586,9 +1422,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->setCheckedDate($this->getYear(), $month, $this->getDay());
     }
 
-    // }}}
-    // {{{ public function setDay()
-
     /**
      * Sets the day of this date without affecting the other date parts.
      *
@@ -1605,9 +1438,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->setCheckedDate($this->getYear(), $this->getMonth(), $day);
     }
 
-    // }}}
-    // {{{ public function setHour()
-
     /**
      * Sets the hour of this date without affecting the other date parts.
      *
@@ -1622,9 +1452,6 @@ class SwatDate extends DateTime implements Stringable
     {
         return $this->setTime($hour, $this->getMinute(), $this->getSecond());
     }
-
-    // }}}
-    // {{{ public function setMinute()
 
     /**
      * Sets the minute of this date without affecting the other date parts.
@@ -1642,9 +1469,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->setTime($this->getHour(), $minute, $this->getSecond());
     }
 
-    // }}}
-    // {{{ public function setSecond()
-
     /**
      * Sets the second of this date without affecting the other date parts.
      *
@@ -1661,9 +1485,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->setTime($this->getHour(), $this->getMinute(), $second);
     }
 
-    // }}}
-    // {{{ public function before()
-
     /**
      * Gets whether or not this date is before the specified date.
      *
@@ -1678,9 +1499,6 @@ class SwatDate extends DateTime implements Stringable
     {
         return self::compare($this, $when) === -1;
     }
-
-    // }}}
-    // {{{ public function after()
 
     /**
      * Gets whether or not this date is after the specified date.
@@ -1697,9 +1515,6 @@ class SwatDate extends DateTime implements Stringable
         return self::compare($this, $when) === 1;
     }
 
-    // }}}
-    // {{{ public function equals()
-
     /**
      * Gets whether or not this date is equivalent to the specified date.
      *
@@ -1714,9 +1529,6 @@ class SwatDate extends DateTime implements Stringable
     {
         return self::compare($this, $when) === 0;
     }
-
-    // }}}
-    // {{{ public function addStrictMonths()
 
     /**
      * Adds months to this date without affecting the day of the month.
@@ -1769,9 +1581,6 @@ class SwatDate extends DateTime implements Stringable
         return $this;
     }
 
-    // }}}
-    // {{{ public function subtractStrictMonths()
-
     /**
      * Subtracts months to this date without affecting the day of the month.
      *
@@ -1795,9 +1604,6 @@ class SwatDate extends DateTime implements Stringable
         return $this->addStrictMonths(-$months);
     }
 
-    // }}}
-    // {{{ protected function setCheckedDate()
-
     /**
      * Sets the date fields for this date and checks if it is a valid date.
      *
@@ -1819,6 +1625,4 @@ class SwatDate extends DateTime implements Stringable
 
         return $this->setDate($year, $month, $day);
     }
-
-    // }}}
 }

--- a/Swat/SwatDateCellRenderer.php
+++ b/Swat/SwatDateCellRenderer.php
@@ -8,8 +8,6 @@
  */
 class SwatDateCellRenderer extends SwatCellRenderer
 {
-    // {{{ public properties
-
     /**
      * Date to render.
      *
@@ -50,9 +48,6 @@ class SwatDateCellRenderer extends SwatCellRenderer
      * @var DateTimeZone|string
      */
     public $display_time_zone;
-
-    // }}}
-    // {{{ public function render()
 
     /**
      * Renders the contents of this cell.
@@ -96,6 +91,4 @@ class SwatDateCellRenderer extends SwatCellRenderer
             );
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatDateEntry.php
+++ b/Swat/SwatDateEntry.php
@@ -8,16 +8,11 @@
  */
 class SwatDateEntry extends SwatInputControl implements SwatState
 {
-    // {{{ class constants
-
     public const YEAR = 1;
     public const MONTH = 2;
     public const DAY = 4;
     public const TIME = 8;
     public const CALENDAR = 16;
-
-    // }}}
-    // {{{ public properties
 
     /**
      * Date of this date entry widget.
@@ -103,9 +98,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
      */
     public $show_blank_titles = true;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new date entry widget.
      *
@@ -133,9 +125,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         $this->addJavaScript('packages/swat/javascript/swat-date-entry.js');
     }
 
-    // }}}
-    // {{{ public function __clone()
-
     /**
      * Clones the valid date range of this date entry.
      */
@@ -144,9 +133,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         $this->valid_range_start = clone $this->valid_range_start;
         $this->valid_range_end = clone $this->valid_range_end;
     }
-
-    // }}}
-    // {{{ public function setValidRange()
 
     /**
      * Set the valid date range.
@@ -177,9 +163,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         $this->valid_range_start->setYear($year + $start_offset);
         $this->valid_range_end->setYear($year + $end_offset + 1);
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this date entry.
@@ -258,9 +241,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 
         $div_tag->close();
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this date entry.
@@ -394,9 +374,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         }
     }
 
-    // }}}
-    // {{{ public function getState()
-
     /**
      * Gets the current state of this date entry widget.
      *
@@ -413,9 +390,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         return $this->value->getDate();
     }
 
-    // }}}
-    // {{{ public function setState()
-
     /**
      * Sets the current state of this date entry widget.
      *
@@ -428,9 +402,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         $this->value = new SwatDate($state);
     }
 
-    // }}}
-    // {{{ public function isValid()
-
     /**
      * Checks if the entered date is within the valid range.
      *
@@ -441,9 +412,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
     {
         return $this->isStartDateValid() && $this->isEndDateValid();
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript required for this control.
@@ -537,9 +505,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         return $javascript;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this date entry widget.
      *
@@ -552,9 +517,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function isStartDateValid()
 
     /**
      * Checks if the entered date is valid with respect to the valid start
@@ -575,9 +537,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         ) >= 0;
     }
 
-    // }}}
-    // {{{ protected function isEndDateValid()
-
     /**
      * Checks if the entered date is valid with respect to the valid end date.
      *
@@ -592,9 +551,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         return SwatDate::compare($this->value, $this->valid_range_end, true)
             < 0;
     }
-
-    // }}}
-    // {{{ protected function validateRanges()
 
     /**
      * Makes sure the date the user entered is within the valid range.
@@ -626,9 +582,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
             $this->addMessage(new SwatMessage($message, 'error'));
         }
     }
-
-    // }}}
-    // {{{ protected function createCompositeWidgets()
 
     /**
      * Creates the composite widgets used by this date entry.
@@ -664,9 +617,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         }
     }
 
-    // }}}
-    // {{{ protected function createYearFlydown()
-
     /**
      * Creates the year flydown for this date entry.
      *
@@ -697,9 +647,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         return $flydown;
     }
 
-    // }}}
-    // {{{ protected function getYearBlankValueTitle()
-
     /**
      * Gets the blank value to use for the year flydown option.
      *
@@ -709,9 +656,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
     {
         return Swat::_('Year');
     }
-
-    // }}}
-    // {{{ protected function createMonthFlydown()
 
     /**
      * Creates the month flydown for this date entry.
@@ -754,9 +698,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         return $flydown;
     }
 
-    // }}}
-    // {{{ protected function getMonthBlankValueTitle()
-
     /**
      * Gets the blank value to use for the month flydown option.
      *
@@ -766,9 +707,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
     {
         return Swat::_('Month');
     }
-
-    // }}}
-    // {{{ protected function getMonthOptionText()
 
     /**
      * Gets the title of a month flydown option.
@@ -791,9 +729,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 
         return $text;
     }
-
-    // }}}
-    // {{{ protected function createDayFlydown()
 
     /**
      * Creates the day flydown for this date entry.
@@ -850,9 +785,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         return $flydown;
     }
 
-    // }}}
-    // {{{ protected function getDayBlankValueTitle()
-
     /**
      * Gets the blank value to use for the day flydown option.
      *
@@ -862,9 +794,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
     {
         return Swat::_('Day');
     }
-
-    // }}}
-    // {{{ protected function createTimeEntry()
 
     /**
      * Creates the time entry widget for this date entry.
@@ -878,9 +807,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 
         return $time_entry;
     }
-
-    // }}}
-    // {{{ protected function createCalendar()
 
     /**
      * Creates the calendar widget for this date entry.
@@ -896,9 +822,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 
         return $calendar;
     }
-
-    // }}}
-    // {{{ private function getFormattedDate()
 
     /**
      * Formats a date for this date entry.
@@ -939,9 +862,6 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 
         return $date->formatLikeIntl($format);
     }
-
-    // }}}
-    // {{{ private function getDatePartOrder()
 
     /**
      * Gets the order of date parts for the current locale.
@@ -1009,6 +929,4 @@ class SwatDateEntry extends SwatInputControl implements SwatState
 
         return $order;
     }
-
-    // }}}
 }

--- a/Swat/SwatDetailsStore.php
+++ b/Swat/SwatDetailsStore.php
@@ -13,8 +13,6 @@
  */
 class SwatDetailsStore extends SwatObject
 {
-    // {{{ private properties
-
     /**
      * The base object for this details store.
      *
@@ -32,9 +30,6 @@ class SwatDetailsStore extends SwatObject
      */
     private $data = [];
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new details store.
      *
@@ -50,9 +45,6 @@ class SwatDetailsStore extends SwatObject
             $this->base_object = $base_object;
         }
     }
-
-    // }}}
-    // {{{ public function __get()
 
     /**
      * Gets a property of this details store.
@@ -102,9 +94,6 @@ class SwatDetailsStore extends SwatObject
         );
     }
 
-    // }}}
-    // {{{ public function __set()
-
     /**
      * Manually sets a property of this details store.
      *
@@ -119,9 +108,6 @@ class SwatDetailsStore extends SwatObject
     {
         $this->data[$name] = $value;
     }
-
-    // }}}
-    // {{{ public function __isset()
 
     /**
      * Gets whether or not a property is set for this details store.
@@ -145,9 +131,6 @@ class SwatDetailsStore extends SwatObject
         return $is_set;
     }
 
-    // }}}
-    // {{{ private function parsePath()
-
     private function parsePath($object, $path)
     {
         $pos = mb_strpos($path, '.');
@@ -164,6 +147,4 @@ class SwatDetailsStore extends SwatObject
 
         return $this->parsePath($sub_object, $rest);
     }
-
-    // }}}
 }

--- a/Swat/SwatDetailsView.php
+++ b/Swat/SwatDetailsView.php
@@ -8,8 +8,6 @@
  */
 class SwatDetailsView extends SwatControl implements SwatUIParent
 {
-    // {{{ public properties
-
     /**
      * An object containing values to display.
      *
@@ -23,9 +21,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
      * @see SwatDetailsViewField
      */
     public $data;
-
-    // }}}
-    // {{{ private properties
 
     /**
      * An array of fields to be displayed by this details view.
@@ -47,9 +42,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
      */
     private $fields_by_id = [];
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new details view.
      *
@@ -63,9 +55,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 
         $this->addStyleSheet('packages/swat/styles/swat-details-view.css');
     }
-
-    // }}}
-    // {{{ public function init()
 
     /**
      * Initializes this details-view.
@@ -83,9 +72,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this details-view.
      */
@@ -97,9 +83,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
             $field->process();
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this details view.
@@ -125,9 +108,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ public function appendField()
-
     /**
      * Appends a field to this details view.
      *
@@ -142,9 +122,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
     {
         $this->insertField($field);
     }
-
-    // }}}
-    // {{{ public function insertFieldBefore()
 
     /**
      * Inserts a field before an existing field in this details-view.
@@ -165,9 +142,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         $this->insertField($field, $reference_field, false);
     }
 
-    // }}}
-    // {{{ public function insertFieldAfter()
-
     /**
      * Inserts a field after an existing field in this details-view.
      *
@@ -187,9 +161,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         $this->insertField($field, $reference_field, true);
     }
 
-    // }}}
-    // {{{ public function getFieldCount()
-
     /**
      * Gets the number of fields of this details-view.
      *
@@ -200,9 +171,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         return count($this->fields);
     }
 
-    // }}}
-    // {{{ public function getFields()
-
     /**
      * Get the fields of this details-view.
      *
@@ -212,9 +180,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
     {
         return $this->fields;
     }
-
-    // }}}
-    // {{{ public function getField()
 
     /**
      * Gets a field in this details view by the field's id.
@@ -238,9 +203,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         return $this->fields_by_id[$id];
     }
 
-    // }}}
-    // {{{ public function hasField()
-
     /**
      * Whether a field exists in this details view.
      *
@@ -252,9 +214,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
     {
         return array_key_exists($id, $this->fields_by_id);
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Adds a child object to this object.
@@ -283,9 +242,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this details-view.
      *
@@ -304,9 +260,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this
@@ -327,9 +280,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -375,9 +325,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -413,9 +360,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -436,9 +380,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         return $states;
     }
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -456,9 +397,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -488,9 +426,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         return $copy;
     }
 
-    // }}}
-    // {{{ protected function validateField()
-
     /**
      * Ensures a field added to this details-view is valid for this
      * details-view.
@@ -515,9 +450,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ protected function insertField()
 
     /**
      * Helper method to insert fields into this details-view.
@@ -601,9 +533,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         $field->parent = $this;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this details view.
      *
@@ -616,9 +545,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript needed by this details view as well as any
@@ -647,9 +573,6 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
         return $javascript;
     }
 
-    // }}}
-    // {{{ protected function displayContent()
-
     /**
      * Displays each field of this view.
      *
@@ -672,6 +595,4 @@ class SwatDetailsView extends SwatControl implements SwatUIParent
             }
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatDetailsViewField.php
+++ b/Swat/SwatDetailsViewField.php
@@ -8,8 +8,6 @@
  */
 class SwatDetailsViewField extends SwatCellRendererContainer
 {
-    // {{{ public properties
-
     /**
      * The unique identifier of this field.
      *
@@ -66,18 +64,12 @@ class SwatDetailsViewField extends SwatCellRendererContainer
      */
     public $show_renderer_classes = true;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * Whether or not this field is odd or even in its parent details view.
      *
      * @var bool
      */
     protected $odd = false;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new details view field.
@@ -91,9 +83,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
         parent::__construct();
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this field.
      *
@@ -106,18 +95,12 @@ class SwatDetailsViewField extends SwatCellRendererContainer
         }
     }
 
-    // }}}
-    // {{{ public function process()
-
     public function process()
     {
         foreach ($this->renderers as $renderer) {
             $renderer->process();
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this details view field using a data object.
@@ -145,9 +128,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
         $tr_tag->close();
     }
 
-    // }}}
-    // {{{ public function displayHeader()
-
     /**
      * Displays the header for this details view field.
      */
@@ -166,9 +146,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 
         $th_tag->display();
     }
-
-    // }}}
-    // {{{ public function displayValue()
 
     /**
      * Displays the value of this details view field.
@@ -197,9 +174,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
         $this->displayRenderers($data);
     }
 
-    // }}}
-    // {{{ public function getTdAttributes()
-
     /**
      * Gets the TD tag attributes for this column.
      *
@@ -213,9 +187,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
             'class' => $this->getCSSClassString(),
         ];
     }
-
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this field.
@@ -236,9 +207,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this
@@ -261,9 +229,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
         return $set;
     }
 
-    // }}}
-    // {{{ protected function getHeaderTitle()
-
     /**
      * Gets the title to use for the header of this details view field.
      *
@@ -283,9 +248,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 
         return $header_title;
     }
-
-    // }}}
-    // {{{ protected function displayRenderers()
 
     /**
      * Renders each cell renderer in this details-view field.
@@ -311,9 +273,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
 
         $td_tag->close();
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this details-view
@@ -386,9 +345,6 @@ class SwatDetailsViewField extends SwatCellRendererContainer
         return $classes;
     }
 
-    // }}}
-    // {{{ protected function getBaseCSSClassNames()
-
     /**
      * Gets the base CSS class names of this details-view field.
      *
@@ -402,6 +358,4 @@ class SwatDetailsViewField extends SwatCellRendererContainer
     {
         return ['swat-details-view-field'];
     }
-
-    // }}}
 }

--- a/Swat/SwatDetailsViewVerticalField.php
+++ b/Swat/SwatDetailsViewVerticalField.php
@@ -9,8 +9,6 @@
  */
 class SwatDetailsViewVerticalField extends SwatDetailsViewField
 {
-    // {{{ public function display()
-
     /**
      * Displays this details view field using a data object.
      *
@@ -44,9 +42,6 @@ class SwatDetailsViewVerticalField extends SwatDetailsViewField
         $tr_tag->close();
     }
 
-    // }}}
-    // {{{ public function displayHeader()
-
     /**
      * Displays the header for this details view field.
      *
@@ -65,9 +60,6 @@ class SwatDetailsViewVerticalField extends SwatDetailsViewField
             $div_tag->display();
         }
     }
-
-    // }}}
-    // {{{ protected function displayRenderers()
 
     /**
      * Renders each cell renderer in this details-view field.
@@ -90,9 +82,6 @@ class SwatDetailsViewVerticalField extends SwatDetailsViewField
         $div_tag->close();
     }
 
-    // }}}
-    // {{{ protected function getBaseCSSClassNames()
-
     /**
      * Gets the base CSS class names of this details-view field.
      *
@@ -103,6 +92,4 @@ class SwatDetailsViewVerticalField extends SwatDetailsViewField
     {
         return ['swat-details-view-vertical-field'];
     }
-
-    // }}}
 }

--- a/Swat/SwatDisclosure.php
+++ b/Swat/SwatDisclosure.php
@@ -8,8 +8,6 @@
  */
 class SwatDisclosure extends SwatDisplayableContainer
 {
-    // {{{ public properties
-
     /**
      * A visible title for the label shown beside the disclosure triangle.
      *
@@ -23,9 +21,6 @@ class SwatDisclosure extends SwatDisplayableContainer
      * @var bool
      */
     public $open = true;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new disclosure container.
@@ -45,9 +40,6 @@ class SwatDisclosure extends SwatDisplayableContainer
         $this->addJavaScript('packages/swat/javascript/swat-disclosure.js');
         $this->addStyleSheet('packages/swat/styles/swat-disclosure.css');
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this disclosure container.
@@ -91,9 +83,6 @@ class SwatDisclosure extends SwatDisplayableContainer
         $control_div->close();
     }
 
-    // }}}
-    // {{{ protected function getControlDivTag()
-
     protected function getControlDivTag()
     {
         $div = new SwatHtmlTag('div');
@@ -103,9 +92,6 @@ class SwatDisclosure extends SwatDisplayableContainer
         return $div;
     }
 
-    // }}}
-    // {{{ protected function getContainerDivTag()
-
     protected function getContainerDivTag()
     {
         $div = new SwatHtmlTag('div');
@@ -114,16 +100,10 @@ class SwatDisclosure extends SwatDisplayableContainer
         return $div;
     }
 
-    // }}}
-    // {{{ protected function getAnimateDivTag()
-
     protected function getAnimateDivTag()
     {
         return new SwatHtmlTag('div');
     }
-
-    // }}}
-    // {{{ protected function getPaddingDivTag()
 
     protected function getPaddingDivTag()
     {
@@ -132,9 +112,6 @@ class SwatDisclosure extends SwatDisplayableContainer
 
         return $div;
     }
-
-    // }}}
-    // {{{ protected function getInputTag()
 
     protected function getInputTag()
     {
@@ -147,9 +124,6 @@ class SwatDisclosure extends SwatDisplayableContainer
         return $input;
     }
 
-    // }}}
-    // {{{ protected function getSpanTag()
-
     protected function getSpanTag()
     {
         $title = strval($this->title);
@@ -160,9 +134,6 @@ class SwatDisclosure extends SwatDisplayableContainer
 
         return $span;
     }
-
-    // }}}
-    // {{{ protected function getJavaScriptClass()
 
     /**
      * Gets the name of the JavaScript class to instantiate for this disclosure.
@@ -177,9 +148,6 @@ class SwatDisclosure extends SwatDisplayableContainer
     {
         return 'SwatDisclosure';
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets disclosure specific inline JavaScript.
@@ -199,9 +167,6 @@ class SwatDisclosure extends SwatDisplayableContainer
         );
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this disclosure.
      *
@@ -218,6 +183,4 @@ class SwatDisclosure extends SwatDisplayableContainer
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatDisplayableContainer.php
+++ b/Swat/SwatDisplayableContainer.php
@@ -8,8 +8,6 @@
  */
 class SwatDisplayableContainer extends SwatContainer
 {
-    // {{{ public function display()
-
     /**
      * Displays this container.
      */
@@ -30,9 +28,6 @@ class SwatDisplayableContainer extends SwatContainer
         $div->close();
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this displayable
      * container.
@@ -46,6 +41,4 @@ class SwatDisplayableContainer extends SwatContainer
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatEmailEntry.php
+++ b/Swat/SwatEmailEntry.php
@@ -11,8 +11,6 @@
  */
 class SwatEmailEntry extends SwatEntry
 {
-    // {{{ public function process()
-
     /**
      * Processes this email entry.
      *
@@ -38,9 +36,6 @@ class SwatEmailEntry extends SwatEntry
         }
     }
 
-    // }}}
-    // {{{ protected function validateEmailAddress()
-
     /**
      * Validates the email address value of this entry.
      *
@@ -51,9 +46,6 @@ class SwatEmailEntry extends SwatEntry
     {
         return SwatString::validateEmailAddress($this->value);
     }
-
-    // }}}
-    // {{{ protected function getValidationMessage()
 
     /**
      * Gets a validation message for this email entry.
@@ -84,9 +76,6 @@ class SwatEmailEntry extends SwatEntry
         return $message;
     }
 
-    // }}}
-    // {{{ protected function getInputTag()
-
     /**
      * Get the input tag to display.
      *
@@ -100,9 +89,6 @@ class SwatEmailEntry extends SwatEntry
         return $tag;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this entry.
      *
@@ -115,6 +101,4 @@ class SwatEmailEntry extends SwatEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatEntry.php
+++ b/Swat/SwatEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatEntry extends SwatInputControl implements SwatState
 {
-    // {{{ public properties
-
     /**
      * Entry value.
      *
@@ -100,9 +98,6 @@ class SwatEntry extends SwatInputControl implements SwatState
      */
     public $select_on_focus = false;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * If autocomplete is turned off, this nonce is used to obfuscate the
      * name of the XHTML input tag.
@@ -120,9 +115,6 @@ class SwatEntry extends SwatInputControl implements SwatState
      * @var bool
      */
     public $auto_trim = true;
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this entry widget.
@@ -148,9 +140,6 @@ class SwatEntry extends SwatInputControl implements SwatState
             $nonce_tag->display();
         }
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this entry widget.
@@ -204,9 +193,6 @@ class SwatEntry extends SwatInputControl implements SwatState
         }
     }
 
-    // }}}
-    // {{{ public function getState()
-
     /**
      * Gets the current state of this entry widget.
      *
@@ -219,9 +205,6 @@ class SwatEntry extends SwatInputControl implements SwatState
         return $this->value;
     }
 
-    // }}}
-    // {{{ public function setState()
-
     /**
      * Sets the current state of this entry widget.
      *
@@ -233,9 +216,6 @@ class SwatEntry extends SwatInputControl implements SwatState
     {
         $this->value = $state;
     }
-
-    // }}}
-    // {{{ public function getFocusableHtmlId()
 
     /**
      * Gets the id attribute of the XHTML element displayed by this widget
@@ -255,9 +235,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 
         return null;
     }
-
-    // }}}
-    // {{{ protected function getValidationMessage()
 
     /**
      * Gets a validation message for this entry.
@@ -286,9 +263,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 
         return new SwatMessage($text, 'error');
     }
-
-    // }}}
-    // {{{ protected function getInputTag()
 
     /**
      * Get the input tag to display.
@@ -346,9 +320,6 @@ class SwatEntry extends SwatInputControl implements SwatState
         return $tag;
     }
 
-    // }}}
-    // {{{ protected function getDisplayValue()
-
     /**
      * Formats a value to display.
      *
@@ -363,9 +334,6 @@ class SwatEntry extends SwatInputControl implements SwatState
         return $value;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this entry widget.
      *
@@ -379,9 +347,6 @@ class SwatEntry extends SwatInputControl implements SwatState
         return array_merge($classes, parent::getCSSClassNames());
     }
 
-    // }}}
-    // {{{ protected function getNonce()
-
     protected function getNonce()
     {
         if ($this->nonce === null) {
@@ -390,9 +355,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 
         return $this->nonce;
     }
-
-    // }}}
-    // {{{ protected function getRawValue()
 
     /**
      * Gets the raw value entered by the user before processing.
@@ -424,9 +386,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 
         return $value;
     }
-
-    // }}}
-    // {{{ protected function hasRawValue()
 
     /**
      * Gets whether or not a value was submitted by the user for this entry.
@@ -461,6 +420,4 @@ class SwatEntry extends SwatInputControl implements SwatState
 
         return $has_value;
     }
-
-    // }}}
 }

--- a/Swat/SwatError.php
+++ b/Swat/SwatError.php
@@ -16,8 +16,6 @@
  */
 class SwatError
 {
-    // {{{ protected properties
-
     /**
      * The message of this error.
      *
@@ -82,9 +80,6 @@ class SwatError
      */
     protected static $fatal_severity = E_USER_ERROR;
 
-    // }}}
-    // {{{ public static function setLogger()
-
     /**
      * Sets the object that logs SwatError objects when they are processed.
      *
@@ -99,9 +94,6 @@ class SwatError
     {
         self::$loggers = [$logger];
     }
-
-    // }}}
-    // {{{ public static function addLogger()
 
     /**
      * Adds an object to the array of objects that log SwatError objects
@@ -120,9 +112,6 @@ class SwatError
         self::$loggers[] = $logger;
     }
 
-    // }}}
-    // {{{ public static function setDisplayer()
-
     /**
      * Sets the object that displays SwatError objects when they are
      * processed.
@@ -140,9 +129,6 @@ class SwatError
         self::$displayer = $displayer;
     }
 
-    // }}}
-    // {{{ public static function setFatalSeverity()
-
     /**
      * Sets the severity of SwatError that should be fatal.
      *
@@ -153,9 +139,6 @@ class SwatError
     {
         self::$fatal_severity = $severity;
     }
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new error object.
@@ -185,9 +168,6 @@ class SwatError
         $this->backtrace = &$backtrace;
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this error.
      *
@@ -212,9 +192,6 @@ class SwatError
         }
     }
 
-    // }}}
-    // {{{ public function getMessage()
-
     /**
      * Gets the original message string of this error.
      *
@@ -224,9 +201,6 @@ class SwatError
     {
         return $this->message;
     }
-
-    // }}}
-    // {{{ public function getSeverity()
 
     /**
      * Gets the severity of this error.
@@ -238,9 +212,6 @@ class SwatError
         return $this->severity;
     }
 
-    // }}}
-    // {{{ public function getFile()
-
     /**
      * Gets the file location where the error occurred.
      *
@@ -251,9 +222,6 @@ class SwatError
         return $this->file;
     }
 
-    // }}}
-    // {{{ public function getLine()
-
     /**
      * Gets the line number where the error occurred.
      *
@@ -263,9 +231,6 @@ class SwatError
     {
         return $this->line;
     }
-
-    // }}}
-    // {{{ public function log()
 
     /**
      * Logs this error.
@@ -283,9 +248,6 @@ class SwatError
         }
     }
 
-    // }}}
-    // {{{ public function display()
-
     public function display()
     {
         if (self::$displayer === null) {
@@ -299,9 +261,6 @@ class SwatError
             $displayer->display($this);
         }
     }
-
-    // }}}
-    // {{{ public function getSummary()
 
     /**
      * Gets a one-line short text summary of this error.
@@ -323,9 +282,6 @@ class SwatError
 
         return ob_get_clean();
     }
-
-    // }}}
-    // {{{ public function toString()
 
     /**
      * Gets this error as a nicely formatted text block.
@@ -383,9 +339,6 @@ class SwatError
 
         return ob_get_clean();
     }
-
-    // }}}
-    // {{{ public function toXHTML()
 
     /**
      * Gets this error as a nicely formatted XHTML fragment.
@@ -453,9 +406,6 @@ class SwatError
         return ob_get_clean();
     }
 
-    // }}}
-    // {{{ public static function handle()
-
     /**
      * Handles an error.
      *
@@ -474,9 +424,6 @@ class SwatError
             $error->process();
         }
     }
-
-    // }}}
-    // {{{ protected function getArguments()
 
     /**
      * Formats a method call's arguments.
@@ -533,9 +480,6 @@ class SwatError
         return implode(', ', $formatted_values);
     }
 
-    // }}}
-    // {{{ protected function formatSensitiveParam()
-
     /**
      * Removes sensitive information from a parameter value and formats
      * the parameter as a string.
@@ -555,9 +499,6 @@ class SwatError
     {
         return '[$' . $name . ' FILTERED]';
     }
-
-    // }}}
-    // {{{ protected function formatValue()
 
     /**
      * Formats a parameter value for display in a stack trace.
@@ -616,9 +557,6 @@ class SwatError
         return $formatted_value;
     }
 
-    // }}}
-    // {{{ protected function displayStyleSheet()
-
     /**
      * Displays styles required to show XHTML error messages.
      *
@@ -650,9 +588,6 @@ class SwatError
         }
     }
 
-    // }}}
-    // {{{ protected function getSeverityString()
-
     /**
      * Gets a string representation of this error's severity.
      *
@@ -676,9 +611,6 @@ class SwatError
 
         return $out;
     }
-
-    // }}}
-    // {{{ protected function isSensitiveParameter()
 
     /**
      * Detects whether or not a parameter is sensitive from the method-level
@@ -726,9 +658,6 @@ class SwatError
         return $sensitive;
     }
 
-    // }}}
-    // {{{ public static function setupHandler()
-
     /**
      * Set the PHP error handler to use SwatError.
      */
@@ -740,6 +669,4 @@ class SwatError
          */
         set_error_handler(['SwatError', 'handle'], error_reporting());
     }
-
-    // }}}
 }

--- a/Swat/SwatErrorDisplayer.php
+++ b/Swat/SwatErrorDisplayer.php
@@ -14,14 +14,10 @@
  */
 abstract class SwatErrorDisplayer
 {
-    // {{{ public abstract function display()
-
     /**
      * Displays a SwatError.
      *
      * This is called by SwatError::process().
      */
     abstract public function display(SwatError $e);
-
-    // }}}
 }

--- a/Swat/SwatErrorLogger.php
+++ b/Swat/SwatErrorLogger.php
@@ -14,14 +14,10 @@
  */
 abstract class SwatErrorLogger
 {
-    // {{{ public abstract function log()
-
     /**
      * Logs a SwatError.
      *
      * This is called by SwatError::process().
      */
     abstract public function log(SwatError $e);
-
-    // }}}
 }

--- a/Swat/SwatExceptionDisplayer.php
+++ b/Swat/SwatExceptionDisplayer.php
@@ -15,14 +15,10 @@
  */
 abstract class SwatExceptionDisplayer
 {
-    // {{{ public abstract function display()
-
     /**
      * Displays a SwatException.
      *
      * This is called by SwatException::process().
      */
     abstract public function display(SwatException $e);
-
-    // }}}
 }

--- a/Swat/SwatExceptionLogger.php
+++ b/Swat/SwatExceptionLogger.php
@@ -14,14 +14,10 @@
  */
 abstract class SwatExceptionLogger
 {
-    // {{{ public abstract function log()
-
     /**
      * Logs a SwatException.
      *
      * This is called by SwatException::process().
      */
     abstract public function log(SwatException $e);
-
-    // }}}
 }

--- a/Swat/SwatExternalJavaScriptHtmlHeadEntry.php
+++ b/Swat/SwatExternalJavaScriptHtmlHeadEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatExternalJavaScriptHtmlHeadEntry extends SwatHtmlHeadEntry
 {
-    // {{{ protected function displayInternal()
-
     protected function displayInternal($uri_prefix = '', $tag = null)
     {
         $uri = $this->uri;
@@ -17,13 +15,8 @@ class SwatExternalJavaScriptHtmlHeadEntry extends SwatHtmlHeadEntry
         printf('<script type="text/javascript" src="%s"></script>', $uri);
     }
 
-    // }}}
-    // {{{ protected function displayInlineInternal()
-
     protected function displayInlineInternal($path)
     {
         // Can't inline external JavaScript resources
     }
-
-    // }}}
 }

--- a/Swat/SwatFieldset.php
+++ b/Swat/SwatFieldset.php
@@ -10,8 +10,6 @@
  */
 class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
 {
-    // {{{ public properties
-
     /**
      * Fieldset title.
      *
@@ -39,9 +37,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
      */
     public $access_key;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new fieldset.
      *
@@ -61,9 +56,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
         $this->addJavaScript('packages/swat/javascript/swat-fieldset.js');
     }
 
-    // }}}
-    // {{{ public function getTitle()
-
     /**
      * Gets the title of this fieldset.
      *
@@ -76,9 +68,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
         return $this->title;
     }
 
-    // }}}
-    // {{{ public function getTitleContentType()
-
     /**
      * Gets the title content-type of this fieldset.
      *
@@ -90,9 +79,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
     {
         return $this->title_content_type;
     }
-
-    // }}}
-    // {{{ public function display()
 
     public function display()
     {
@@ -125,9 +111,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
         $fieldset_tag->close();
     }
 
-    // }}}
-    // {{{ protected function getInlineJavaScript()
-
     /**
      * Gets fieldset specific inline JavaScript.
      *
@@ -142,9 +125,6 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
         );
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this fieldset.
      *
@@ -156,6 +136,4 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatFileEntry.php
+++ b/Swat/SwatFileEntry.php
@@ -15,8 +15,6 @@
  */
 class SwatFileEntry extends SwatInputControl
 {
-    // {{{ public properties
-
     /**
      * The size in characters of the XHTML form input, or null if no width is
      * specified.
@@ -82,9 +80,6 @@ class SwatFileEntry extends SwatInputControl
      */
     public $display_maximum_upload_size = false;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * Stores the relevant part of the $_FILES array for this widget after
      * the widget's parent is processed.
@@ -92,9 +87,6 @@ class SwatFileEntry extends SwatInputControl
      * @var array
      */
     protected $file;
-
-    // }}}
-    // {{{ private properties
 
     /**
      * The mime type of the uploaded file.
@@ -107,9 +99,6 @@ class SwatFileEntry extends SwatInputControl
      * @var string
      */
     private $mime_type;
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this entry widget.
@@ -153,9 +142,6 @@ class SwatFileEntry extends SwatInputControl
         }
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this file entry widget.
      *
@@ -195,9 +181,6 @@ class SwatFileEntry extends SwatInputControl
         }
     }
 
-    // }}}
-    // {{{ public function getNote()
-
     /**
      * Gets a note specifying the mime types this file entry accepts.
      *
@@ -234,9 +217,6 @@ class SwatFileEntry extends SwatInputControl
         return $message;
     }
 
-    // }}}
-    // {{{ public function isUploaded()
-
     /**
      * Is file uploaded.
      *
@@ -246,9 +226,6 @@ class SwatFileEntry extends SwatInputControl
     {
         return $this->file !== null;
     }
-
-    // }}}
-    // {{{ public function getFileName()
 
     /**
      * Gets the original file name of the uploaded file.
@@ -262,9 +239,6 @@ class SwatFileEntry extends SwatInputControl
     {
         return $this->isUploaded() ? $this->file['name'] : null;
     }
-
-    // }}}
-    // {{{ public function getUniqueFileName()
 
     /**
      * Gets a unique file name for the uploaded file for the given path.
@@ -290,9 +264,6 @@ class SwatFileEntry extends SwatInputControl
         );
     }
 
-    // }}}
-    // {{{ public function getTempFileName()
-
     /**
      * Gets the temporary name of the uploaded file.
      *
@@ -306,9 +277,6 @@ class SwatFileEntry extends SwatInputControl
         return $this->isUploaded() ? $this->file['tmp_name'] : null;
     }
 
-    // }}}
-    // {{{ public function getSize()
-
     /**
      * Gets the size of the uploaded file in bytes.
      *
@@ -319,9 +287,6 @@ class SwatFileEntry extends SwatInputControl
     {
         return $this->isUploaded() ? $this->file['size'] : null;
     }
-
-    // }}}
-    // {{{ public function getMimeType()
 
     /**
      * Gets the mime type of the uploaded file.
@@ -361,9 +326,6 @@ class SwatFileEntry extends SwatInputControl
         return $this->mime_type;
     }
 
-    // }}}
-    // {{{ public function saveFile()
-
     /**
      * Saves the uploaded file to the server.
      *
@@ -401,9 +363,6 @@ class SwatFileEntry extends SwatInputControl
         );
     }
 
-    // }}}
-    // {{{ public function getFocusableHtmlId()
-
     /**
      * Gets the id attribute of the XHTML element displayed by this widget
      * that should receive focus.
@@ -418,9 +377,6 @@ class SwatFileEntry extends SwatInputControl
     {
         return $this->visible ? $this->id : null;
     }
-
-    // }}}
-    // {{{ public static function getMaximumFileUploadSize()
 
     /**
      * Returns the size (in bytes) of the upload size limit of the PHP
@@ -440,9 +396,6 @@ class SwatFileEntry extends SwatInputControl
             self::parseFileUploadSize(ini_get('upload_max_filesize')),
         );
     }
-
-    // }}}
-    // {{{ protected function getValidationMessage()
 
     /**
      * Gets a validation message for this file entry.
@@ -520,9 +473,6 @@ class SwatFileEntry extends SwatInputControl
         return $message;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this file entry widget.
      *
@@ -535,9 +485,6 @@ class SwatFileEntry extends SwatInputControl
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function hasValidMimeType()
 
     /**
      * Whether or not the uploaded file's mime type is valid.
@@ -576,9 +523,6 @@ class SwatFileEntry extends SwatInputControl
         return $valid;
     }
 
-    // }}}
-    // {{{ protected function getMaximumUploadSizeText()
-
     protected function getMaximumUploadSizeText()
     {
         return sprintf(
@@ -586,9 +530,6 @@ class SwatFileEntry extends SwatInputControl
             SwatString::byteFormat(self::getMaximumFileUploadSize()),
         );
     }
-
-    // }}}
-    // {{{ protected function getFinfo()
 
     /**
      * Gets a new finfo resource.
@@ -607,9 +548,6 @@ class SwatFileEntry extends SwatInputControl
 
         return new finfo($mime_constant);
     }
-
-    // }}}
-    // {{{ protected function getDisplayableTypes()
 
     /**
      * Gets a unique array of acceptable human-readable file and mime types for
@@ -636,9 +574,6 @@ class SwatFileEntry extends SwatInputControl
         return $displayable_types;
     }
 
-    // }}}
-    // {{{ private function generateUniqueFileName()
-
     private function generateUniqueFileName($path, $count = 0)
     {
         if (mb_strpos($this->getFileName(), '.') === false) {
@@ -662,9 +597,6 @@ class SwatFileEntry extends SwatInputControl
 
         return $file_name;
     }
-
-    // }}}
-    // {{{ private static function parseFileUploadSize()
 
     private static function parseFileUploadSize($ini_value)
     {
@@ -701,6 +633,4 @@ class SwatFileEntry extends SwatInputControl
 
         return $value;
     }
-
-    // }}}
 }

--- a/Swat/SwatFloatEntry.php
+++ b/Swat/SwatFloatEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatFloatEntry extends SwatNumericEntry
 {
-    // {{{ public function process()
-
     /**
      * Checks to make sure value is a number.
      *
@@ -32,9 +30,6 @@ class SwatFloatEntry extends SwatNumericEntry
             $this->value = $float_value;
         }
     }
-
-    // }}}
-    // {{{ protected function getDisplayValue()
 
     /**
      * Formats a float value to display.
@@ -59,9 +54,6 @@ class SwatFloatEntry extends SwatNumericEntry
         return $value;
     }
 
-    // }}}
-    // {{{ protected function getNumericValue()
-
     /**
      * Gets the float value of this widget.
      *
@@ -79,9 +71,6 @@ class SwatFloatEntry extends SwatNumericEntry
 
         return $locale->parseFloat($value);
     }
-
-    // }}}
-    // {{{ protected function getValidationMessage()
 
     /**
      * Gets a validation message for this float entry.
@@ -112,9 +101,6 @@ class SwatFloatEntry extends SwatNumericEntry
         return $message;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this entry.
      *
@@ -127,6 +113,4 @@ class SwatFloatEntry extends SwatNumericEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatFlydown.php
+++ b/Swat/SwatFlydown.php
@@ -8,8 +8,6 @@
  */
 class SwatFlydown extends SwatOptionControl implements SwatState
 {
-    // {{{ public properties
-
     /**
      * Flydown value.
      *
@@ -45,9 +43,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
      * or display it as a list/flydown with just one option.
      */
     public bool $collapse_single = true;
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this flydown.
@@ -165,9 +160,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
         $wrapper->close();
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Figures out what option was selected.
      *
@@ -197,9 +189,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
         }
     }
 
-    // }}}
-    // {{{ public function addDivider()
-
     /**
      * Adds a divider to this flydown.
      *
@@ -215,9 +204,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
         $this->options[] = new SwatFlydownDivider(null, $title, $content_type);
     }
 
-    // }}}
-    // {{{ public function reset()
-
     /**
      * Resets this flydown.
      *
@@ -229,9 +215,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
         reset($this->options);
         $this->value = null;
     }
-
-    // }}}
-    // {{{ public function getState()
 
     /**
      * Gets the current state of this flydown.
@@ -245,9 +228,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
         return $this->value;
     }
 
-    // }}}
-    // {{{ public function setState()
-
     /**
      * Sets the current state of this flydown.
      *
@@ -259,9 +239,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
     {
         $this->value = $state;
     }
-
-    // }}}
-    // {{{ public function getFocusableHtmlId()
 
     /**
      * Gets the id attribute of the XHTML element displayed by this widget
@@ -291,9 +268,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
         return $focusable_id;
     }
 
-    // }}}
-    // {{{ protected function processValue()
-
     /**
      * Processes the value of this flydown from user-submitted form data.
      *
@@ -320,9 +294,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 
         return true;
     }
-
-    // }}}
-    // {{{ protected function displaySingle()
 
     /**
      * Displays this flydown if there is only a single option.
@@ -351,9 +322,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
         $span_tag->display();
     }
 
-    // }}}
-    // {{{ protected function getBlankOption()
-
     /**
      * Gets the the blank option for this flydown.
      *
@@ -363,9 +331,6 @@ class SwatFlydown extends SwatOptionControl implements SwatState
     {
         return new SwatFlydownBlankOption(null, $this->blank_title);
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this flydown.
@@ -378,6 +343,4 @@ class SwatFlydown extends SwatOptionControl implements SwatState
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatFlydownDivider.php
+++ b/Swat/SwatFlydownDivider.php
@@ -11,8 +11,6 @@
  */
 class SwatFlydownDivider extends SwatOption
 {
-    // {{{ public function __construct()
-
     /**
      * Creates a flydown option.
      *
@@ -33,6 +31,4 @@ class SwatFlydownDivider extends SwatOption
 
         parent::__construct($value, $title, $content_type);
     }
-
-    // }}}
 }

--- a/Swat/SwatFooterFormField.php
+++ b/Swat/SwatFooterFormField.php
@@ -10,8 +10,6 @@
  */
 class SwatFooterFormField extends SwatFormField
 {
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this footer form field.
      *
@@ -25,6 +23,4 @@ class SwatFooterFormField extends SwatFormField
 
         return $classes;
     }
-
-    // }}}
 }

--- a/Swat/SwatForm.php
+++ b/Swat/SwatForm.php
@@ -14,8 +14,6 @@
  */
 class SwatForm extends SwatDisplayableContainer
 {
-    // {{{ constants
-
     public const METHOD_POST = 'post';
     public const METHOD_GET = 'get';
 
@@ -28,9 +26,6 @@ class SwatForm extends SwatDisplayableContainer
     public const ENCODING_ENTITY_VALUE = '&auml;&trade;&reg;';
     public const ENCODING_UTF8_VALUE = "\xc3\xa4\xe2\x84\xa2\xc2\xae";
     public const ENCODING_8BIT_VALUE = "\xe4\x99\xae";
-
-    // }}}
-    // {{{ public properties
 
     /**
      * The action attribute of the HTML form tag.
@@ -121,9 +116,6 @@ class SwatForm extends SwatDisplayableContainer
      */
     public static $default_salt;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * Hidden form fields.
      *
@@ -202,9 +194,6 @@ class SwatForm extends SwatDisplayableContainer
      */
     protected $connection_close_uri;
 
-    // }}}
-    // {{{ private properties
-
     /**
      * The method to use for this form.
      *
@@ -227,9 +216,6 @@ class SwatForm extends SwatDisplayableContainer
      * @see SwatForm::isAuthenticated()
      */
     private static $authentication_token;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new form.
@@ -259,9 +245,6 @@ class SwatForm extends SwatDisplayableContainer
         $this->addJavaScript('packages/swat/javascript/swat-form.js');
     }
 
-    // }}}
-    // {{{ public function setMethod()
-
     /**
      * Sets the HTTP method this form uses to send data.
      *
@@ -281,9 +264,6 @@ class SwatForm extends SwatDisplayableContainer
         $this->method = $method;
     }
 
-    // }}}
-    // {{{ public function getMethod()
-
     /**
      * Gets the HTTP method this form uses to send data.
      *
@@ -293,9 +273,6 @@ class SwatForm extends SwatDisplayableContainer
     {
         return $this->method;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this form.
@@ -334,9 +311,6 @@ class SwatForm extends SwatDisplayableContainer
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this form.
      *
@@ -364,9 +338,6 @@ class SwatForm extends SwatDisplayableContainer
             }
         }
     }
-
-    // }}}
-    // {{{ public function addHiddenField()
 
     /**
      * Adds a hidden form field.
@@ -400,9 +371,6 @@ class SwatForm extends SwatDisplayableContainer
 
         $this->hidden_fields[$name] = $value;
     }
-
-    // }}}
-    // {{{ public function getHiddenField()
 
     /**
      * Gets the value of a hidden form field.
@@ -442,9 +410,6 @@ class SwatForm extends SwatDisplayableContainer
         return $data;
     }
 
-    // }}}
-    // {{{ public function clearHiddenFields()
-
     /**
      * Clears all hidden fields.
      */
@@ -452,9 +417,6 @@ class SwatForm extends SwatDisplayableContainer
     {
         $this->hidden_fields = [];
     }
-
-    // }}}
-    // {{{ public function addWithField()
 
     /**
      * Adds a widget within a new SwatFormField.
@@ -474,9 +436,6 @@ class SwatForm extends SwatDisplayableContainer
         $field->title = $title;
         $this->add($field);
     }
-
-    // }}}
-    // {{{ public function &getFormData()
 
     /**
      * Returns the super-global array with this form's data.
@@ -504,9 +463,6 @@ class SwatForm extends SwatDisplayableContainer
         return $data;
     }
 
-    // }}}
-    // {{{ public function isSubmitted()
-
     /**
      * Whether or not this form was submitted on the previous page request.
      *
@@ -524,9 +480,6 @@ class SwatForm extends SwatDisplayableContainer
         return isset($raw_data[self::PROCESS_FIELD])
             && $raw_data[self::PROCESS_FIELD] == $this->id;
     }
-
-    // }}}
-    // {{{ public function isAuthenticated()
 
     /**
      * Whether or not this form is authenticated.
@@ -570,9 +523,6 @@ class SwatForm extends SwatDisplayableContainer
             || self::$authentication_token === $token;
     }
 
-    // }}}
-    // {{{ public function setSalt()
-
     /**
      * Sets the salt value to use when salting signature data.
      *
@@ -582,9 +532,6 @@ class SwatForm extends SwatDisplayableContainer
     {
         $this->salt = (string) $salt;
     }
-
-    // }}}
-    // {{{ public function getSalt()
 
     /**
      * Gets the salt value to use when salting signature data.
@@ -603,9 +550,6 @@ class SwatForm extends SwatDisplayableContainer
         return $this->salt;
     }
 
-    // }}}
-    // {{{ public function set8BitEncoding()
-
     /**
      * Sets the encoding to assume for 8-bit content submitted from clients.
      *
@@ -621,9 +565,6 @@ class SwatForm extends SwatDisplayableContainer
     {
         $this->_8bit_encoding = $encoding;
     }
-
-    // }}}
-    // {{{ public function setConnectionCloseUri()
 
     /**
      * Sets the URI at which a Connection: close header may be sent to the
@@ -643,9 +584,6 @@ class SwatForm extends SwatDisplayableContainer
         $this->connection_close_uri = $connection_close_uri;
     }
 
-    // }}}
-    // {{{ public static function setDefault8BitEncoding()
-
     /**
      * Sets the default encoding to assume for 8-bit content submitted from
      * clients.
@@ -662,9 +600,6 @@ class SwatForm extends SwatDisplayableContainer
     {
         self::$default_8bit_encoding = $encoding;
     }
-
-    // }}}
-    // {{{ public static function setDefaultConnectionCloseUri()
 
     /**
      * Sets the default URI at which a Connection: close header may be sent to
@@ -685,9 +620,6 @@ class SwatForm extends SwatDisplayableContainer
         self::$default_connection_close_uri = $connection_close_uri;
     }
 
-    // }}}
-    // {{{ public static function setAuthenticationToken()
-
     /**
      * Sets the token value used to prevent cross-site request forgeries.
      *
@@ -707,9 +639,6 @@ class SwatForm extends SwatDisplayableContainer
         self::$authentication_token = (string) $token;
     }
 
-    // }}}
-    // {{{ public static function clearAuthenticationToken()
-
     /**
      * Clears the token value used to prevent cross-site request forgeries.
      *
@@ -722,9 +651,6 @@ class SwatForm extends SwatDisplayableContainer
     {
         self::$authentication_token = null;
     }
-
-    // }}}
-    // {{{ protected function processHiddenFields()
 
     /**
      * Checks submitted form data for hidden fields.
@@ -759,9 +685,6 @@ class SwatForm extends SwatDisplayableContainer
             }
         }
     }
-
-    // }}}
-    // {{{ protected function processEncoding()
 
     /**
      * Detects 8-bit character encoding in form data and converts data to UTF-8.
@@ -847,9 +770,6 @@ class SwatForm extends SwatDisplayableContainer
         }
     }
 
-    // }}}
-    // {{{ protected function notifyOfAdd()
-
     /**
      * Notifies this widget that a widget was added.
      *
@@ -876,9 +796,6 @@ class SwatForm extends SwatDisplayableContainer
             }
         }
     }
-
-    // }}}
-    // {{{ protected function displayHiddenFields()
 
     /**
      * Displays hidden form fields.
@@ -976,9 +893,6 @@ class SwatForm extends SwatDisplayableContainer
         echo '</div>';
     }
 
-    // }}}
-    // {{{ protected fucntion getFormTag()
-
     /**
      * Gets the XHTML form tag used to display this form.
      *
@@ -1004,9 +918,6 @@ class SwatForm extends SwatDisplayableContainer
         return $form_tag;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this form.
      *
@@ -1018,9 +929,6 @@ class SwatForm extends SwatDisplayableContainer
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets inline JavaScript required for this form.
@@ -1071,9 +979,6 @@ class SwatForm extends SwatDisplayableContainer
         return $javascript;
     }
 
-    // }}}
-    // {{{ protected function getJavaScriptClass()
-
     /**
      * Gets the name of the JavaScript class to instantiate for this form.
      *
@@ -1087,9 +992,6 @@ class SwatForm extends SwatDisplayableContainer
     {
         return 'SwatForm';
     }
-
-    // }}}
-    // {{{ protected function serializeHiddenField()
 
     /**
      * Serializes a hidden field value into a string safe for including in
@@ -1113,9 +1015,6 @@ class SwatForm extends SwatDisplayableContainer
         return str_replace("\x0d", '\x0d', $value);
     }
 
-    // }}}
-    // {{{ protected function unserializeHiddenField()
-
     /**
      * Unserializes a hidden field value that was serialized using
      * {@link SwatForm::serializeHiddenField()}.
@@ -1138,6 +1037,4 @@ class SwatForm extends SwatDisplayableContainer
 
         return SwatString::signedUnserialize($value, $this->salt);
     }
-
-    // }}}
 }

--- a/Swat/SwatFormField.php
+++ b/Swat/SwatFormField.php
@@ -10,8 +10,6 @@
  */
 class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 {
-    // {{{ constants
-
     /**
      * Indicates the required status display should highlight no fields.
      */
@@ -26,9 +24,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
      * Indicates the required status display should highlight optional fields.
      */
     public const SHOW_OPTIONAL = 2;
-
-    // }}}
-    // {{{ public properties
 
     /**
      * The visible name for this field, or null.
@@ -153,9 +148,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
      */
     public $show_title = true;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * Container tag to use.
      *
@@ -183,9 +175,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
      */
     protected $widget_class;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new form field.
      *
@@ -200,9 +189,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
         $this->addStyleSheet('packages/swat/styles/swat-message.css');
     }
 
-    // }}}
-    // {{{ public function getTitle()
-
     /**
      * Gets the title of this form field.
      *
@@ -215,9 +201,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
         return $this->title;
     }
 
-    // }}}
-    // {{{ public function getTitleContentType()
-
     /**
      * Gets the title content-type of this form field.
      *
@@ -229,9 +212,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
     {
         return $this->title_content_type;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this form field.
@@ -333,9 +313,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
         $container_tag->close();
     }
 
-    // }}}
-    // {{{ protected function displayTitle()
-
     protected function displayTitle()
     {
         if (
@@ -351,9 +328,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
         $this->displayRequiredStatus();
         $title_tag->close();
     }
-
-    // }}}
-    // {{{ protected function displayRequiredStatus()
 
     /**
      * Highlights required and/or optional fields according to the required
@@ -383,9 +357,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
         }
     }
 
-    // }}}
-    // {{{ protected function displayContent()
-
     protected function displayContent()
     {
         $contents_tag = new SwatHtmlTag($this->contents_tag);
@@ -395,9 +366,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
         $this->displayChildren();
         $contents_tag->close();
     }
-
-    // }}}
-    // {{{ protected function displayMessages()
 
     protected function displayMessages()
     {
@@ -439,9 +407,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 
         $message_ul->close();
     }
-
-    // }}}
-    // {{{ protected function displayNotes()
 
     protected function displayNotes()
     {
@@ -486,9 +451,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
         }
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this form field.
      *
@@ -513,9 +475,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getTitleTag()
 
     /**
      * Get a SwatHtmlTag to display the title.
@@ -544,9 +503,6 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
 
         return $label_tag;
     }
-
-    // }}}
-    // {{{ protected function notifyOfAdd()
 
     /**
      * Notifies this widget that a widget was added.
@@ -577,10 +533,7 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
         }
     }
 
-    // }}}
-
     // deprecated
-    // {{{ protected function displayRequired()
 
     /**
      * @deprecated use the displayRequiredStatus() method instead
@@ -594,6 +547,4 @@ class SwatFormField extends SwatDisplayableContainer implements SwatTitleable
             $span_tag->display();
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatFrame.php
+++ b/Swat/SwatFrame.php
@@ -8,8 +8,6 @@
  */
 class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
 {
-    // {{{ public properties
-
     /**
      * A visible title for this frame, or null.
      *
@@ -50,9 +48,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
      */
     public $header_level;
 
-    // }}}
-    // {{{ public function getTitle()
-
     /**
      * Gets the title of this frame.
      *
@@ -73,9 +68,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
         return $this->title . ': ' . $this->subtitle;
     }
 
-    // }}}
-    // {{{ public function getTitleContentType()
-
     /**
      * Gets the title content-type of this frame.
      *
@@ -87,9 +79,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
     {
         return $this->title_content_type;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this frame.
@@ -111,9 +100,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
         $this->displayContent();
         $outer_div->close();
     }
-
-    // }}}
-    // {{{ protected function displayTitle()
 
     /**
      * Displays this frame's title.
@@ -144,9 +130,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
         }
     }
 
-    // }}}
-    // {{{ protected function displayContent()
-
     /**
      * Displays this frame's content.
      */
@@ -159,9 +142,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
         $inner_div->close();
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this frame.
      *
@@ -173,9 +153,6 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getHeaderLevel()
 
     protected function getHeaderLevel()
     {
@@ -201,6 +178,4 @@ class SwatFrame extends SwatDisplayableContainer implements SwatTitleable
 
         return $level;
     }
-
-    // }}}
 }

--- a/Swat/SwatFrameDisclosure.php
+++ b/Swat/SwatFrameDisclosure.php
@@ -8,8 +8,6 @@
  */
 class SwatFrameDisclosure extends SwatDisclosure
 {
-    // {{{ public function __construct()
-
     /**
      * Creates a new frame disclosure container.
      *
@@ -23,9 +21,6 @@ class SwatFrameDisclosure extends SwatDisclosure
 
         $this->addStyleSheet('packages/swat/styles/swat-frame-disclosure.css');
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this frame disclosure container.
@@ -88,9 +83,6 @@ class SwatFrameDisclosure extends SwatDisclosure
         $control_div->close();
     }
 
-    // }}}
-    // {{{ protected function getContainerDivTag()
-
     protected function getContainerDivTag()
     {
         $div = new SwatHtmlTag('div');
@@ -100,9 +92,6 @@ class SwatFrameDisclosure extends SwatDisclosure
         return $div;
     }
 
-    // }}}
-    // {{{ protected function getSpanTag()
-
     protected function getSpanTag()
     {
         $span_tag = parent::getSpanTag();
@@ -110,9 +99,6 @@ class SwatFrameDisclosure extends SwatDisclosure
 
         return $span_tag;
     }
-
-    // }}}
-    // {{{ protected function getJavaScriptClass()
 
     /**
      * Gets the name of the JavaScript class to instantiate for this disclosure.
@@ -127,9 +113,6 @@ class SwatFrameDisclosure extends SwatDisclosure
     {
         return 'SwatFrameDisclosure';
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this disclosure.
@@ -147,6 +130,4 @@ class SwatFrameDisclosure extends SwatDisclosure
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatGroupedFlydown.php
+++ b/Swat/SwatGroupedFlydown.php
@@ -21,7 +21,7 @@ class SwatGroupedFlydown extends SwatTreeFlydown
      *
      * @throws SwatException if the tree more than 3 levels deep
      */
-    public function setTree(SwatTreeFlydownNode $tree)
+    public function setTree($tree): void
     {
         $this->checkTree($tree);
         parent::setTree($tree);

--- a/Swat/SwatGroupedFlydown.php
+++ b/Swat/SwatGroupedFlydown.php
@@ -17,12 +17,14 @@ class SwatGroupedFlydown extends SwatTreeFlydown
      * The tree for a grouped flydown may be at most 3 levels deep including
      * the root node.
      *
-     * @param SwatDataTreeNode $tree the tree to use for display
+     * @param SwatDataTreeNode|SwatTreeFlydownNode $tree the tree to use for
+     *                                                   display
      *
-     * @throws SwatException if the tree more than 3 levels deep
+     * @throws SwatException if the tree is more than 3 levels deep
      */
-    public function setTree($tree): void
+    public function setTree(SwatDataTreeNode|SwatTreeFlydownNode $tree): void
     {
+        $tree = $this->normalizeTree($tree);
         $this->checkTree($tree);
         parent::setTree($tree);
     }
@@ -76,13 +78,14 @@ class SwatGroupedFlydown extends SwatTreeFlydown
     /**
      * Checks a tree to ensure it is valid for a grouped flydown.
      *
-     * @param SwatTreeFlydownNode the tree to check
-     * @param mixed $level
+     * @param SwatTreeFlydownNode $tree the tree to check
      *
      * @throws SwatException if the tree is not valid for a grouped flydown
      */
-    protected function checkTree(SwatTreeFlydownNode $tree, $level = 0)
-    {
+    protected function checkTree(
+        SwatTreeFlydownNode $tree,
+        int $level = 0
+    ): void {
         if ($level > 2) {
             throw new SwatException(
                 'SwatGroupedFlydown tree must not be '

--- a/Swat/SwatGroupedFlydown.php
+++ b/Swat/SwatGroupedFlydown.php
@@ -11,8 +11,6 @@
  */
 class SwatGroupedFlydown extends SwatTreeFlydown
 {
-    // {{{ public function setTree()
-
     /**
      * Sets the tree to use for display.
      *
@@ -28,9 +26,6 @@ class SwatGroupedFlydown extends SwatTreeFlydown
         $this->checkTree($tree);
         parent::setTree($tree);
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this grouped flydown.
@@ -78,9 +73,6 @@ class SwatGroupedFlydown extends SwatTreeFlydown
         }
     }
 
-    // }}}
-    // {{{ protected function checkTree()
-
     /**
      * Checks a tree to ensure it is valid for a grouped flydown.
      *
@@ -102,9 +94,6 @@ class SwatGroupedFlydown extends SwatTreeFlydown
             $this->checkTree($child, $level + 1);
         }
     }
-
-    // }}}
-    // {{{ protected function displayNode()
 
     /**
      * Displays a grouped tree flydown node and its child nodes.
@@ -180,9 +169,6 @@ class SwatGroupedFlydown extends SwatTreeFlydown
         }
     }
 
-    // }}}
-    // {{{ protected function buildDisplayTree()
-
     /**
      * Builds this grouped flydown's display tree by copying nodes from this
      * grouped flydown's tree.
@@ -206,9 +192,6 @@ class SwatGroupedFlydown extends SwatTreeFlydown
             $this->buildDisplayTree($child, $new_node, $path);
         }
     }
-
-    // }}}
-    // {{{ protected function getDisplayTree()
 
     /**
      * Gets the display tree of this grouped flydown.
@@ -237,6 +220,4 @@ class SwatGroupedFlydown extends SwatTreeFlydown
 
         return $display_tree;
     }
-
-    // }}}
 }

--- a/Swat/SwatGroupingFormField.php
+++ b/Swat/SwatGroupingFormField.php
@@ -11,8 +11,6 @@
  */
 class SwatGroupingFormField extends SwatFormField
 {
-    // {{{ protected function getTitleTag()
-
     /**
      * Get a SwatHtmlTag to display the title.
      *
@@ -27,9 +25,6 @@ class SwatGroupingFormField extends SwatFormField
 
         return $legend_tag;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this form field.
@@ -65,9 +60,6 @@ class SwatGroupingFormField extends SwatFormField
         $container_tag->close();
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this footer form field.
      *
@@ -81,6 +73,4 @@ class SwatGroupingFormField extends SwatFormField
 
         return $classes;
     }
-
-    // }}}
 }

--- a/Swat/SwatHeaderFormField.php
+++ b/Swat/SwatHeaderFormField.php
@@ -10,8 +10,6 @@
  */
 class SwatHeaderFormField extends SwatFormField
 {
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this header form field.
      *
@@ -25,6 +23,4 @@ class SwatHeaderFormField extends SwatFormField
 
         return $classes;
     }
-
-    // }}}
 }

--- a/Swat/SwatHtmlHeadEntry.php
+++ b/Swat/SwatHtmlHeadEntry.php
@@ -11,8 +11,6 @@
  */
 abstract class SwatHtmlHeadEntry extends SwatObject
 {
-    // {{{ protected properties
-
     /**
      * The uri of this head entry.
      *
@@ -34,9 +32,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
      */
     protected $ie_condition = '';
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new HTML head entry.
      *
@@ -46,9 +41,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
     {
         $this->uri = $uri;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this html head entry.
@@ -67,9 +59,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
         $this->closeIECondition();
     }
 
-    // }}}
-    // {{{ public function displayInline()
-
     /**
      * Displays the resource referenced by this html head entry inline.
      *
@@ -84,9 +73,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
         $this->closeIECondition();
     }
 
-    // }}}
-    // {{{ public function getUri()
-
     /**
      * Gets the URI of this HTML head entry.
      *
@@ -97,9 +83,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
         return $this->uri;
     }
 
-    // }}}
-    // {{{ public function getType()
-
     /**
      * Gets the type of this HTML head entry.
      *
@@ -109,9 +92,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
     {
         return get_class($this);
     }
-
-    // }}}
-    // {{{ public function getIECondition()
 
     /**
      * Gets the conditional expression used to limit display for Internet
@@ -125,9 +105,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
     {
         return $this->ie_conditional;
     }
-
-    // }}}
-    // {{{ public function setIECondition()
 
     /**
      * Sets the conditional expression used to limit display for Internet
@@ -146,9 +123,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
         $this->ie_condition = (string) $condition;
     }
 
-    // }}}
-    // {{{ protected abstract function displayInternal()
-
     /**
      * Displays this html head entry.
      *
@@ -161,9 +135,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
      */
     abstract protected function displayInternal($uri_prefix = '', $tag = null);
 
-    // }}}
-    // {{{ protected abstract function displayInlineInternal()
-
     /**
      * Displays the resource referenced by this html head entry inline.
      *
@@ -172,9 +143,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
      * @param string $path the path containing the resource files
      */
     abstract protected function displayInlineInternal($path);
-
-    // }}}
-    // {{{ protected function openIECondition()
 
     /**
      * Renders the opening tag for the IE condditional if an IE conditional
@@ -192,9 +160,6 @@ abstract class SwatHtmlHeadEntry extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ protected function closeIECondition()
-
     /**
      * Renders the closing tag for the IE condditional if an IE conditional
      * is set.
@@ -208,6 +173,4 @@ abstract class SwatHtmlHeadEntry extends SwatObject
             echo '<![endif]-->';
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatHtmlHeadEntrySet.php
+++ b/Swat/SwatHtmlHeadEntrySet.php
@@ -8,6 +8,8 @@
  *
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
+ * @implements IteratorAggregate<string, SwatHtmlHeadEntry>
  */
 class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 {
@@ -15,6 +17,8 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
      * HTML head entries managed by this collection.
      *
      * Entries are indexed by URI.
+     *
+     * @var array<string, SwatHtmlHeadEntry>
      */
     protected array $entries = [];
 
@@ -113,14 +117,13 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
      *
      * Fulfills the IteratorAggregate interface.
      *
-     * @return iterable an iterator over the entries in this set
+     * @return Traversable<string, SwatHtmlHeadEntry> an iterator over the entries in this set
      */
-    #[ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         // return an array copy by design to fulfil the IteratorAggregate
         // interface.
-        return $this->entries;
+        return new ArrayIterator($this->entries);
     }
 
     public function setTypeMapping($type, $class = null)

--- a/Swat/SwatHtmlHeadEntrySet.php
+++ b/Swat/SwatHtmlHeadEntrySet.php
@@ -11,8 +11,6 @@
  */
 class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 {
-    // {{{ protected properties
-
     /**
      * HTML head entries managed by this collection.
      *
@@ -34,9 +32,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
         '/\.less$/' => 'SwatLessStyleSheetHtmlHeadEntry',
     ];
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new HTML head entry collection.
      *
@@ -49,9 +44,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
             $this->addEntrySet($set);
         }
     }
-
-    // }}}
-    // {{{ public function addEntry()
 
     /**
      * Adds a HTML head entry to this set.
@@ -89,9 +81,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
         }
     }
 
-    // }}}
-    // {{{ public function addEntrySet()
-
     /**
      * Adds a set of HTML head entries to this set.
      *
@@ -102,16 +91,10 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
         $this->entries = array_merge($this->entries, $set->entries);
     }
 
-    // }}}
-    // {{{ public function toArray()
-
     public function toArray()
     {
         return $this->entries;
     }
-
-    // }}}
-    // {{{ public function count()
 
     /**
      * Gets the number of entries in this set.
@@ -124,9 +107,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
     {
         return count($this->entries);
     }
-
-    // }}}
-    // {{{ public function getIterator()
 
     /**
      * Gets an iterator over the entries in this set.
@@ -141,9 +121,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
         // interface.
         return $this->entries;
     }
-
-    // }}}
-    // {{{ public function addTypeMapping()
 
     public function setTypeMapping($type, $class = null)
     {
@@ -172,9 +149,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
         $this->type_map = array_merge($this->type_map, $type);
     }
 
-    // }}}
-    // {{{ public function getByType()
-
     /**
      * Gets a subset of this set by the entry type.
      *
@@ -198,9 +172,6 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
         return $set;
     }
 
-    // }}}
-    // {{{ protected function getClassFromType()
-
     protected function getClassFromType($entry)
     {
         $class = null;
@@ -214,6 +185,4 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
 
         return $class;
     }
-
-    // }}}
 }

--- a/Swat/SwatHtmlHeadEntrySet.php
+++ b/Swat/SwatHtmlHeadEntrySet.php
@@ -15,28 +15,28 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
      * HTML head entries managed by this collection.
      *
      * Entries are indexed by URI.
-     *
-     * @var array
      */
-    protected $entries = [];
+    protected array $entries = [];
 
     /**
      * Maps HTML head entry URIs to {@link SwatHtmlHeadEntry} class names.
      *
+     * @var array<string, class-string>
+     *
      * @see SwatHtmlHeadEntrySet::addEntry()
      * @see SwatHtmlHeadEntrySet::addTypeMapping()
      */
-    protected $type_map = [
-        '/\.js$/'   => 'SwatJavaScriptHtmlHeadEntry',
-        '/\.css$/'  => 'SwatStyleSheetHtmlHeadEntry',
-        '/\.less$/' => 'SwatLessStyleSheetHtmlHeadEntry',
+    protected array $type_map = [
+        '/\.js$/'   => SwatJavaScriptHtmlHeadEntry::class,
+        '/\.css$/'  => SwatStyleSheetHtmlHeadEntry::class,
+        '/\.less$/' => SwatLessStyleSheetHtmlHeadEntry::class,
     ];
 
     /**
      * Creates a new HTML head entry collection.
      *
-     * @param SwatHtmlHeadEntrySet $set an optional existing HTML head entry
-     *                                  set to build this set from
+     * @param ?SwatHtmlHeadEntrySet $set an optional existing HTML head entry
+     *                                   set to build this set from
      */
     public function __construct(?SwatHtmlHeadEntrySet $set = null)
     {
@@ -103,7 +103,7 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
      *
      * @return int the number of entries in this set
      */
-    public function count()
+    public function count(): int
     {
         return count($this->entries);
     }
@@ -115,6 +115,7 @@ class SwatHtmlHeadEntrySet implements Countable, IteratorAggregate
      *
      * @return iterable an iterator over the entries in this set
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         // return an array copy by design to fulfil the IteratorAggregate

--- a/Swat/SwatHtmlHeadEntrySetDisplayer.php
+++ b/Swat/SwatHtmlHeadEntrySetDisplayer.php
@@ -11,15 +11,10 @@
  */
 class SwatHtmlHeadEntrySetDisplayer extends SwatObject
 {
-    // {{{ protected properties
-
     /**
      * @var Concentrate_Concentrator
      */
     protected $concentrator;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new HTML head entry collection.
@@ -28,9 +23,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
     {
         $this->concentrator = $concentrator;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays a set of HTML head entries.
@@ -101,9 +93,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
         echo "\n";
     }
 
-    // }}}
-    // {{{ public function displayInline()
-
     /**
      * Displays the contents of the set of HTML head entries inline.
      *
@@ -138,9 +127,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
         echo "\n";
     }
 
-    // }}}
-    // {{{ protected function getCombinedEntries()
-
     /**
      * Gets the entries of this set accounting for combining.
      *
@@ -170,9 +156,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
             'superset' => $info['superset'],
         ];
     }
-
-    // }}}
-    // {{{ protected function getSortedEntries()
 
     /**
      * Gets the entries of this set sorted by their correct display order.
@@ -207,9 +190,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
 
         return $sorted_entries;
     }
-
-    // }}}
-    // {{{ protected function compareEntries()
 
     /**
      * Compares two {@link SwatHtmlHeadEntry} objects to get their display
@@ -264,9 +244,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
         return 0;
     }
 
-    // }}}
-    // {{{ protected function compareTypes()
-
     /**
      * Compares two HTML head entry types.
      *
@@ -302,9 +279,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
         return 0;
     }
 
-    // }}}
-    // {{{ protected function getTypeOrder()
-
     /**
      * Gets the order in which HTML head entry types should be displayed.
      *
@@ -328,9 +302,6 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
             '__unknown__'                       => 5,
         ];
     }
-
-    // }}}
-    // {{{ protected function checkForConflicts()
 
     /**
      * Check for conflicts in a set of HTML head entry URIs.
@@ -365,6 +336,4 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
             );
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatHtmlTag.php
+++ b/Swat/SwatHtmlTag.php
@@ -8,8 +8,6 @@
  */
 class SwatHtmlTag extends SwatObject
 {
-    // {{{ private properties
-
     /**
      * The name of the HTML tag.
      *
@@ -43,9 +41,6 @@ class SwatHtmlTag extends SwatObject
      */
     private $content_type = 'text/plain';
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new HTML tag.
      *
@@ -61,9 +56,6 @@ class SwatHtmlTag extends SwatObject
             $this->attributes = $attributes;
         }
     }
-
-    // }}}
-    // {{{ public function setContent()
 
     /**
      * Set content for the body of the XHTML tag.
@@ -86,9 +78,6 @@ class SwatHtmlTag extends SwatObject
         $this->content_type = $type;
     }
 
-    // }}}
-    // {{{ public function addAtributes()
-
     /**
      * Adds an array of attributes to this XHTML tag.
      *
@@ -107,9 +96,6 @@ class SwatHtmlTag extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ public function removeAttribute()
-
     /**
      * Removes an attribute.
      *
@@ -122,9 +108,6 @@ class SwatHtmlTag extends SwatObject
     {
         unset($this->attributes[$attribute]);
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this tag.
@@ -149,9 +132,6 @@ class SwatHtmlTag extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ public function displayContent()
-
     /**
      * Displays the content of this tag.
      *
@@ -170,9 +150,6 @@ class SwatHtmlTag extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ public function open()
-
     /**
      * Opens this tag.
      *
@@ -187,9 +164,6 @@ class SwatHtmlTag extends SwatObject
         $this->openInternal(false);
     }
 
-    // }}}
-    // {{{ public function close()
-
     /**
      * Closes this tag.
      *
@@ -202,9 +176,6 @@ class SwatHtmlTag extends SwatObject
     {
         echo '</', $this->tag_name, '>';
     }
-
-    // }}}
-    // {{{ public function toString()
 
     /**
      * Gets this tag as a string.
@@ -226,9 +197,6 @@ class SwatHtmlTag extends SwatObject
         return ob_get_clean();
     }
 
-    // }}}
-    // {{{ public function __get()
-
     /**
      * Magic __get method.
      *
@@ -249,9 +217,6 @@ class SwatHtmlTag extends SwatObject
         return null;
     }
 
-    // }}}
-    // {{{ public function __set()
-
     /**
      * Magic __set method.
      *
@@ -266,9 +231,6 @@ class SwatHtmlTag extends SwatObject
         $this->attributes[$attribute]
             = $value === null ? null : (string) $value;
     }
-
-    // }}}
-    // {{{ public function __toString()
 
     /**
      * Gets this tag as a string.
@@ -294,9 +256,6 @@ class SwatHtmlTag extends SwatObject
     {
         return $this->toString();
     }
-
-    // }}}
-    // {{{ private function openInternal()
 
     /**
      * Outputs opening tag and all attributes.
@@ -327,6 +286,4 @@ class SwatHtmlTag extends SwatObject
             echo '>';
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatImageButton.php
+++ b/Swat/SwatImageButton.php
@@ -11,8 +11,6 @@
  */
 class SwatImageButton extends SwatButton
 {
-    // {{{ public properties
-
     /**
      * Image.
      *
@@ -45,9 +43,6 @@ class SwatImageButton extends SwatButton
      */
     public $alt;
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Does button processing.
      *
@@ -67,9 +62,6 @@ class SwatImageButton extends SwatButton
             $this->getForm()->button = $this;
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this image button.
@@ -123,9 +115,6 @@ class SwatImageButton extends SwatButton
         }
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this button.
      *
@@ -137,6 +126,4 @@ class SwatImageButton extends SwatButton
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatImageCellRenderer.php
+++ b/Swat/SwatImageCellRenderer.php
@@ -8,8 +8,6 @@
  */
 class SwatImageCellRenderer extends SwatCellRenderer
 {
-    // {{{ public properties
-
     /**
      * The relative uri of the image file for this image renderer.
      *
@@ -99,9 +97,6 @@ class SwatImageCellRenderer extends SwatCellRenderer
      */
     public $alt;
 
-    // }}}
-    // {{{ public function render()
-
     /**
      * Renders the contents of this cell.
      *
@@ -167,9 +162,6 @@ class SwatImageCellRenderer extends SwatCellRenderer
         $image_tag->display();
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this cell renderer.
      *
@@ -181,6 +173,4 @@ class SwatImageCellRenderer extends SwatCellRenderer
 
         return array_merge($classes, $this->classes);
     }
-
-    // }}}
 }

--- a/Swat/SwatImageCropper.php
+++ b/Swat/SwatImageCropper.php
@@ -11,8 +11,6 @@
  */
 class SwatImageCropper extends SwatInputControl
 {
-    // {{{ public properties
-
     /**
      * Image URI.
      *
@@ -128,9 +126,6 @@ class SwatImageCropper extends SwatInputControl
      */
     public $crop_box_top;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new image cropper.
      *
@@ -150,9 +145,6 @@ class SwatImageCropper extends SwatInputControl
         $this->addJavaScript('packages/swat/javascript/swat-image-cropper.js');
     }
 
-    // }}}
-    // {{{ public function process()
-
     public function process()
     {
         parent::process();
@@ -170,9 +162,6 @@ class SwatImageCropper extends SwatInputControl
         $this->crop_box_left = $this->crop_left;
         $this->crop_box_top = $this->crop_top;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this image cropper.
@@ -228,9 +217,6 @@ class SwatImageCropper extends SwatInputControl
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ protected function getInlineJavaScript()
-
     /**
      * Gets the inline JavaScript required by this image cropper.
      *
@@ -285,9 +271,6 @@ class SwatImageCropper extends SwatInputControl
             $options_string,
         );
     }
-
-    // }}}
-    // {{{ protected function autoCropBoxDimensions()
 
     /**
      * Automatically sets crop box dimensions if they are not specified and
@@ -390,6 +373,4 @@ class SwatImageCropper extends SwatInputControl
             $this->crop_height = $this->image_height - $this->crop_top;
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatImageDisplay.php
+++ b/Swat/SwatImageDisplay.php
@@ -10,8 +10,6 @@
  */
 class SwatImageDisplay extends SwatControl
 {
-    // {{{ public properties
-
     /**
      * Image.
      *
@@ -91,9 +89,6 @@ class SwatImageDisplay extends SwatControl
      */
     public $alt;
 
-    // }}}
-    // {{{ public function display()
-
     /**
      * Displays this image.
      */
@@ -141,9 +136,6 @@ class SwatImageDisplay extends SwatControl
         $image_tag->display();
     }
 
-    // }}}
-    // {{{ public static function getOccupyMargin()
-
     public static function getOccupyMargin(
         $width,
         $height,
@@ -178,9 +170,6 @@ class SwatImageDisplay extends SwatControl
         return $style;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this image display.
      *
@@ -193,6 +182,4 @@ class SwatImageDisplay extends SwatControl
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatImageLinkCellRenderer.php
+++ b/Swat/SwatImageLinkCellRenderer.php
@@ -8,8 +8,6 @@
  */
 class SwatImageLinkCellRenderer extends SwatImageCellRenderer
 {
-    // {{{ public properties
-
     /**
      * The href attribute in the XHTML anchor tag.
      *
@@ -37,9 +35,6 @@ class SwatImageLinkCellRenderer extends SwatImageCellRenderer
      * @see SwatImageLinkCellRenderer::$link
      */
     public $link_value;
-
-    // }}}
-    // {{{ public function render()
 
     /**
      * Renders the contents of this cell.
@@ -72,6 +67,4 @@ class SwatImageLinkCellRenderer extends SwatImageCellRenderer
             $anchor->close();
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatImagePreviewDisplay.php
+++ b/Swat/SwatImagePreviewDisplay.php
@@ -11,8 +11,6 @@
  */
 class SwatImagePreviewDisplay extends SwatImageDisplay
 {
-    // {{{ public properties
-
     /**
      * Preview Image.
      *
@@ -139,9 +137,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
      */
     public $close_text;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new image preview display.
      *
@@ -172,9 +167,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
 
         $this->title = Swat::_('View Larger Image');
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this image.
@@ -218,9 +210,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
         }
     }
 
-    // }}}
-    // {{{ protected function isPreviewDisplayable()
-
     /**
      * Checks whether the preview exists, and whether it should be displayed.
      *
@@ -238,9 +227,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
             && ($this->show_preview_when_smaller || $difference >= 0.2);
     }
 
-    // }}}
-    // {{{ protected function getJavaScriptClass()
-
     /**
      * Gets the name of the JavaScript class to instantiate for this image
      * preview display.
@@ -256,9 +242,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
     {
         return 'SwatImagePreviewDisplay';
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets inline JavaScript required by this image preview.
@@ -307,9 +290,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
         return $javascript;
     }
 
-    // }}}
-    // {{{ protected function getInlineJavaScriptTranslations()
-
     /**
      * Gets translatable string resources for the JavaScript object for
      * this widget.
@@ -327,9 +307,6 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
         );
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this image display.
      *
@@ -342,6 +319,4 @@ class SwatImagePreviewDisplay extends SwatImageDisplay
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatInlineJavaScriptHtmlHeadEntry.php
+++ b/Swat/SwatInlineJavaScriptHtmlHeadEntry.php
@@ -6,15 +6,10 @@
  */
 class SwatInlineJavaScriptHtmlHeadEntry extends SwatHtmlHeadEntry
 {
-    // {{{ protected properties
-
     /**
      * @var string
      */
     protected $script;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new HTML head entry.
@@ -27,21 +22,13 @@ class SwatInlineJavaScriptHtmlHeadEntry extends SwatHtmlHeadEntry
         $this->script = $script;
     }
 
-    // }}}
-    // {{{ protected function displayInternal()
-
     protected function displayInternal($uri_prefix = '', $tag = null)
     {
         Swat::displayInlineJavaScript($this->script);
     }
 
-    // }}}
-    // {{{ protected function displayInlineInternal()
-
     protected function displayInlineInternal($path)
     {
         $this->displayInternal();
     }
-
-    // }}}
 }

--- a/Swat/SwatInputCell.php
+++ b/Swat/SwatInputCell.php
@@ -15,8 +15,6 @@
  */
 class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 {
-    // {{{ private properties
-
     /**
      * A lookup array for widgets contained in this cell.
      *
@@ -52,18 +50,12 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
      */
     private $clones = [];
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * The prototype widget displayed in this cell.
      *
      * @var SwatWidget
      */
     protected $widget;
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Adds a child object.
@@ -94,9 +86,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         }
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this input cell.
      *
@@ -114,9 +103,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         }
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this input cell given a numeric row identifier.
      *
@@ -132,9 +118,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         $widget->process();
     }
 
-    // }}}
-    // {{{ public function display()
-
     /**
      * Displays this input cell given a numeric row identifier.
      *
@@ -148,9 +131,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         $widget = $this->getClonedWidget($row_identifier);
         $widget->display();
     }
-
-    // }}}
-    // {{{ public function getTitle()
 
     /**
      * Gets the title of this input cell.
@@ -168,9 +148,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         return $this->parent->title;
     }
 
-    // }}}
-    // {{{ public function getTitleContentType()
-
     /**
      * Gets the title content-type of this input cell.
      *
@@ -183,9 +160,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         return 'text/plain';
     }
 
-    // }}}
-    // {{{ public function setWidget()
-
     /**
      * Sets the prototype widget of this input cell.
      *
@@ -196,9 +170,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         $this->widget = $widget;
         $widget->parent = $this;
     }
-
-    // }}}
-    // {{{ public function getPrototypeWidget()
 
     /**
      * Gets the widget of this input cell.
@@ -217,9 +188,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
     {
         return $this->widget;
     }
-
-    // }}}
-    // {{{ public function getWidget()
 
     /**
      * Gets a particular widget in this input cell.
@@ -255,9 +223,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         );
     }
 
-    // }}}
-    // {{{ public function unsetWidget()
-
     /**
      * Unsets a cloned widget within this cell.
      *
@@ -280,9 +245,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         }
     }
 
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this input cell.
      *
@@ -299,9 +261,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this input cell.
      *
@@ -317,9 +276,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -371,9 +327,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -412,9 +365,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         return $out;
     }
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -435,9 +385,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         return $states;
     }
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -455,9 +402,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
             }
         }
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -504,9 +448,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
         return $copy;
     }
 
-    // }}}
-    // {{{ protected function getInputRow()
-
     /**
      * Gets the input row this cell belongs to.
      *
@@ -524,9 +465,6 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 
         return $view->getFirstRowByClass('SwatTableViewInputRow');
     }
-
-    // }}}
-    // {{{ protected function getClonedWidget()
 
     /**
      * Gets a cloned widget given a unique identifier.
@@ -596,6 +534,4 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
 
         return $new_widget;
     }
-
-    // }}}
 }

--- a/Swat/SwatInputControl.php
+++ b/Swat/SwatInputControl.php
@@ -8,8 +8,6 @@
  */
 abstract class SwatInputControl extends SwatControl
 {
-    // {{{ public properties
-
     /**
      * Whether this entry widget is required or not.
      *
@@ -26,9 +24,6 @@ abstract class SwatInputControl extends SwatControl
      */
     public $show_field_title_in_messages = true;
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this widget.
      *
@@ -44,9 +39,6 @@ abstract class SwatInputControl extends SwatControl
             $this->parent->required = true;
         }
     }
-
-    // }}}
-    // {{{ public function getForm()
 
     /**
      * Gets the form that this control is contained in.
@@ -79,9 +71,6 @@ abstract class SwatInputControl extends SwatControl
 
         return $form;
     }
-
-    // }}}
-    // {{{ protected function getValidationMessage()
 
     /**
      * Gets a validation message for this control.
@@ -121,6 +110,4 @@ abstract class SwatInputControl extends SwatControl
 
         return new SwatMessage($text, 'error');
     }
-
-    // }}}
 }

--- a/Swat/SwatIntegerEntry.php
+++ b/Swat/SwatIntegerEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatIntegerEntry extends SwatNumericEntry
 {
-    // {{{ public function process()
-
     /**
      * Checks to make sure value is an integer.
      *
@@ -47,9 +45,6 @@ class SwatIntegerEntry extends SwatNumericEntry
         }
     }
 
-    // }}}
-    // {{{ protected function getDisplayValue()
-
     /**
      * Formats an integer value to display.
      *
@@ -73,9 +68,6 @@ class SwatIntegerEntry extends SwatNumericEntry
         return $value;
     }
 
-    // }}}
-    // {{{  protected function getNumericValue()
-
     /**
      * Gets the numeric value of this widget.
      *
@@ -93,9 +85,6 @@ class SwatIntegerEntry extends SwatNumericEntry
 
         return $locale->parseInteger($value);
     }
-
-    // }}}
-    // {{{ protected function getValidationMessage()
 
     /**
      * Gets a validation message for this integer entry.
@@ -146,9 +135,6 @@ class SwatIntegerEntry extends SwatNumericEntry
         return $message;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this entry.
      *
@@ -161,6 +147,4 @@ class SwatIntegerEntry extends SwatNumericEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatJavaScriptHtmlHeadEntry.php
+++ b/Swat/SwatJavaScriptHtmlHeadEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatJavaScriptHtmlHeadEntry extends SwatHtmlHeadEntry
 {
-    // {{{ protected function displayInternal()
-
     protected function displayInternal($uri_prefix = '', $tag = null)
     {
         $uri = $this->uri;
@@ -29,15 +27,10 @@ class SwatJavaScriptHtmlHeadEntry extends SwatHtmlHeadEntry
         );
     }
 
-    // }}}
-    // {{{ protected function displayInlineInternal()
-
     protected function displayInlineInternal($path)
     {
         echo '<script type="text/javascript">';
         readfile($path . $this->getUri());
         echo '</script>';
     }
-
-    // }}}
 }

--- a/Swat/SwatLessStyleSheetHtmlHeadEntry.php
+++ b/Swat/SwatLessStyleSheetHtmlHeadEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatLessStyleSheetHtmlHeadEntry extends SwatStyleSheetHtmlHeadEntry
 {
-    // {{{ protected function displayInternal()
-
     protected function displayInternal($uri_prefix = '', $tag = null)
     {
         $uri = $this->uri;
@@ -29,13 +27,8 @@ class SwatLessStyleSheetHtmlHeadEntry extends SwatStyleSheetHtmlHeadEntry
         );
     }
 
-    // }}}
-    // {{{ public function getStyleSheetHeadEntry()
-
     public function getStyleSheetHeadEntry()
     {
         return new SwatStyleSheetHtmlHeadEntry($this->uri);
     }
-
-    // }}}
 }

--- a/Swat/SwatLinkCellRenderer.php
+++ b/Swat/SwatLinkCellRenderer.php
@@ -8,8 +8,6 @@
  */
 class SwatLinkCellRenderer extends SwatCellRenderer
 {
-    // {{{ public properties
-
     /**
      * The href attribute in the XHTML anchor tag.
      *
@@ -72,9 +70,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
      */
     public $link_value;
 
-    // }}}
-    // {{{ public function render()
-
     /**
      * Renders the contents of this cell.
      *
@@ -95,9 +90,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
         }
     }
 
-    // }}}
-    // {{{ protected function isSensitive()
-
     /**
      * Whether or not this link is sensitive.
      *
@@ -112,9 +104,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
         return $this->sensitive && $this->link !== null;
     }
 
-    // }}}
-    // {{{ protected function renderSensitive()
-
     /**
      * Renders this link as sensitive.
      */
@@ -128,9 +117,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
         $anchor_tag->display();
     }
 
-    // }}}
-    // {{{ protected function renderInsensitive()
-
     /**
      * Renders this link as not sensitive.
      */
@@ -143,16 +129,10 @@ class SwatLinkCellRenderer extends SwatCellRenderer
         $span_tag->display();
     }
 
-    // }}}
-    // {{{ protected function getTitle()
-
     protected function getTitle()
     {
         return null;
     }
-
-    // }}}
-    // {{{ protected function getText()
 
     protected function getText()
     {
@@ -166,9 +146,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
 
         return $text;
     }
-
-    // }}}
-    // {{{ protected function getLink()
 
     protected function getLink()
     {
@@ -190,9 +167,6 @@ class SwatLinkCellRenderer extends SwatCellRenderer
         return $link;
     }
 
-    // }}}
-    // {{{ public function getDataSpecificCSSClassNames()
-
     /**
      * Gets the data specific CSS class names for this cell renderer.
      *
@@ -208,6 +182,4 @@ class SwatLinkCellRenderer extends SwatCellRenderer
 
         return $classes;
     }
-
-    // }}}
 }

--- a/Swat/SwatLinkHtmlHeadEntry.php
+++ b/Swat/SwatLinkHtmlHeadEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatLinkHtmlHeadEntry extends SwatHtmlHeadEntry
 {
-    // {{{ protected properties
-
     /**
      * The URI linked to by this link.
      *
@@ -38,9 +36,6 @@ class SwatLinkHtmlHeadEntry extends SwatHtmlHeadEntry
      */
     protected $type;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new link HTML head entry.
      *
@@ -66,9 +61,6 @@ class SwatLinkHtmlHeadEntry extends SwatHtmlHeadEntry
         $this->title = $title;
     }
 
-    // }}}
-    // {{{ protected function displayInternal()
-
     protected function displayInternal($uri_prefix = '', $tag = null)
     {
         $link = new SwatHtmlTag('link');
@@ -79,13 +71,8 @@ class SwatLinkHtmlHeadEntry extends SwatHtmlHeadEntry
         $link->display();
     }
 
-    // }}}
-    // {{{ protected function displayInlineInternal()
-
     protected function displayInlineInternal($path)
     {
         $this->displayInternal();
     }
-
-    // }}}
 }

--- a/Swat/SwatListEntry.php
+++ b/Swat/SwatListEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatListEntry extends SwatEntry
 {
-    // {{{ public properties
-
     /**
      * The values of this list entry.
      *
@@ -73,9 +71,6 @@ class SwatListEntry extends SwatEntry
      */
     public $min_entries = 1;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new list entry widget.
      *
@@ -88,9 +83,6 @@ class SwatListEntry extends SwatEntry
         parent::__construct($id);
         $this->minlength = 1;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this list entry.
@@ -110,9 +102,6 @@ class SwatListEntry extends SwatEntry
 
         $this->maxlength = $old_maxlength;
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this list entry widget.
@@ -233,9 +222,6 @@ class SwatListEntry extends SwatEntry
         }
     }
 
-    // }}}
-    // {{{ public function getState()
-
     /**
      * Gets the current state of this entry widget.
      *
@@ -247,9 +233,6 @@ class SwatListEntry extends SwatEntry
     {
         return $this->values;
     }
-
-    // }}}
-    // {{{ public function setState()
 
     /**
      * Sets the current state of this list entry widget.
@@ -266,9 +249,6 @@ class SwatListEntry extends SwatEntry
             $this->values = $this->splitValues($values);
         }
     }
-
-    // }}}
-    // {{{ public function getDisplayValue()
 
     /**
      * Gets the value displayed in the XHTML input.
@@ -288,9 +268,6 @@ class SwatListEntry extends SwatEntry
 
         return implode($this->delimiter, $this->values);
     }
-
-    // }}}
-    // {{{ public function getNote()
 
     /**
      * Gets a note describing the rules on this list entry.
@@ -357,9 +334,6 @@ class SwatListEntry extends SwatEntry
         return $message;
     }
 
-    // }}}
-    // {{{ protected function splitValues()
-
     /**
      * Splits a value string with entries separated by delimiters into
      * an array.
@@ -385,9 +359,6 @@ class SwatListEntry extends SwatEntry
         return preg_split($expression, $value, -1, PREG_SPLIT_NO_EMPTY);
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this entry.
      *
@@ -400,6 +371,4 @@ class SwatListEntry extends SwatEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatMessage.php
+++ b/Swat/SwatMessage.php
@@ -25,8 +25,6 @@
  */
 class SwatMessage extends SwatObject
 {
-    // {{{ constants
-
     /**
      * Notification message type.
      *
@@ -67,9 +65,6 @@ class SwatMessage extends SwatObject
      */
     public const SYSTEM_ERROR = 'system-error';
 
-    // }}}
-    // {{{ public properties
-
     /**
      * Type of message.
      *
@@ -106,9 +101,6 @@ class SwatMessage extends SwatObject
      */
     public $content_type = 'text/plain';
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new SwatMessage.
      *
@@ -125,9 +117,6 @@ class SwatMessage extends SwatObject
         $this->primary_content = $primary_content;
         $this->type = $type;
     }
-
-    // }}}
-    // {{{ public function getCSSClassString()
 
     /**
      * Gets the CSS class names of this message as a string.
@@ -155,9 +144,6 @@ class SwatMessage extends SwatObject
         return implode(' ', $classes);
     }
 
-    // }}}
-    // {{{ public function getCssClass()
-
     /**
      * An alias for SwatMessage::getCSSClassString().
      *
@@ -169,6 +155,4 @@ class SwatMessage extends SwatObject
     {
         return $this->getCSSClassString();
     }
-
-    // }}}
 }

--- a/Swat/SwatMessageDisplay.php
+++ b/Swat/SwatMessageDisplay.php
@@ -8,8 +8,6 @@
  */
 class SwatMessageDisplay extends SwatControl
 {
-    // {{{ class constants
-
     /**
      * Dismiss link for message is on.
      */
@@ -28,9 +26,6 @@ class SwatMessageDisplay extends SwatControl
      */
     public const DISMISS_AUTO = 3;
 
-    // }}}
-    // {{{ public properties
-
     /**
      * Text to display for closing the message.
      *
@@ -39,9 +34,6 @@ class SwatMessageDisplay extends SwatControl
      * @var string
      */
     public $close_text;
-
-    // }}}
-    // {{{ protected properties
 
     /**
      * The messages to display.
@@ -61,9 +53,6 @@ class SwatMessageDisplay extends SwatControl
      * @var array
      */
     protected $dismissable_messages = [];
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new message display.
@@ -88,9 +77,6 @@ class SwatMessageDisplay extends SwatControl
         $this->addStyleSheet('packages/swat/styles/swat-message.css');
         $this->addStyleSheet('packages/swat/styles/swat-message-display.css');
     }
-
-    // }}}
-    // {{{ public function add()
 
     /**
      * Adds a message.
@@ -140,9 +126,6 @@ class SwatMessageDisplay extends SwatControl
         }
     }
 
-    // }}}
-    // {{{ public function display()
-
     /**
      * Displays messages in this message display.
      *
@@ -191,9 +174,6 @@ class SwatMessageDisplay extends SwatControl
         }
     }
 
-    // }}}
-    // {{{ public function isVisible()
-
     /**
      * Gets whether or not this message display is visible.
      *
@@ -211,9 +191,6 @@ class SwatMessageDisplay extends SwatControl
         return $this->getMessageCount() > 0 && parent::isVisible();
     }
 
-    // }}}
-    // {{{ public function getMessageCount()
-
     /**
      * Gets the number of messages in this message display.
      *
@@ -223,9 +200,6 @@ class SwatMessageDisplay extends SwatControl
     {
         return count($this->display_messages);
     }
-
-    // }}}
-    // {{{ protected function displayMessage()
 
     /**
      * Display a single message of this message display.
@@ -287,9 +261,6 @@ class SwatMessageDisplay extends SwatControl
         $message_div->close();
     }
 
-    // }}}
-    // {{{ protected function getDismissableMessageTypes()
-
     /**
      * Gets an array of message types that are dismissable by default.
      *
@@ -299,9 +270,6 @@ class SwatMessageDisplay extends SwatControl
     {
         return ['notice', 'warning', 'cart'];
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this message display.
@@ -315,9 +283,6 @@ class SwatMessageDisplay extends SwatControl
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript for hiding messages.
@@ -347,9 +312,6 @@ class SwatMessageDisplay extends SwatControl
         return $javascript;
     }
 
-    // }}}
-    // {{{ protected function getJavaScriptClass()
-
     /**
      * Gets the name of the JavaScript class to instantiate for this message
      * display.
@@ -364,9 +326,6 @@ class SwatMessageDisplay extends SwatControl
     {
         return 'SwatMessageDisplay';
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScriptTranslations()
 
     /**
      * Gets translatable string resources for the JavaScript object for
@@ -383,6 +342,4 @@ class SwatMessageDisplay extends SwatControl
 
         return "SwatMessageDisplayMessage.close_text = '{$close_text}';\n";
     }
-
-    // }}}
 }

--- a/Swat/SwatMoneyCellRenderer.php
+++ b/Swat/SwatMoneyCellRenderer.php
@@ -8,8 +8,6 @@
  */
 class SwatMoneyCellRenderer extends SwatCellRenderer
 {
-    // {{{ public properties
-
     /**
      * Optional locale for currency format.
      *
@@ -74,9 +72,6 @@ class SwatMoneyCellRenderer extends SwatCellRenderer
      */
     public $null_display_value;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a money cell renderer.
      */
@@ -88,9 +83,6 @@ class SwatMoneyCellRenderer extends SwatCellRenderer
             'packages/swat/styles/swat-money-cell-renderer.css',
         );
     }
-
-    // }}}
-    // {{{ public function render()
 
     /**
      * Renders the contents of this cell.
@@ -131,9 +123,6 @@ class SwatMoneyCellRenderer extends SwatCellRenderer
         }
     }
 
-    // }}}
-    // {{{ protected function getCurrencyFormat()
-
     /**
      * Gets currency format to use when rendering.
      *
@@ -143,6 +132,4 @@ class SwatMoneyCellRenderer extends SwatCellRenderer
     {
         return ['fractional_digits' => $this->decimal_places];
     }
-
-    // }}}
 }

--- a/Swat/SwatMoneyEntry.php
+++ b/Swat/SwatMoneyEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatMoneyEntry extends SwatFloatEntry
 {
-    // {{{ public properties
-
     /**
      * Optional locale for currency format.
      *
@@ -41,9 +39,6 @@ class SwatMoneyEntry extends SwatFloatEntry
      */
     public $decimal_places;
 
-    // }}}
-    // {{{ public function display()
-
     /**
      * Displays this money entry widget.
      *
@@ -64,9 +59,6 @@ class SwatMoneyEntry extends SwatFloatEntry
             );
         }
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this money entry widget.
@@ -172,9 +164,6 @@ class SwatMoneyEntry extends SwatFloatEntry
         }
     }
 
-    // }}}
-    // {{{ protected function getDisplayValue()
-
     /**
      * Formats a monetary value to display.
      *
@@ -196,9 +185,6 @@ class SwatMoneyEntry extends SwatFloatEntry
         return $value;
     }
 
-    // }}}
-    // {{{ protected function getNumericValue()
-
     /**
      * Gets the numeric value of this money entry.
      *
@@ -211,9 +197,6 @@ class SwatMoneyEntry extends SwatFloatEntry
     {
         return SwatI18NLocale::get($this->locale)->parseCurrency($value);
     }
-
-    // }}}
-    // {{{ protected function getValidationMessage()
 
     /**
      * Gets a validation message for this money entry widget.
@@ -281,9 +264,6 @@ class SwatMoneyEntry extends SwatFloatEntry
         return $message;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this entry.
      *
@@ -296,6 +276,4 @@ class SwatMoneyEntry extends SwatFloatEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatNavBar.php
+++ b/Swat/SwatNavBar.php
@@ -38,7 +38,7 @@ class SwatNavBar extends SwatControl implements Countable
     /**
      * Array of SwatNavBarEntry objects displayed in this navbar.
      *
-     * @see SwatNavBarEntry
+     * @var list<SwatNavBarEntry>
      */
     private array $entries = [];
 

--- a/Swat/SwatNavBar.php
+++ b/Swat/SwatNavBar.php
@@ -15,20 +15,16 @@ class SwatNavBar extends SwatControl implements Countable
      *
      * If set to false, the last entry is displayed as text even if the last
      * navbar entry has a link. Defaults to true.
-     *
-     * @var bool
      */
-    public $link_last_entry = true;
+    public bool $link_last_entry = true;
 
     /**
      * Separator characters displayed between each navbar entry in this navbar.
      *
      * The default separator is a non-breaking space followed by a right
      * guillemet followed by a breaking space.
-     *
-     * @var string
      */
-    public $separator = ' » ';
+    public ?string $separator = ' » ';
 
     /**
      * Optional container tag for this navigational bar.
@@ -42,11 +38,9 @@ class SwatNavBar extends SwatControl implements Countable
     /**
      * Array of SwatNavBarEntry objects displayed in this navbar.
      *
-     * @var array
-     *
      * @see SwatNavBarEntry
      */
-    private $entries = [];
+    private array $entries = [];
 
     /**
      * Creates a SwatNavBarEntry and adds it to the end of this navigation bar.
@@ -200,7 +194,7 @@ class SwatNavBar extends SwatControl implements Countable
      *
      * @return int number of entries in this navigational bar
      */
-    public function count()
+    public function count(): int
     {
         return count($this->entries);
     }

--- a/Swat/SwatNavBar.php
+++ b/Swat/SwatNavBar.php
@@ -10,8 +10,6 @@
  */
 class SwatNavBar extends SwatControl implements Countable
 {
-    // {{{ public properties
-
     /**
      * Whether or not to display the last entry in this navbar as a link.
      *
@@ -41,9 +39,6 @@ class SwatNavBar extends SwatControl implements Countable
      */
     public $container_tag;
 
-    // }}}
-    // {{{ private properties
-
     /**
      * Array of SwatNavBarEntry objects displayed in this navbar.
      *
@@ -52,9 +47,6 @@ class SwatNavBar extends SwatControl implements Countable
      * @see SwatNavBarEntry
      */
     private $entries = [];
-
-    // }}}
-    // {{{ public function createEntry()
 
     /**
      * Creates a SwatNavBarEntry and adds it to the end of this navigation bar.
@@ -71,9 +63,6 @@ class SwatNavBar extends SwatControl implements Countable
         $this->addEntry(new SwatNavBarEntry($title, $link, $content_type));
     }
 
-    // }}}
-    // {{{ public function addEntry()
-
     /**
      * Adds a SwatNavBarEntry to the end of this navigation bar.
      *
@@ -83,9 +72,6 @@ class SwatNavBar extends SwatControl implements Countable
     {
         $this->entries[] = $entry;
     }
-
-    // }}}
-    // {{{ public function addEntries()
 
     /**
      * Adds an array of SwatNavBarEntry to the end of this navigation bar.
@@ -99,9 +85,6 @@ class SwatNavBar extends SwatControl implements Countable
         }
     }
 
-    // }}}
-    // {{{ public function addEntryToStart()
-
     /**
      * Adds a SwatNavBarEntry to the beginning of this navigation bar.
      *
@@ -111,9 +94,6 @@ class SwatNavBar extends SwatControl implements Countable
     {
         array_unshift($this->entries, $entry);
     }
-
-    // }}}
-    // {{{ public function replaceEntryByPosition()
 
     /**
      * Replaces an entry in this navigation bar.
@@ -147,9 +127,6 @@ class SwatNavBar extends SwatControl implements Countable
             ),
         );
     }
-
-    // }}}
-    // {{{ public function getEntryByPosition()
 
     /**
      * Gets an entry from this navigation bar.
@@ -185,9 +162,6 @@ class SwatNavBar extends SwatControl implements Countable
         );
     }
 
-    // }}}
-    // {{{ public function getLastEntry()
-
     /**
      * Gets the last entry from this navigation bar.
      *
@@ -206,9 +180,6 @@ class SwatNavBar extends SwatControl implements Countable
         return end($this->entries);
     }
 
-    // }}}
-    // {{{ public function getCount()
-
     /**
      * Gets the number of entries in this navigational bar.
      *
@@ -222,9 +193,6 @@ class SwatNavBar extends SwatControl implements Countable
         return count($this->entries);
     }
 
-    // }}}
-    // {{{ public function count()
-
     /**
      * Gets the number of entries in this navigational bar.
      *
@@ -236,9 +204,6 @@ class SwatNavBar extends SwatControl implements Countable
     {
         return count($this->entries);
     }
-
-    // }}}
-    // {{{ public function popEntry()
 
     /**
      * Pops the last entry off the end of this navigational bar.
@@ -259,9 +224,6 @@ class SwatNavBar extends SwatControl implements Countable
 
         return array_pop($this->entries);
     }
-
-    // }}}
-    // {{{ public function popEntries()
 
     /**
      * Pops one or more entries off the end of this navigational bar.
@@ -295,9 +257,6 @@ class SwatNavBar extends SwatControl implements Countable
         return array_splice($this->entries, -$number);
     }
 
-    // }}}
-    // {{{ public function clear()
-
     /**
      * Clears all entries from this navigational bar.
      *
@@ -311,9 +270,6 @@ class SwatNavBar extends SwatControl implements Countable
 
         return $entries;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this navigational bar.
@@ -352,9 +308,6 @@ class SwatNavBar extends SwatControl implements Countable
         $container_tag->close();
     }
 
-    // }}}
-    // {{{ protected function displayEntry()
-
     /**
      * Displays an entry in this navigational bar.
      *
@@ -391,9 +344,6 @@ class SwatNavBar extends SwatControl implements Countable
         }
     }
 
-    // }}}
-    // {{{ protected function getLink()
-
     /**
      * Gets the link from an entry.
      *
@@ -405,9 +355,6 @@ class SwatNavBar extends SwatControl implements Countable
     {
         return $entry->link;
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this navigational bar.
@@ -421,9 +368,6 @@ class SwatNavBar extends SwatControl implements Countable
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getContainerTag()
 
     /**
      * Gets the container tag for this navigational bar.
@@ -445,6 +389,4 @@ class SwatNavBar extends SwatControl implements Countable
 
         return $tag;
     }
-
-    // }}}
 }

--- a/Swat/SwatNavBarEntry.php
+++ b/Swat/SwatNavBarEntry.php
@@ -10,8 +10,6 @@
  */
 class SwatNavBarEntry extends SwatObject
 {
-    // {{{ public properties
-
     /**
      * The visible title of this entry.
      *
@@ -38,9 +36,6 @@ class SwatNavBarEntry extends SwatObject
      */
     public $content_type = 'text/plain';
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new navbar entry.
      *
@@ -57,6 +52,4 @@ class SwatNavBarEntry extends SwatObject
         $this->link = $link;
         $this->content_type = $content_type;
     }
-
-    // }}}
 }

--- a/Swat/SwatNoteBook.php
+++ b/Swat/SwatNoteBook.php
@@ -10,8 +10,6 @@
  */
 class SwatNoteBook extends SwatWidget implements SwatUIParent
 {
-    // {{{ constants
-
     /**
      * Positions notebook tabs on the top of notebook pages.
      */
@@ -32,9 +30,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
      */
     public const POSITION_LEFT = 4;
 
-    // }}}
-    // {{{ public properties
-
     /**
      * Position of tabs for this notebook.
      *
@@ -52,9 +47,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
      */
     public $selected_page;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * Note book child objects initally added to this widget.
      *
@@ -68,9 +60,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
      * @var array
      */
     protected $pages = [];
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new notebook.
@@ -88,9 +77,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 
         $this->addStyleSheet('packages/swat/styles/swat-note-book.css');
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Adds a {@link SwatNoteBookChild} to this notebook.
@@ -125,9 +111,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function addPage()
-
     /**
      * Adds a {@link SwatNoteBookPage} to this notebook.
      *
@@ -138,9 +121,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
         $this->pages[] = $page;
         $page->parent = $this;
     }
-
-    // }}}
-    // {{{ public function getPage()
 
     /**
      * Gets a page in this notebook.
@@ -166,9 +146,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
         return $found_page;
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this notebook.
      */
@@ -188,9 +165,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this notebook.
      */
@@ -201,9 +175,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
             $page->process();
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this notebook.
@@ -264,9 +235,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ public function printWidgetTree()
-
     public function printWidgetTree()
     {
         echo get_class($this), ' ', $this->id;
@@ -281,9 +249,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
             echo '</ul>';
         }
     }
-
-    // }}}
-    // {{{ public function getMessages()
 
     /**
      * Gets all messaages.
@@ -306,9 +271,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
         return $messages;
     }
 
-    // }}}
-    // {{{ public function hasMessage()
-
     /**
      * Checks for the presence of messages.
      *
@@ -328,9 +290,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 
         return $has_message;
     }
-
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
 
     /**
      * Gets the {@link SwatHtmlHeadEntry} objects needed by this notebook.
@@ -352,9 +311,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the {@link SwatHtmlHeadEntry} objects that may be needed by this
      * notebook.
@@ -375,9 +331,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -423,9 +376,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -461,9 +411,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -484,9 +431,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
         return $states;
     }
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -504,9 +448,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -531,9 +472,6 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
 
         return $copy;
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript used by this notebook.
@@ -569,6 +507,4 @@ class SwatNoteBook extends SwatWidget implements SwatUIParent
             $position,
         );
     }
-
-    // }}}
 }

--- a/Swat/SwatNoteBookChild.php
+++ b/Swat/SwatNoteBookChild.php
@@ -11,8 +11,6 @@
  */
 interface SwatNoteBookChild
 {
-    // {{{ public function getPages()
-
     /**
      * Gets the notebook pages of this child.
      *
@@ -21,6 +19,4 @@ interface SwatNoteBookChild
      * @see SwatNoteBookPage
      */
     public function getPages();
-
-    // }}}
 }

--- a/Swat/SwatNoteBookPage.php
+++ b/Swat/SwatNoteBookPage.php
@@ -10,8 +10,6 @@
  */
 class SwatNoteBookPage extends SwatContainer implements SwatNoteBookChild
 {
-    // {{{ public properties
-
     /**
      * The title of this page.
      *
@@ -28,9 +26,6 @@ class SwatNoteBookPage extends SwatContainer implements SwatNoteBookChild
      */
     public $title_content_type = 'text/plain';
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new notebook page.
      *
@@ -42,9 +37,6 @@ class SwatNoteBookPage extends SwatContainer implements SwatNoteBookChild
 
         $this->requires_id = true;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this notebook page.
@@ -66,9 +58,6 @@ class SwatNoteBookPage extends SwatContainer implements SwatNoteBookChild
         $div_tag->close();
     }
 
-    // }}}
-    // {{{ public function getPages()
-
     /**
      * Gets the notebook pages of this notebook page.
      *
@@ -80,9 +69,6 @@ class SwatNoteBookPage extends SwatContainer implements SwatNoteBookChild
     {
         return [$this];
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this page.
@@ -96,6 +82,4 @@ class SwatNoteBookPage extends SwatContainer implements SwatNoteBookChild
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatNullTextCellRenderer.php
+++ b/Swat/SwatNullTextCellRenderer.php
@@ -9,8 +9,6 @@
  */
 class SwatNullTextCellRenderer extends SwatTextCellRenderer
 {
-    // {{{ public properties
-
     /**
      * The text to display in this cell if the
      * {@link SwatTextCellRenderer::$text} proeprty is null when the render()
@@ -28,9 +26,6 @@ class SwatNullTextCellRenderer extends SwatTextCellRenderer
      */
     public $strict = false;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a null text cell renderer.
      */
@@ -42,9 +37,6 @@ class SwatNullTextCellRenderer extends SwatTextCellRenderer
             'packages/swat/styles/swat-null-text-cell-renderer.css',
         );
     }
-
-    // }}}
-    // {{{ public function render()
 
     /**
      * Renders this cell renderer.
@@ -70,6 +62,4 @@ class SwatNullTextCellRenderer extends SwatTextCellRenderer
             parent::render();
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatNumber.php
+++ b/Swat/SwatNumber.php
@@ -8,8 +8,6 @@
  */
 class SwatNumber extends SwatObject
 {
-    // {{{ public static function roundUp()
-
     /**
      * Rounds a number to the specified number of fractional digits using the
      * round-half-up rounding method.
@@ -28,9 +26,6 @@ class SwatNumber extends SwatObject
 
         return ceil($value * $power) / $power;
     }
-
-    // }}}
-    // {{{ public static function roundToEven()
 
     /**
      * Rounds a number to the specified number of fractional digits using the
@@ -66,9 +61,6 @@ class SwatNumber extends SwatObject
 
         return $value;
     }
-
-    // }}}
-    // {{{ public static function ordinal()
 
     /**
      * Formats an integer as an ordinal number (1st, 2nd, 3rd).
@@ -157,15 +149,10 @@ class SwatNumber extends SwatObject
         return $ordinal_value;
     }
 
-    // }}}
-    // {{{ private function __construct()
-
     /**
      * Don't allow instantiation of the SwatNumber object.
      *
      * This class contains only static methods and should not be instantiated.
      */
     private function __construct() {}
-
-    // }}}
 }

--- a/Swat/SwatNumericCellRenderer.php
+++ b/Swat/SwatNumericCellRenderer.php
@@ -8,8 +8,6 @@
  */
 class SwatNumericCellRenderer extends SwatCellRenderer
 {
-    // {{{ public properties
-
     /**
      * Value can be either a float or an integer.
      *
@@ -48,9 +46,6 @@ class SwatNumericCellRenderer extends SwatCellRenderer
      */
     public $show_thousands_separator = true;
 
-    // }}}
-    // {{{ public function render()
-
     /**
      * Renders the contents of this cell.
      *
@@ -71,9 +66,6 @@ class SwatNumericCellRenderer extends SwatCellRenderer
         }
     }
 
-    // }}}
-    // {{{ protected function renderNullValue()
-
     protected function renderNullValue()
     {
         $span_tag = new SwatHtmlTag('span');
@@ -81,9 +73,6 @@ class SwatNumericCellRenderer extends SwatCellRenderer
         $span_tag->setContent($this->null_display_value);
         $span_tag->display();
     }
-
-    // }}}
-    // {{{ protected function getDisplayValue()
 
     public function getDisplayValue()
     {
@@ -99,6 +88,4 @@ class SwatNumericCellRenderer extends SwatCellRenderer
 
         return $value;
     }
-
-    // }}}
 }

--- a/Swat/SwatNumericEntry.php
+++ b/Swat/SwatNumericEntry.php
@@ -8,8 +8,6 @@
  */
 abstract class SwatNumericEntry extends SwatEntry
 {
-    // {{{ public properties
-
     /**
      * Show Thousands Seperator.
      *
@@ -38,9 +36,6 @@ abstract class SwatNumericEntry extends SwatEntry
      */
     public $maximum_value;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new numeric entry widget.
      *
@@ -56,9 +51,6 @@ abstract class SwatNumericEntry extends SwatEntry
 
         $this->size = 10;
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Checks the minimum and maximum values of this numeric entry widget.
@@ -113,9 +105,6 @@ abstract class SwatNumericEntry extends SwatEntry
         }
     }
 
-    // }}}
-    // {{{ protected function getValidationMessage()
-
     /**
      * Gets a validation message for this numeric entry.
      *
@@ -152,9 +141,6 @@ abstract class SwatNumericEntry extends SwatEntry
         return $message;
     }
 
-    // }}}
-    // {{{ abstract protected function getNumericValue()
-
     /**
      * Gets the numeric value of this widget.
      *
@@ -168,9 +154,6 @@ abstract class SwatNumericEntry extends SwatEntry
      */
     abstract protected function getNumericValue($value);
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this entry.
      *
@@ -183,6 +166,4 @@ abstract class SwatNumericEntry extends SwatEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatObject.php
+++ b/Swat/SwatObject.php
@@ -8,8 +8,6 @@
  */
 class SwatObject implements Stringable
 {
-    // {{{ public function __toString()
-
     /**
      * Gets this object as a string.
      *
@@ -30,6 +28,4 @@ class SwatObject implements Stringable
 
         return ob_get_clean();
     }
-
-    // }}}
 }

--- a/Swat/SwatOption.php
+++ b/Swat/SwatOption.php
@@ -8,8 +8,6 @@
  */
 class SwatOption extends SwatObject
 {
-    // {{{ public properties
-
     /**
      * Option title.
      *
@@ -33,9 +31,6 @@ class SwatOption extends SwatObject
      */
     public $value;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates an option.
      *
@@ -51,6 +46,4 @@ class SwatOption extends SwatObject
         $this->title = $title;
         $this->content_type = $content_type;
     }
-
-    // }}}
 }

--- a/Swat/SwatOptionControl.php
+++ b/Swat/SwatOptionControl.php
@@ -8,8 +8,6 @@
  */
 abstract class SwatOptionControl extends SwatInputControl
 {
-    // {{{ public properties
-
     /**
      * Options.
      *
@@ -66,9 +64,6 @@ abstract class SwatOptionControl extends SwatInputControl
      * @var bool
      */
     public $serialize_values = true;
-
-    // }}}
-    // {{{ public function addOption()
 
     /**
      * Adds an option to this option control.
@@ -135,9 +130,6 @@ abstract class SwatOptionControl extends SwatInputControl
         }
     }
 
-    // }}}
-    // {{{ public function addOptionMetadata()
-
     /**
      * Sets the metadata for an option.
      *
@@ -173,9 +165,6 @@ abstract class SwatOptionControl extends SwatInputControl
             $this->option_metadata[$key][$metadata] = $value;
         }
     }
-
-    // }}}
-    // {{{ public function getOptionMetadata()
 
     /**
      * Gets the metadata for an option.
@@ -221,9 +210,6 @@ abstract class SwatOptionControl extends SwatInputControl
         return $metadata;
     }
 
-    // }}}
-    // {{{ public function removeOption()
-
     /**
      * Removes an option from this option control.
      *
@@ -250,9 +236,6 @@ abstract class SwatOptionControl extends SwatInputControl
 
         return $removed_option;
     }
-
-    // }}}
-    // {{{ public function removeOptionsByValue()
 
     /**
      * Removes options from this option control by their value.
@@ -282,9 +265,6 @@ abstract class SwatOptionControl extends SwatInputControl
         return $removed_options;
     }
 
-    // }}}
-    // {{{ public function addOptionsByArray()
-
     /**
      * Adds options to this option control using an associative array.
      *
@@ -302,9 +282,6 @@ abstract class SwatOptionControl extends SwatInputControl
             $this->addOption($value, $title, $content_type);
         }
     }
-
-    // }}}
-    // {{{ public function getOptionsByValue()
 
     /**
      * Gets options from this option control by their value.
@@ -328,9 +305,6 @@ abstract class SwatOptionControl extends SwatInputControl
         return $options;
     }
 
-    // }}}
-    // {{{ protected function getOptions()
-
     /**
      * Gets a reference to the array of options.
      *
@@ -342,9 +316,6 @@ abstract class SwatOptionControl extends SwatInputControl
     {
         return $this->options;
     }
-
-    // }}}
-    // {{{ protected function getOption()
 
     /**
      * Gets an option within this option control.
@@ -366,9 +337,6 @@ abstract class SwatOptionControl extends SwatInputControl
         return $option;
     }
 
-    // }}}
-    // {{{ protected function getOptionMetadataKey()
-
     /**
      * Gets the key used to load and store metadata for an option.
      *
@@ -381,6 +349,4 @@ abstract class SwatOptionControl extends SwatInputControl
     {
         return spl_object_hash($option);
     }
-
-    // }}}
 }

--- a/Swat/SwatPagination.php
+++ b/Swat/SwatPagination.php
@@ -10,8 +10,6 @@
  */
 class SwatPagination extends SwatControl
 {
-    // {{{ class constants
-
     /**
      * Display part constant for the displaying 'next' link.
      */
@@ -33,9 +31,6 @@ class SwatPagination extends SwatControl
      * current page.
      */
     public const PAGES = 8;
-
-    // }}}
-    // {{{ public properties
 
     /**
      * The URI linked by this pagination widget.
@@ -109,9 +104,6 @@ class SwatPagination extends SwatControl
      */
     public $display_parts;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * The next page to display.
      *
@@ -142,9 +134,6 @@ class SwatPagination extends SwatControl
      */
     protected $total_pages = 0;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new pagination widget.
      *
@@ -167,9 +156,6 @@ class SwatPagination extends SwatControl
 
         $this->addStyleSheet('packages/swat/styles/swat-pagination.css');
     }
-
-    // }}}
-    // {{{ public function getResultsMessage()
 
     /**
      * Gets a human readable summary of the current state of this pagination
@@ -219,9 +205,6 @@ class SwatPagination extends SwatControl
         return $message;
     }
 
-    // }}}
-    // {{{ public function display()
-
     /**
      * Displays this pagination widget.
      */
@@ -261,9 +244,6 @@ class SwatPagination extends SwatControl
         }
     }
 
-    // }}}
-    // {{{ public function setCurrentPage()
-
     /**
      * Set the current page that is displayed.
      *
@@ -278,9 +258,6 @@ class SwatPagination extends SwatControl
         $this->current_record = ($this->current_page - 1) * $this->page_size;
     }
 
-    // }}}
-    // {{{ public function getCurrentPage()
-
     /**
      * Get the current page that is displayed.
      *
@@ -290,9 +267,6 @@ class SwatPagination extends SwatControl
     {
         return $this->current_page;
     }
-
-    // }}}
-    // {{{ protected function displayPrev()
 
     /**
      * Displays the previous page link.
@@ -316,9 +290,6 @@ class SwatPagination extends SwatControl
         }
     }
 
-    // }}}
-    // {{{ protected function displayPosition()
-
     /**
      * Displays the current page position.
      *
@@ -339,9 +310,6 @@ class SwatPagination extends SwatControl
 
         $div->display();
     }
-
-    // }}}
-    // {{{ protected function displayNext()
 
     /**
      * Displays the next page link.
@@ -365,9 +333,6 @@ class SwatPagination extends SwatControl
             $span->display();
         }
     }
-
-    // }}}
-    // {{{ protected function displayPages()
 
     /**
      * Displays a smart list of pages.
@@ -427,9 +392,6 @@ class SwatPagination extends SwatControl
         }
     }
 
-    // }}}
-    // {{{ protected function getLink()
-
     /**
      * Gets the base link for all page links.
      *
@@ -439,9 +401,6 @@ class SwatPagination extends SwatControl
     {
         return $this->link === null ? '%s' : $this->link;
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this pagination
@@ -456,9 +415,6 @@ class SwatPagination extends SwatControl
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function calculatePages()
 
     /**
      * Calculates page totals.
@@ -484,6 +440,4 @@ class SwatPagination extends SwatControl
             $this->prev_page = 0;
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatPasswordEntry.php
+++ b/Swat/SwatPasswordEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatPasswordEntry extends SwatEntry
 {
-    // {{{ public function __construct()
-
     /**
      * Creates a new password entry and defaults the size to 20.
      *
@@ -23,9 +21,6 @@ class SwatPasswordEntry extends SwatEntry
         $this->size = 20;
     }
 
-    // }}}
-    // {{{ protected function getInputTag()
-
     protected function getInputTag()
     {
         $tag = parent::getInputTag();
@@ -33,9 +28,6 @@ class SwatPasswordEntry extends SwatEntry
 
         return $tag;
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this entry.
@@ -49,6 +41,4 @@ class SwatPasswordEntry extends SwatEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatPercentageCellRenderer.php
+++ b/Swat/SwatPercentageCellRenderer.php
@@ -8,8 +8,6 @@
  */
 class SwatPercentageCellRenderer extends SwatNumericCellRenderer
 {
-    // {{{ public function render()
-
     /**
      * Renders the contents of this cell.
      *
@@ -32,6 +30,4 @@ class SwatPercentageCellRenderer extends SwatNumericCellRenderer
             $this->value = $old_value;
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatPercentageEntry.php
+++ b/Swat/SwatPercentageEntry.php
@@ -9,8 +9,6 @@
  */
 class SwatPercentageEntry extends SwatFloatEntry
 {
-    // {{{ protected function getDisplayValue()
-
     /**
      * Returns a value for this widget.
      *
@@ -32,9 +30,6 @@ class SwatPercentageEntry extends SwatFloatEntry
 
         return $value;
     }
-
-    // }}}
-    // {{{ protected function getNumericValue()
 
     /**
      * Gets the float value of this widget.
@@ -58,9 +53,6 @@ class SwatPercentageEntry extends SwatFloatEntry
         return $value;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this entry.
      *
@@ -73,6 +65,4 @@ class SwatPercentageEntry extends SwatFloatEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatPhoneEntry.php
+++ b/Swat/SwatPhoneEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatPhoneEntry extends SwatEntry
 {
-    // {{{ protected function getInputTag()
-
     /**
      * Get the input tag to display.
      *
@@ -23,9 +21,6 @@ class SwatPhoneEntry extends SwatEntry
         return $tag;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this entry.
      *
@@ -38,6 +33,4 @@ class SwatPhoneEntry extends SwatEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatProgressBar.php
+++ b/Swat/SwatProgressBar.php
@@ -21,8 +21,6 @@
  */
 class SwatProgressBar extends SwatControl
 {
-    // {{{ class constants
-
     /**
      * Progress bar displays horizontally and completes from left to right.
      */
@@ -42,9 +40,6 @@ class SwatProgressBar extends SwatControl
      * Progress bar displays vertically and completes from top to bottom.
      */
     public const ORIENTATION_TOP_TO_BOTTOM = 4;
-
-    // }}}
-    // {{{ public properties
 
     /**
      * Orientation of this progress bar.
@@ -117,9 +112,6 @@ class SwatProgressBar extends SwatControl
      */
     public $length = '200px';
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new progress bar.
      *
@@ -139,9 +131,6 @@ class SwatProgressBar extends SwatControl
         $this->addStyleSheet('packages/swat/styles/swat-progress-bar.css');
         $this->addJavaScript('packages/swat/javascript/swat-progress-bar.js');
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this progress bar.
@@ -170,9 +159,6 @@ class SwatProgressBar extends SwatControl
 
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
-
-    // }}}
-    // {{{ protected function displayBar()
 
     /**
      * Displays the bar part of this progress bar.
@@ -261,9 +247,6 @@ class SwatProgressBar extends SwatControl
         $bar_div_tag->close();
     }
 
-    // }}}
-    // {{{ protected function displayText()
-
     /**
      * Displays the text part of this progress bar.
      */
@@ -290,9 +273,6 @@ class SwatProgressBar extends SwatControl
         $span_tag->display();
     }
 
-    // }}}
-    // {{{ protected function getInlineJavaScript()
-
     /**
      * Gets inline JavaScript for this progress bar.
      *
@@ -309,9 +289,6 @@ class SwatProgressBar extends SwatControl
         );
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this progress bar.
      *
@@ -324,6 +301,4 @@ class SwatProgressBar extends SwatControl
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatRadioButtonCellRenderer.php
+++ b/Swat/SwatRadioButtonCellRenderer.php
@@ -13,8 +13,6 @@
  */
 class SwatRadioButtonCellRenderer extends SwatCellRenderer implements SwatViewSelector
 {
-    // {{{ public properties
-
     /**
      * Identifier of this radio button cell renderer.
      *
@@ -55,9 +53,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer implements SwatViewSe
      */
     public $content_type = 'text/plain';
 
-    // }}}
-    // {{{ private properties
-
     /**
      * The selected value populated during the processing of this cell
      * renderer.
@@ -68,9 +63,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer implements SwatViewSe
      * @var array
      */
     private $selected_value;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new radio button cell renderer.
@@ -90,9 +82,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer implements SwatViewSe
         // auto-generate an id to use if no id is set
         $this->id = $this->getUniqueId();
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this radio button cell renderer.
@@ -114,9 +103,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer implements SwatViewSe
             }
         }
     }
-
-    // }}}
-    // {{{ public function render()
 
     /**
      * Renders this radio button cell renderer.
@@ -164,9 +150,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer implements SwatViewSe
         }
     }
 
-    // }}}
-    // {{{ public function getId()
-
     /**
      * Gets the identifier of this checkbox cell renderer.
      *
@@ -178,9 +161,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer implements SwatViewSe
     {
         return $this->id;
     }
-
-    // }}}
-    // {{{ public function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript required by this radio button cell renderer.
@@ -205,9 +185,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer implements SwatViewSe
         return $javascript;
     }
 
-    // }}}
-    // {{{ public function copy()
-
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
      *
@@ -229,9 +206,6 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer implements SwatViewSe
 
         return $copy;
     }
-
-    // }}}
-    // {{{ private function getForm()
 
     /**
      * Gets the form this radio button cell renderer is contained in.
@@ -255,6 +229,4 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer implements SwatViewSe
 
         return $form;
     }
-
-    // }}}
 }

--- a/Swat/SwatRadioList.php
+++ b/Swat/SwatRadioList.php
@@ -8,8 +8,6 @@
  */
 class SwatRadioList extends SwatFlydown
 {
-    // {{{ private properties
-
     /**
      * Used for displaying radio buttons.
      *
@@ -23,9 +21,6 @@ class SwatRadioList extends SwatFlydown
      * @var SwatHtmlTag
      */
     private $label_tag;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new radiolist.
@@ -43,9 +38,6 @@ class SwatRadioList extends SwatFlydown
 
         $this->addStyleSheet('packages/swat/styles/swat-radio-list.css');
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this radio list.
@@ -124,9 +116,6 @@ class SwatRadioList extends SwatFlydown
         $ul_tag->close();
     }
 
-    // }}}
-    // {{{ protected function processValue()
-
     /**
      * Processes the value of this radio list from user-submitted form data.
      *
@@ -159,9 +148,6 @@ class SwatRadioList extends SwatFlydown
         return true;
     }
 
-    // }}}
-    // {{{ protected function displayDivider()
-
     /**
      * Displays a divider option in this radio list.
      *
@@ -180,9 +166,6 @@ class SwatRadioList extends SwatFlydown
         $span_tag->setContent($option->title, $option->content_type);
         $span_tag->display();
     }
-
-    // }}}
-    // {{{ protected function displayOption()
 
     /**
      * Displays an option in the radio list.
@@ -238,9 +221,6 @@ class SwatRadioList extends SwatFlydown
         echo '</span>';
     }
 
-    // }}}
-    // {{{ protected function displayOptionLabel()
-
     /**
      * Displays an option in the radio list.
      *
@@ -260,9 +240,6 @@ class SwatRadioList extends SwatFlydown
         $this->label_tag->display();
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this radio list.
      *
@@ -275,6 +252,4 @@ class SwatRadioList extends SwatFlydown
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatRadioNoteBook.php
+++ b/Swat/SwatRadioNoteBook.php
@@ -13,8 +13,6 @@
  */
 class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 {
-    // {{{ public properties
-
     /**
      * Selected page.
      *
@@ -24,9 +22,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
      * @var string
      */
     public $selected_page;
-
-    // }}}
-    // {{{ protected properties
 
     /**
      * Note book child objects initally added to this widget.
@@ -41,9 +36,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
      * @var array
      */
     protected $pages = [];
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new notebook.
@@ -65,9 +57,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
             'packages/swat/javascript/swat-radio-note-book.js',
         );
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Adds a {@link SwatNoteBookChild} to this notebook.
@@ -102,9 +91,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function addPage()
-
     /**
      * Adds a {@link SwatNoteBookPage} to this notebook.
      *
@@ -115,9 +101,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
         $this->pages[] = $page;
         $page->parent = $this;
     }
-
-    // }}}
-    // {{{ public function getPage()
 
     /**
      * Gets a page in this notebook.
@@ -143,9 +126,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
         return $found_page;
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this notebook.
      */
@@ -164,9 +144,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
             $page->init();
         }
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this notebook.
@@ -193,9 +170,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this notebook.
@@ -241,9 +215,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function printWidgetTree()
-
     public function printWidgetTree()
     {
         echo get_class($this), ' ', $this->id;
@@ -259,9 +230,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
             echo '</ul>';
         }
     }
-
-    // }}}
-    // {{{ public function getMessages()
 
     /**
      * Gets all messaages.
@@ -284,9 +252,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
         return $messages;
     }
 
-    // }}}
-    // {{{ public function hasMessage()
-
     /**
      * Checks for the presence of messages.
      *
@@ -306,9 +271,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 
         return $has_message;
     }
-
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
 
     /**
      * Gets the {@link SwatHtmlHeadEntry} objects needed by this notebook.
@@ -330,9 +292,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the {@link SwatHtmlHeadEntry} objects that may be needed by this
      * notebook.
@@ -353,9 +312,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -401,9 +357,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -439,9 +392,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -462,9 +412,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
         return $states;
     }
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -482,9 +429,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -509,9 +453,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 
         return $copy;
     }
-
-    // }}}
-    // {{{ public function processValue()
 
     /**
      * Processes the value of this radio list from user-submitted form data.
@@ -543,9 +484,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
 
         return true;
     }
-
-    // }}}
-    // {{{ protected function displayPage()
 
     /**
      * Displays an individual page in this radio notebook.
@@ -604,9 +542,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
         echo '</tr>';
     }
 
-    // }}}
-    // {{{ protected function displaySinglePage()
-
     /**
      * Displays the only page of this notebook if this notebook contains only
      * one page.
@@ -636,9 +571,6 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
         $container->close();
     }
 
-    // }}}
-    // {{{ protected function getInlineJavaScript()
-
     /**
      * Gets the inline JavaScript used by this notebook.
      *
@@ -652,6 +584,4 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
             SwatString::quoteJavaScriptString($this->id),
         );
     }
-
-    // }}}
 }

--- a/Swat/SwatRadioTable.php
+++ b/Swat/SwatRadioTable.php
@@ -8,8 +8,6 @@
  */
 class SwatRadioTable extends SwatRadioList
 {
-    // {{{ public function __construct()
-
     /**
      * Creates a new radio table.
      *
@@ -23,9 +21,6 @@ class SwatRadioTable extends SwatRadioList
 
         $this->addStyleSheet('packages/swat/styles/swat-radio-table.css');
     }
-
-    // }}}
-    // {{{ public function display()
 
     public function display()
     {
@@ -59,9 +54,6 @@ class SwatRadioTable extends SwatRadioList
 
         $table_tag->close();
     }
-
-    // }}}
-    // {{{ protected function displayRadioTableOption()
 
     /**
      * Displays a single option in this radio table.
@@ -105,9 +97,6 @@ class SwatRadioTable extends SwatRadioList
         $tr_tag->close();
     }
 
-    // }}}
-    // {{{ protected function getTrTag()
-
     /**
      * Gets the tr tag used to display a single option in this radio table.
      *
@@ -118,9 +107,6 @@ class SwatRadioTable extends SwatRadioList
     {
         return new SwatHtmlTag('tr');
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this radio table.
@@ -134,6 +120,4 @@ class SwatRadioTable extends SwatRadioList
 
         return array_merge($classes, $this->classes);
     }
-
-    // }}}
 }

--- a/Swat/SwatRating.php
+++ b/Swat/SwatRating.php
@@ -8,8 +8,6 @@
  */
 class SwatRating extends SwatInputControl
 {
-    // {{{ public properties
-
     /**
      * The value of this rating control.
      *
@@ -23,9 +21,6 @@ class SwatRating extends SwatInputControl
      * @var int
      */
     public $maximum_value = 5;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new rating control.
@@ -46,9 +41,6 @@ class SwatRating extends SwatInputControl
         $this->addStyleSheet('packages/swat/styles/swat-rating.css');
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this rating control.
      */
@@ -59,9 +51,6 @@ class SwatRating extends SwatInputControl
         $flydown = $this->getCompositeWidget('flydown');
         $flydown->addOptionsByArray($this->getRatings());
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this rating control.
@@ -77,9 +66,6 @@ class SwatRating extends SwatInputControl
             $this->value = (int) $flydown->value;
         }
     }
-
-    // }}}
-    //  {{{ public function display()
 
     /**
      * Displays this rating control.
@@ -108,9 +94,6 @@ class SwatRating extends SwatInputControl
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ protected function getRatings()
-
     protected function getRatings()
     {
         $ratings = [];
@@ -121,9 +104,6 @@ class SwatRating extends SwatInputControl
 
         return $ratings;
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this rating control.
@@ -137,9 +117,6 @@ class SwatRating extends SwatInputControl
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript for this rating control.
@@ -158,9 +135,6 @@ class SwatRating extends SwatInputControl
         );
     }
 
-    // }}}
-    // {{{ protected function createCompositeWidgets()
-
     /**
      * Creates the composite flydown used by this rating control.
      *
@@ -173,6 +147,4 @@ class SwatRating extends SwatInputControl
         $flydown->serialize_values = false;
         $this->addCompositeWidget($flydown, 'flydown');
     }
-
-    // }}}
 }

--- a/Swat/SwatRatingCellRenderer.php
+++ b/Swat/SwatRatingCellRenderer.php
@@ -8,16 +8,11 @@
  */
 class SwatRatingCellRenderer extends SwatNumericCellRenderer
 {
-    // {{{ constants
-
     public const ROUND_FLOOR = 1;
     public const ROUND_CEIL = 2;
     public const ROUND_UP = 3;
     public const ROUND_NONE = 4;
     public const ROUND_HALF = 5;
-
-    // }}}
-    // {{{ public properties
 
     /**
      * Maximum value a rating can be.
@@ -36,9 +31,6 @@ class SwatRatingCellRenderer extends SwatNumericCellRenderer
      * @var int
      */
     public $round_mode = self::ROUND_FLOOR;
-
-    // }}}
-    // {{{ public function render()
 
     /**
      * Renders the contents of this cell.
@@ -89,9 +81,6 @@ class SwatRatingCellRenderer extends SwatNumericCellRenderer
         }
     }
 
-    // }}}
-    // {{{ protected function getDisplayValue()
-
     public function getDisplayValue()
     {
         switch ($this->round_mode) {
@@ -118,6 +107,4 @@ class SwatRatingCellRenderer extends SwatNumericCellRenderer
 
         return $value;
     }
-
-    // }}}
 }

--- a/Swat/SwatRemoveInputCell.php
+++ b/Swat/SwatRemoveInputCell.php
@@ -18,8 +18,6 @@
  */
 class SwatRemoveInputCell extends SwatInputCell
 {
-    // {{{ public function init()
-
     /**
      * Sets the remove widget for this input cell.
      *
@@ -63,9 +61,6 @@ class SwatRemoveInputCell extends SwatInputCell
         $content->parent = $this;
     }
 
-    // }}}
-    // {{{ public function display()
-
     /**
      * Displays this remove input cell given a numeric row identifier.
      *
@@ -82,9 +77,6 @@ class SwatRemoveInputCell extends SwatInputCell
         $widget->display();
     }
 
-    // }}}
-    // {{{ public function setWidget()
-
     /**
      * Sets the widget of this input cell.
      *
@@ -97,6 +89,4 @@ class SwatRemoveInputCell extends SwatInputCell
     {
         throw new SwatException('Remove input cells must be empty');
     }
-
-    // }}}
 }

--- a/Swat/SwatReplicable.php
+++ b/Swat/SwatReplicable.php
@@ -8,8 +8,6 @@
  */
 interface SwatReplicable
 {
-    // {{{ public function getWidget()
-
     /**
      * Retrives a reference to a replicated widget.
      *
@@ -21,6 +19,4 @@ interface SwatReplicable
      * @throws SwatWidgetNotFoundException
      */
     public function getWidget($widget_id, $replicator_id);
-
-    // }}}
 }

--- a/Swat/SwatReplicableContainer.php
+++ b/Swat/SwatReplicableContainer.php
@@ -8,8 +8,6 @@
  */
 class SwatReplicableContainer extends SwatDisplayableContainer implements SwatReplicable
 {
-    // {{{ public properties
-
     /**
      * An array of unique id => title pairs, one for each replication.
      *
@@ -33,14 +31,8 @@ class SwatReplicableContainer extends SwatDisplayableContainer implements SwatRe
      */
     public $replication_ids;
 
-    // }}}
-    // {{{ private properties
-
     private $widgets = [];
     private $prototype_widgets = [];
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new replicator container.
@@ -54,9 +46,6 @@ class SwatReplicableContainer extends SwatDisplayableContainer implements SwatRe
         parent::__construct($id);
         $this->requires_id = true;
     }
-
-    // }}}
-    // {{{ public function init()
 
     /**
      * Initilizes this replicable container.
@@ -86,9 +75,6 @@ class SwatReplicableContainer extends SwatDisplayableContainer implements SwatRe
 
         parent::init();
     }
-
-    // }}}
-    // {{{ public function addReplication()
 
     public function addReplication($id)
     {
@@ -122,9 +108,6 @@ class SwatReplicableContainer extends SwatDisplayableContainer implements SwatRe
         }
     }
 
-    // }}}
-    // {{{ public function getWidget()
-
     /**
      * Retrives a reference to a replicated widget.
      *
@@ -144,6 +127,4 @@ class SwatReplicableContainer extends SwatDisplayableContainer implements SwatRe
 
         return $widget;
     }
-
-    // }}}
 }

--- a/Swat/SwatReplicableDisclosure.php
+++ b/Swat/SwatReplicableDisclosure.php
@@ -15,8 +15,6 @@
  */
 class SwatReplicableDisclosure extends SwatReplicableContainer
 {
-    // {{{ public function init()
-
     /**
      * Initilizes this replicable disclosure.
      */
@@ -44,6 +42,4 @@ class SwatReplicableDisclosure extends SwatReplicableContainer
             $disclosure->title = $title;
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatReplicableFieldset.php
+++ b/Swat/SwatReplicableFieldset.php
@@ -15,8 +15,6 @@
  */
 class SwatReplicableFieldset extends SwatReplicableContainer
 {
-    // {{{ public function init()
-
     /**
      * Initilizes this replicable fieldset.
      */
@@ -44,6 +42,4 @@ class SwatReplicableFieldset extends SwatReplicableContainer
             $fieldset->title = $title;
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatReplicableFormField.php
+++ b/Swat/SwatReplicableFormField.php
@@ -15,8 +15,6 @@
  */
 class SwatReplicableFormField extends SwatReplicableContainer
 {
-    // {{{ public function init()
-
     /**
      * Initilizes this replicable form field.
      */
@@ -44,6 +42,4 @@ class SwatReplicableFormField extends SwatReplicableContainer
             $field->title = $title;
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatReplicableFrame.php
+++ b/Swat/SwatReplicableFrame.php
@@ -15,8 +15,6 @@
  */
 class SwatReplicableFrame extends SwatReplicableContainer
 {
-    // {{{ public function init()
-
     /**
      * Initilizes this replicable frame.
      */
@@ -46,6 +44,4 @@ class SwatReplicableFrame extends SwatReplicableContainer
             }
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatReplicableNoteBookChild.php
+++ b/Swat/SwatReplicableNoteBookChild.php
@@ -8,8 +8,6 @@
  */
 class SwatReplicableNoteBookChild extends SwatReplicableContainer implements SwatNoteBookChild
 {
-    // {{{ public function getPages()
-
     /**
      * Gets the notebook pages of this replicable notebook child.
      *
@@ -30,9 +28,6 @@ class SwatReplicableNoteBookChild extends SwatReplicableContainer implements Swa
 
         return $pages;
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Adds a {@link SwatNoteBookChild} to this replicable notebook child.
@@ -59,6 +54,4 @@ class SwatReplicableNoteBookChild extends SwatReplicableContainer implements Swa
 
         parent::addChild($child);
     }
-
-    // }}}
 }

--- a/Swat/SwatReplicableNoteBookPage.php
+++ b/Swat/SwatReplicableNoteBookPage.php
@@ -15,8 +15,6 @@
  */
 class SwatReplicableNoteBookPage extends SwatReplicableContainer implements SwatNoteBookChild
 {
-    // {{{ public function init()
-
     /**
      * Initilizes this replicable notebook page.
      */
@@ -54,9 +52,6 @@ class SwatReplicableNoteBookPage extends SwatReplicableContainer implements Swat
         $this->add($note_book);
     }
 
-    // }}}
-    // {{{ public function getPages()
-
     /**
      * Gets the notebook pages of this replicable notebook page.
      *
@@ -69,6 +64,4 @@ class SwatReplicableNoteBookPage extends SwatReplicableContainer implements Swat
     {
         return $this->children;
     }
-
-    // }}}
 }

--- a/Swat/SwatSearchEntry.php
+++ b/Swat/SwatSearchEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatSearchEntry extends SwatEntry
 {
-    // {{{ public properties
-
     /**
      * An XHTML name for this search entry widget.
      *
@@ -20,9 +18,6 @@ class SwatSearchEntry extends SwatEntry
      * @var string
      */
     public $name;
-
-    // }}}
-    // {{{ public function __construct()
 
     public function __construct($id = null)
     {
@@ -35,9 +30,6 @@ class SwatSearchEntry extends SwatEntry
         $this->addJavaScript('packages/swat/javascript/swat-search-entry.js');
         $this->addStyleSheet('packages/swat/styles/swat-search-entry.css');
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this search entry.
@@ -55,9 +47,6 @@ class SwatSearchEntry extends SwatEntry
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ protected function getInlineJavaScript()
-
     /**
      * Gets the inline JavaScript for this entry to function.
      *
@@ -72,9 +61,6 @@ class SwatSearchEntry extends SwatEntry
         return "var {$this->id}_obj = new SwatSearchEntry('{$this->id}');";
     }
 
-    // }}}
-    // {{{ protected function getInputTag()
-
     protected function getInputTag()
     {
         $tag = parent::getInputTag();
@@ -85,9 +71,6 @@ class SwatSearchEntry extends SwatEntry
 
         return $tag;
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this entry.
@@ -101,9 +84,6 @@ class SwatSearchEntry extends SwatEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getRawValue()
 
     /**
      * Gets the raw value entered by the user before processing.
@@ -127,9 +107,6 @@ class SwatSearchEntry extends SwatEntry
 
         return $value;
     }
-
-    // }}}
-    // {{{ protected function hasRawValue()
 
     /**
      * Gets whether or not a value was submitted by the user for this entry.
@@ -156,6 +133,4 @@ class SwatSearchEntry extends SwatEntry
 
         return $has_value;
     }
-
-    // }}}
 }

--- a/Swat/SwatSelectList.php
+++ b/Swat/SwatSelectList.php
@@ -8,17 +8,12 @@
  */
 class SwatSelectList extends SwatCheckboxList
 {
-    // {{{ public properties
-
     /**
      * Optional number of rows in the select list.
      *
      * @var int
      */
     public $size;
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this select list.
@@ -59,9 +54,6 @@ class SwatSelectList extends SwatCheckboxList
         $select_tag->close();
     }
 
-    // }}}
-    // {{{ public function getNote()
-
     /**
      * Gets a note letting the user know the select list can select multiple
      * options.
@@ -79,6 +71,4 @@ class SwatSelectList extends SwatCheckboxList
 
         return new SwatMessage($message);
     }
-
-    // }}}
 }

--- a/Swat/SwatSimpleColorEntry.php
+++ b/Swat/SwatSimpleColorEntry.php
@@ -11,8 +11,6 @@
  */
 class SwatSimpleColorEntry extends SwatAbstractOverlay
 {
-    // {{{ public properties
-
     /**
      * Show "none" option.
      *
@@ -74,9 +72,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
         'a40000',
     ];
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new simple color selection widget.
      *
@@ -104,9 +99,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
             'packages/swat/styles/swat-simple-color-entry.css',
         );
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this color entry.
@@ -145,9 +137,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
         }
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this simple color
      * entry widget.
@@ -161,9 +150,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets simple color selector inline JavaScript.
@@ -198,9 +184,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
         return $javascript;
     }
 
-    // }}}
-    // {{{ protected function validateColor()
-
     /**
      * Validates a color.
      *
@@ -231,9 +214,6 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
         return $valid;
     }
 
-    // }}}
-    // {{{ protected function getJavaScriptClassName()
-
     /**
      * Get the name of the JavaScript class for this widget.
      *
@@ -243,6 +223,4 @@ class SwatSimpleColorEntry extends SwatAbstractOverlay
     {
         return 'SwatSimpleColorEntry';
     }
-
-    // }}}
 }

--- a/Swat/SwatState.php
+++ b/Swat/SwatState.php
@@ -8,8 +8,6 @@
  */
 interface SwatState
 {
-    // {{{ public function setState()
-
     /**
      * Set the state of the control.
      *
@@ -21,9 +19,6 @@ interface SwatState
      * @param mixed $state the state to load into the control
      */
     public function setState($state);
-
-    // }}}
-    // {{{ public function getState()
 
     /**
      * Get the state of the control.
@@ -37,6 +32,4 @@ interface SwatState
      * @return mixed the current state of the control
      */
     public function getState();
-
-    // }}}
 }

--- a/Swat/SwatString.php
+++ b/Swat/SwatString.php
@@ -8,8 +8,6 @@
  */
 class SwatString extends SwatObject
 {
-    // {{{ public static properties
-
     /**
      * Block level XHTML elements used when filtering strings.
      *
@@ -157,9 +155,6 @@ class SwatString extends SwatObject
      * @var array
      */
     public static $preformatted_elements = ['script', 'style', 'pre'];
-
-    // }}}
-    // {{{ public static function toXHTML()
 
     /**
      * Intelligently converts a text block to XHTML.
@@ -384,9 +379,6 @@ class SwatString extends SwatObject
         return $text;
     }
 
-    // }}}
-    // {{{ public static function minimizeEntities()
-
     /**
      * Converts a UTF-8 text string to have the minimal number of entities
      * necessary to output it as valid UTF-8 XHTML without ever double-escaping.
@@ -413,9 +405,6 @@ class SwatString extends SwatObject
         // and double quote (") characters as their XML entities
         return htmlspecialchars($text, ENT_COMPAT, 'UTF-8');
     }
-
-    // }}}
-    // {{{ public static function minimizeEntitiesWithTags()
 
     /**
      * Same as {@link SwatString::minimizeEntities()} but also accepts a list
@@ -449,9 +438,6 @@ class SwatString extends SwatObject
 
         return $output;
     }
-
-    // }}}
-    // {{{ public static function condense()
 
     /**
      * Takes a block of text and condenses it into a small fragment of XHTML.
@@ -568,9 +554,6 @@ class SwatString extends SwatObject
         return $text;
     }
 
-    // }}}
-    // {{{ public static function condenseToName()
-
     /**
      * Condenses a string to a name.
      *
@@ -682,9 +665,6 @@ class SwatString extends SwatObject
         return $string_out;
     }
 
-    // }}}
-    // {{{ public static function ellipsizeRight()
-
     /**
      * Ellipsizes a string to the right.
      *
@@ -765,9 +745,6 @@ class SwatString extends SwatObject
 
         return $string;
     }
-
-    // }}}
-    // {{{ public static function ellipsizeMiddle()
 
     /**
      * Ellipsizes a string in the middle.
@@ -895,9 +872,6 @@ class SwatString extends SwatObject
         return $string;
     }
 
-    // }}}
-    // {{{ public static function removeTrailingPunctuation()
-
     /**
      * Removes trailing punctuation from a string.
      *
@@ -910,9 +884,6 @@ class SwatString extends SwatObject
         return preg_replace('/\W+$/su', '', $string);
     }
 
-    // }}}
-    // {{{ public static function removeLeadingPunctuation()
-
     /**
      * Removes leading punctuation from a string.
      *
@@ -924,9 +895,6 @@ class SwatString extends SwatObject
     {
         return preg_replace('/^\W+/su', '', $string);
     }
-
-    // }}}
-    // {{{ public static function removePunctuation()
 
     /**
      * Removes both leading and trailing punctuation from a string.
@@ -941,9 +909,6 @@ class SwatString extends SwatObject
 
         return self::removeLeadingPunctuation($string);
     }
-
-    // }}}
-    // {{{ public static function moneyFormat()
 
     /**
      * Formats a numeric value as currency.
@@ -1042,9 +1007,6 @@ class SwatString extends SwatObject
         return $output;
     }
 
-    // }}}
-    // {{{ public static function getInternationalCurrencySymbol()
-
     /**
      * Gets the international currency symbol of a locale.
      *
@@ -1102,9 +1064,6 @@ class SwatString extends SwatObject
 
         return $symbol;
     }
-
-    // }}}
-    // {{{ public static function numberFormat()
 
     /**
      * Formats a number using locale-based separators.
@@ -1187,9 +1146,6 @@ class SwatString extends SwatObject
         return $output;
     }
 
-    // }}}
-    // {{{ public static function ordinalNumberFormat()
-
     /**
      * Formats an integer as an ordinal number (1st, 2nd, 3rd).
      *
@@ -1202,9 +1158,6 @@ class SwatString extends SwatObject
     {
         return SwatNumber::ordinal($value);
     }
-
-    // }}}
-    // {{{ public static function byteFormat()
 
     /**
      * Format bytes in human readible units.
@@ -1319,9 +1272,6 @@ class SwatString extends SwatObject
         return $formatted_value . ' ' . $units[$unit_magnitude];
     }
 
-    // }}}
-    // {{{ public static function pad()
-
     /**
      * Pads a string in a UTF-8 safe way.
      *
@@ -1386,9 +1336,6 @@ class SwatString extends SwatObject
         return $output;
     }
 
-    // }}}
-    // {{{ public static function toInteger()
-
     /**
      * Convert a locale-formatted number and return it as an integer.
      *
@@ -1452,9 +1399,6 @@ class SwatString extends SwatObject
         return $value;
     }
 
-    // }}}
-    // {{{ public static function toFloat()
-
     /**
      * Convert a locale-formatted number and return it as an float.
      *
@@ -1490,9 +1434,6 @@ class SwatString extends SwatObject
 
         return is_numeric($value) ? floatval($value) : null;
     }
-
-    // }}}
-    // {{{ public static function toList()
 
     /**
      * Convert an iterable object or array into a human-readable, delimited
@@ -1559,9 +1500,6 @@ class SwatString extends SwatObject
 
         return $list;
     }
-
-    // }}}
-    // {{{ public static function getTimePeriodParts()
 
     /**
      * Gets the parts representing a time period matching a desired interval
@@ -1680,9 +1618,6 @@ class SwatString extends SwatObject
         return $parts;
     }
 
-    // }}}
-    // {{{ public static function getHumanReadableTimePeriodParts()
-
     /**
      * Gets the parts to construct a human-readable string representing a time
      * period.
@@ -1776,9 +1711,6 @@ class SwatString extends SwatObject
         return $parts;
     }
 
-    // }}}
-    // {{{ public static function toHumanReadableTimePeriod()
-
     /**
      * Gets a human-readable string representing a time period.
      *
@@ -1804,9 +1736,6 @@ class SwatString extends SwatObject
 
         return self::toHumanReadableTimePeriodString($parts, $largest_part);
     }
-
-    // }}}
-    // {{{ public static function toHumanReadableTimePeriodWithWeeks()
 
     /**
      * Gets a human-readable string representing a time period that includes
@@ -1846,9 +1775,6 @@ class SwatString extends SwatObject
 
         return self::toHumanReadableTimePeriodString($parts, $largest_part);
     }
-
-    // }}}
-    // {{{ public static function toHumanReadableTimePeriodWithWeeksAndDays()
 
     /**
      * Gets a human-readable string representing a time period that includes
@@ -1890,9 +1816,6 @@ class SwatString extends SwatObject
         return self::toHumanReadableTimePeriodString($parts, true);
     }
 
-    // }}}
-    // {{{ public static function hash()
-
     /**
      * Gets a unique hash of a string.
      *
@@ -1919,9 +1842,6 @@ class SwatString extends SwatObject
         return str_replace('/', '-', $hash);
     }
 
-    // }}}
-    // {{{ public static function getSalt()
-
     /**
      * Gets a salt value of the specified length.
      *
@@ -1945,9 +1865,6 @@ class SwatString extends SwatObject
 
         return $salt;
     }
-
-    // }}}
-    // {{{ public static function getCryptSalt()
 
     /**
      * Gets a salt value for crypt(3).
@@ -1981,9 +1898,6 @@ class SwatString extends SwatObject
         return $salt;
     }
 
-    // }}}
-    // {{{ public static function stripXHTMLTags()
-
     /**
      * Removes all XHTML tags from a string.
      *
@@ -2007,9 +1921,6 @@ class SwatString extends SwatObject
         );
     }
 
-    // }}}
-    // {{{ public static function linkify()
-
     /**
      * Replaces all URI's in a string with anchor markup tags.
      *
@@ -2030,9 +1941,6 @@ class SwatString extends SwatObject
             $string,
         );
     }
-
-    // }}}
-    // {{{ public static function signedSerialize()
 
     /**
      * Serializes and signs a value using a salt.
@@ -2056,9 +1964,6 @@ class SwatString extends SwatObject
 
         return $signature_data . '|' . $serialized_data;
     }
-
-    // }}}
-    // {{{ public static function signedUnserialize()
 
     /**
      * Unserializes a signed serialized value.
@@ -2099,9 +2004,6 @@ class SwatString extends SwatObject
 
         return unserialize($serialized_data);
     }
-
-    // }}}
-    // {{{ public static function quoteJavaScriptString()
 
     /**
      * Safely quotes a PHP string into a JavaScript string.
@@ -2159,9 +2061,6 @@ class SwatString extends SwatObject
         return "'" . $string . "'";
     }
 
-    // }}}
-    // {{{ public static function validateUtf8()
-
     /**
      * Checks whether or not a string is valid UTF-8.
      *
@@ -2173,9 +2072,6 @@ class SwatString extends SwatObject
     {
         return mb_detect_encoding($string, 'UTF-8', true) === 'UTF-8';
     }
-
-    // }}}
-    // {{{ public static function validateEmailAddress()
 
     /**
      * Validates an email address.
@@ -2204,9 +2100,6 @@ class SwatString extends SwatObject
 
         return preg_match($valid_address_regexp, $value) === 1;
     }
-
-    // }}}
-    // {{{ public static function escapeBinary()
 
     /**
      * Escapes a binary string making it safe to display using ASCII encoding.
@@ -2246,9 +2139,6 @@ class SwatString extends SwatObject
         return $escaped;
     }
 
-    // }}}
-    // {{{ protected static function toHumanReadableTimePeriodString()
-
     /**
      * Gets a human-readable string representing a time period from an array of
      * human readable date parts.
@@ -2281,9 +2171,6 @@ class SwatString extends SwatObject
         return self::toList($parts);
     }
 
-    // }}}
-    // {{{ private static function stripEntities()
-
     /**
      * Strips entities from a string remembering their positions.
      *
@@ -2302,9 +2189,6 @@ class SwatString extends SwatObject
 
         $string = preg_replace($reg_exp, '*', $string);
     }
-
-    // }}}
-    // {{{ private static function insertEntities()
 
     /**
      * Re-inserts stripped entities into a string in the correct positions.
@@ -2365,9 +2249,6 @@ class SwatString extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ private static function parseNegativeNotation()
-
     private static function parseNegativeNotation($string)
     {
         $lc = localeconv();
@@ -2403,9 +2284,6 @@ class SwatString extends SwatObject
         return $string;
     }
 
-    // }}}
-    // {{{ private static function getDecimalPrecision()
-
     private static function getDecimalPrecision($value)
     {
         $lc = localeconv();
@@ -2417,15 +2295,10 @@ class SwatString extends SwatObject
             : 0;
     }
 
-    // }}}
-    // {{{ private function __construct()
-
     /**
      * Don't allow instantiation of the SwatString object.
      *
      * This class contains only static methods and should not be instantiated.
      */
     private function __construct() {}
-
-    // }}}
 }

--- a/Swat/SwatStyleSheetHtmlHeadEntry.php
+++ b/Swat/SwatStyleSheetHtmlHeadEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatStyleSheetHtmlHeadEntry extends SwatHtmlHeadEntry
 {
-    // {{{ protected function displayInternal()
-
     protected function displayInternal($uri_prefix = '', $tag = null)
     {
         $uri = $this->uri;
@@ -29,15 +27,10 @@ class SwatStyleSheetHtmlHeadEntry extends SwatHtmlHeadEntry
         );
     }
 
-    // }}}
-    // {{{ protected function displayInlineInternal()
-
     protected function displayInlineInternal($path)
     {
         echo '<style type="text/css" media="all">';
         readfile($path . $this->getUri());
         echo '</style>';
     }
-
-    // }}}
 }

--- a/Swat/SwatTableStore.php
+++ b/Swat/SwatTableStore.php
@@ -13,6 +13,8 @@ class SwatTableStore extends SwatObject implements SwatTableModel
 {
     /**
      * The individual rows for this data structure.
+     *
+     * @var list<mixed>
      */
     private array $rows = [];
 
@@ -38,8 +40,7 @@ class SwatTableStore extends SwatObject implements SwatTableModel
      *
      * @return mixed the current element
      */
-    #[ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         return $this->rows[$this->current_index];
     }

--- a/Swat/SwatTableStore.php
+++ b/Swat/SwatTableStore.php
@@ -11,8 +11,6 @@
  */
 class SwatTableStore extends SwatObject implements SwatTableModel
 {
-    // {{{ private properties
-
     /**
      * The indvidual rows for this data structure.
      *
@@ -27,9 +25,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
      */
     private $current_index = 0;
 
-    // }}}
-    // {{{ public function count()
-
     /**
      * Gets the number of rows.
      *
@@ -42,9 +37,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
         return count($this->rows);
     }
 
-    // }}}
-    // {{{ public function current()
-
     /**
      * Returns the current element.
      *
@@ -54,9 +46,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
     {
         return $this->rows[$this->current_index];
     }
-
-    // }}}
-    // {{{ public function key()
 
     /**
      * Returns the key of the current element.
@@ -68,9 +57,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
         return $this->current_index;
     }
 
-    // }}}
-    // {{{ public function next()
-
     /**
      * Moves forward to the next element.
      */
@@ -78,9 +64,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
     {
         $this->current_index++;
     }
-
-    // }}}
-    // {{{ public function prev()
 
     /**
      * Moves forward to the previous element.
@@ -90,9 +73,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
         $this->current_index--;
     }
 
-    // }}}
-    // {{{ public function rewind()
-
     /**
      * Rewinds this iterator to the first element.
      */
@@ -100,9 +80,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
     {
         $this->current_index = 0;
     }
-
-    // }}}
-    // {{{ public function valid()
 
     /**
      * Checks is there is a current element after calls to rewind() and next().
@@ -115,9 +92,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
         return array_key_exists($this->current_index, $this->rows);
     }
 
-    // }}}
-    // {{{ public function add()
-
     /**
      * Adds a row to this data structure.
      *
@@ -127,9 +101,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
     {
         $this->rows[] = $data;
     }
-
-    // }}}
-    // {{{ public function addToStart()
 
     /**
      * Adds a row to the beginning of this data structure.
@@ -142,9 +113,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
         $this->current_index++;
     }
 
-    // }}}
-    // {{{ public function getRowCount()
-
     /**
      * Gets the number of rows in this data structure.
      *
@@ -154,9 +122,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
     {
         return count($this->rows);
     }
-
-    // }}}
-    // {{{ public function &getRows()
 
     /**
      * Gets the rows of this data structure as an array.
@@ -170,9 +135,6 @@ class SwatTableStore extends SwatObject implements SwatTableModel
         return $this->rows;
     }
 
-    // }}}
-    // {{{ public function addRow()
-
     /**
      * Adds a row to this data structure.
      *
@@ -185,6 +147,4 @@ class SwatTableStore extends SwatObject implements SwatTableModel
     {
         $this->add($data);
     }
-
-    // }}}
 }

--- a/Swat/SwatTableStore.php
+++ b/Swat/SwatTableStore.php
@@ -12,18 +12,14 @@
 class SwatTableStore extends SwatObject implements SwatTableModel
 {
     /**
-     * The indvidual rows for this data structure.
-     *
-     * @var array
+     * The individual rows for this data structure.
      */
-    private $rows = [];
+    private array $rows = [];
 
     /**
      * The current index of the iterator interface.
-     *
-     * @var int
      */
-    private $current_index = 0;
+    private int $current_index = 0;
 
     /**
      * Gets the number of rows.
@@ -42,6 +38,7 @@ class SwatTableStore extends SwatObject implements SwatTableModel
      *
      * @return mixed the current element
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->rows[$this->current_index];
@@ -52,7 +49,7 @@ class SwatTableStore extends SwatObject implements SwatTableModel
      *
      * @return int the key of the current element
      */
-    public function key()
+    public function key(): int
     {
         return $this->current_index;
     }
@@ -68,7 +65,7 @@ class SwatTableStore extends SwatObject implements SwatTableModel
     /**
      * Moves forward to the previous element.
      */
-    public function prev()
+    public function prev(): void
     {
         $this->current_index--;
     }
@@ -95,7 +92,7 @@ class SwatTableStore extends SwatObject implements SwatTableModel
     /**
      * Adds a row to this data structure.
      *
-     * @param $data the data of the row to add
+     * @param mixed $data the data of the row to add
      */
     public function add($data)
     {
@@ -105,7 +102,7 @@ class SwatTableStore extends SwatObject implements SwatTableModel
     /**
      * Adds a row to the beginning of this data structure.
      *
-     * @param $data the data of the row to add
+     * @param $data mixed the data of the row to add
      */
     public function addToStart($data)
     {
@@ -138,8 +135,8 @@ class SwatTableStore extends SwatObject implements SwatTableModel
     /**
      * Adds a row to this data structure.
      *
-     * @param $data the data of the row to add
-     * @param $id   an optional uniqueid of the row to add
+     * @param $data mixed the data of the row to add
+     * @param $id   mixed an optional uniqueid of the row to add
      *
      * @deprecated Use SwatTableStore::add()
      */

--- a/Swat/SwatTableView.php
+++ b/Swat/SwatTableView.php
@@ -12,8 +12,6 @@
  */
 class SwatTableView extends SwatView implements SwatUIParent
 {
-    // {{{ public properties
-
     /**
      * The column of this table-view that data in the model is currently being
      * sorted by.
@@ -83,9 +81,6 @@ class SwatTableView extends SwatView implements SwatUIParent
      * @var bool
      */
     public $use_invalid_tfoot_ordering = false;
-
-    // }}}
-    // {{{ protected properties
 
     /**
      * The columns of this table-view indexed by their unique identifier.
@@ -185,10 +180,7 @@ class SwatTableView extends SwatView implements SwatUIParent
      */
     protected $has_input_row = false;
 
-    // }}}
-
     // general methods
-    // {{{ public function __construct()
 
     /**
      * Creates a new table view.
@@ -207,9 +199,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         $this->addJavaScript('packages/swat/javascript/swat-table-view.js');
         $this->addStyleSheet('packages/swat/styles/swat-table-view.css');
     }
-
-    // }}}
-    // {{{ public function init()
 
     /**
      * Initializes this table-view.
@@ -254,9 +243,6 @@ class SwatTableView extends SwatView implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this table-view.
@@ -323,9 +309,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this table-view.
      */
@@ -351,9 +334,6 @@ class SwatTableView extends SwatView implements SwatUIParent
             $this->checked_items = $items->getItems();
         }
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Adds a child object.
@@ -397,9 +377,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function getMessages()
-
     /**
      * Gathers all messages from this table-view.
      *
@@ -435,9 +412,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
         return $messages;
     }
-
-    // }}}
-    // {{{ public function hasMessage()
 
     /**
      * Gets whether or not this table-view has any messages.
@@ -479,9 +453,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $has_message;
     }
 
-    // }}}
-    // {{{ public function getXhtmlColspan()
-
     /**
      * Gets how many XHTML table columns the visible column objects of this
      * table-view object span on display.
@@ -510,9 +481,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
         return $colspan;
     }
-
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this table.
@@ -545,9 +513,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this table.
      *
@@ -578,9 +543,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -668,9 +630,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -754,9 +713,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -777,9 +733,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $states;
     }
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -797,9 +750,6 @@ class SwatTableView extends SwatView implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -861,9 +811,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $copy;
     }
 
-    // }}}
-    // {{{ protected function hasHeader()
-
     /**
      * Whether this table has a header to display.
      *
@@ -883,9 +830,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $has_header;
     }
 
-    // }}}
-    // {{{ protected function displayHeader()
-
     /**
      * Displays the column headers for this table-view.
      *
@@ -904,9 +848,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         echo '</tr>';
         echo '</thead>';
     }
-
-    // }}}
-    // {{{ protected function displayBody()
 
     /**
      * Displays the contents of this view.
@@ -950,9 +891,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ protected function displayRow()
-
     /**
      * Displays a single row.
      *
@@ -974,9 +912,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         $this->displayRowGroupFooters($row, $next_row, $count);
     }
 
-    // }}}
-    // {{{ protected function displayRowGroupHeaders()
-
     /**
      * Displays row group headers.
      *
@@ -993,9 +928,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ protected function displayRowGroupFooters()
-
     /**
      * Displays row group headers.
      *
@@ -1011,9 +943,6 @@ class SwatTableView extends SwatView implements SwatUIParent
             $group->displayFooter($row, $next_row);
         }
     }
-
-    // }}}
-    // {{{ protected function displayRowColumns()
 
     /**
      * Displays the columns for a row.
@@ -1060,9 +989,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ protected function displayRowSpanningColumns()
-
     /**
      * Displays row spanning columns.
      *
@@ -1091,9 +1017,6 @@ class SwatTableView extends SwatView implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ protected function displayRowMessages()
 
     /**
      * Displays a list of {@link SwatMessage} object for the given row.
@@ -1143,9 +1066,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ protected function displayFooter()
-
     /**
      * Displays any footer content for this table-view.
      *
@@ -1171,9 +1091,6 @@ class SwatTableView extends SwatView implements SwatUIParent
             $tfoot_tag->display();
         }
     }
-
-    // }}}
-    // {{{ protected function rowHasMessage()
 
     /**
      * Whether any of the columns in the row has a message.
@@ -1207,9 +1124,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $has_message;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this table view.
      *
@@ -1222,9 +1136,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getRowClasses()
 
     /**
      * Gets CSS classes for the XHTML tr tag.
@@ -1254,9 +1165,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $classes;
     }
 
-    // }}}
-    // {{{ protected function getRowClassString()
-
     /**
      * Gets CSS class string for the XHTML tr tag.
      *
@@ -1278,9 +1186,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
         return $class_string;
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets inline JavaScript required by this table-view as well as any
@@ -1351,10 +1256,7 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $javascript;
     }
 
-    // }}}
-
     // column methods
-    // {{{ public function appendColumn()
 
     /**
      * Appends a column to this table-view.
@@ -1368,9 +1270,6 @@ class SwatTableView extends SwatView implements SwatUIParent
     {
         $this->insertColumn($column);
     }
-
-    // }}}
-    // {{{ public function insertColumnBefore()
 
     /**
      * Inserts a column before an existing column in this table-view.
@@ -1391,9 +1290,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         $this->insertColumn($column, $reference_column, false);
     }
 
-    // }}}
-    // {{{ public function insertColumnAfter()
-
     /**
      * Inserts a column after an existing column in this table-view.
      *
@@ -1413,9 +1309,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         $this->insertColumn($column, $reference_column, true);
     }
 
-    // }}}
-    // {{{ public function hasColumn()
-
     /**
      * Returns true if a column with the given id exists within this
      * table-view.
@@ -1430,9 +1323,6 @@ class SwatTableView extends SwatView implements SwatUIParent
     {
         return array_key_exists($id, $this->columns_by_id);
     }
-
-    // }}}
-    // {{{ public function getColumn()
 
     /**
      * Gets a column in this table-view by the column's id.
@@ -1455,9 +1345,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $this->columns_by_id[$id];
     }
 
-    // }}}
-    // {{{ public function getColumns()
-
     /**
      * Gets all columns of this table-view as an array.
      *
@@ -1468,9 +1355,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $this->columns;
     }
 
-    // }}}
-    // {{{ public function getColumnCount()
-
     /**
      * Gets the number of columns in this table-view.
      *
@@ -1480,9 +1364,6 @@ class SwatTableView extends SwatView implements SwatUIParent
     {
         return count($this->columns);
     }
-
-    // }}}
-    // {{{ public function getVisibleColumns()
 
     /**
      * Gets all visible columns of this table-view as an array.
@@ -1501,9 +1382,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $columns;
     }
 
-    // }}}
-    // {{{ public function getVisibleColumnCount()
-
     /**
      * Gets the number of visible columns in this table-view.
      *
@@ -1513,9 +1391,6 @@ class SwatTableView extends SwatView implements SwatUIParent
     {
         return count($this->getVisibleColumns());
     }
-
-    // }}}
-    // {{{ public function setDefaultOrderbyColumn()
 
     /**
      * Sets a default column to use for ordering the data of this table-view.
@@ -1543,9 +1418,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         $column->setDirection($direction);
     }
 
-    // }}}
-    // {{{ protected function validateColumn()
-
     /**
      * Ensures a column added to this table-view is valid for this table-view.
      *
@@ -1569,9 +1441,6 @@ class SwatTableView extends SwatView implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ protected function insertColumn()
 
     /**
      * Helper method to insert columns into this table-view.
@@ -1655,10 +1524,7 @@ class SwatTableView extends SwatView implements SwatUIParent
         $column->parent = $this;
     }
 
-    // }}}
-
     // spanning column methods
-    // {{{ public function appendSpanningColumn()
 
     /**
      * Appends a spanning column object to this table-view.
@@ -1675,9 +1541,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         $column->parent = $this;
     }
 
-    // }}}
-    // {{{ public function hasSpanningColumn()
-
     /**
      * Returns true if a spanning column with the given id exists within this table-view.
      *
@@ -1689,9 +1552,6 @@ class SwatTableView extends SwatView implements SwatUIParent
     {
         return array_key_exists($id, $this->spanning_columns_by_id);
     }
-
-    // }}}
-    // {{{ public function getSpanningColumn()
 
     /**
      * Gets a spanning column in this table-view by the spanning column's id.
@@ -1715,9 +1575,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $this->spanning_columns_by_id[$id];
     }
 
-    // }}}
-    // {{{ public function getSpanningColumns()
-
     /**
      * Gets all spanning columns of this table-view as an array.
      *
@@ -1727,9 +1584,6 @@ class SwatTableView extends SwatView implements SwatUIParent
     {
         return $this->spanning_columns;
     }
-
-    // }}}
-    // {{{ public function getVisibleSpanningColumns()
 
     /**
      * Gets all visible spanning columns of this table-view as an array.
@@ -1749,10 +1603,7 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $columns;
     }
 
-    // }}}
-
     // grouping methods
-    // {{{ public function appendGroup()
 
     /**
      * Appends a grouping object to this table-view.
@@ -1785,9 +1636,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         $group->parent = $this;
     }
 
-    // }}}
-    // {{{ public function hasGroup()
-
     /**
      * Returns true if a group with the given id exists within this table-view.
      *
@@ -1801,9 +1649,6 @@ class SwatTableView extends SwatView implements SwatUIParent
     {
         return array_key_exists($id, $this->groups_by_id);
     }
-
-    // }}}
-    // {{{ public function getGroup()
 
     /**
      * Gets a group in this table-view by the group's id.
@@ -1826,9 +1671,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $this->groups_by_id[$id];
     }
 
-    // }}}
-    // {{{ public function getGroups()
-
     /**
      * Gets all groups of this table-view as an array.
      *
@@ -1838,9 +1680,6 @@ class SwatTableView extends SwatView implements SwatUIParent
     {
         return $this->groups;
     }
-
-    // }}}
-    // {{{ protected function validateGroup()
 
     /**
      * Ensures a group added to this table-view is valid for this table-view.
@@ -1866,10 +1705,7 @@ class SwatTableView extends SwatView implements SwatUIParent
         }
     }
 
-    // }}}
-
     // extra row methods
-    // {{{ public function appendRow()
 
     /**
      * Appends a single row to this table-view.
@@ -1886,9 +1722,6 @@ class SwatTableView extends SwatView implements SwatUIParent
     {
         $this->insertRow($row);
     }
-
-    // }}}
-    // {{{ public function insertRowBefore()
 
     /**
      * Inserts a row before an existing row in this table-view.
@@ -1911,9 +1744,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         $this->insertRow($row, $reference_row, false);
     }
 
-    // }}}
-    // {{{ public function insertRowAfter()
-
     /**
      * Inserts a row after an existing row in this table-view.
      *
@@ -1935,9 +1765,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         $this->insertRow($row, $reference_row, true);
     }
 
-    // }}}
-    // {{{ public function hasRow()
-
     /**
      * Returns true if a row with the given id exists within this table-view.
      *
@@ -1951,9 +1778,6 @@ class SwatTableView extends SwatView implements SwatUIParent
     {
         return array_key_exists($id, $this->rows_by_id);
     }
-
-    // }}}
-    // {{{ public function getRow()
 
     /**
      * Gets a row in this table-view by the row's id.
@@ -1976,9 +1800,6 @@ class SwatTableView extends SwatView implements SwatUIParent
         return $this->rows_by_id[$id];
     }
 
-    // }}}
-    // {{{ public function getRowsByClass()
-
     /**
      * Gets all the extra rows of the specified class from this table-view.
      *
@@ -1997,9 +1818,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
         return $rows;
     }
-
-    // }}}
-    // {{{ public function getFirstRowByClass()
 
     /**
      * Gets the first extra row of the specified class from this table-view.
@@ -2028,9 +1846,6 @@ class SwatTableView extends SwatView implements SwatUIParent
 
         return $my_row;
     }
-
-    // }}}
-    // {{{ protected function validateRow()
 
     /**
      * Ensures a row added to this table-view is valid for this table-view.
@@ -2064,9 +1879,6 @@ class SwatTableView extends SwatView implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ protected function insertRow()
 
     /**
      * Helper method to insert rows into this table-view.
@@ -2146,6 +1958,4 @@ class SwatTableView extends SwatView implements SwatUIParent
         $row->view = $this; // deprecated reference
         $row->parent = $this;
     }
-
-    // }}}
 }

--- a/Swat/SwatTableViewCheckAllRow.php
+++ b/Swat/SwatTableViewCheckAllRow.php
@@ -8,8 +8,6 @@
  */
 class SwatTableViewCheckAllRow extends SwatTableViewRow
 {
-    // {{{ public properties
-
     /**
      * Optional checkbox label title.
      *
@@ -67,18 +65,12 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
      */
     public $tab_index;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * The check-all widget for this row.
      *
      * @var SwatCheckAll
      */
     protected $check_all;
-
-    // }}}
-    // {{{ private properties
 
     /**
      * The table-view checkbox column to which this check-all row is bound.
@@ -107,9 +99,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
      */
     private $widgets_created = false;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new table-view check-all row.
      *
@@ -125,9 +114,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
         $this->column = $column;
         $this->list_id = $list_id;
     }
-
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this check-all row.
@@ -146,9 +132,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this
@@ -169,9 +152,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
         return $set;
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this check-all row.
      */
@@ -181,9 +161,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
         $this->createEmbeddedWidgets();
         $this->check_all->init();
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this check-all row.
@@ -195,9 +172,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
         $this->check_all->process();
     }
 
-    // }}}
-    // {{{ public function isExtendedSelected()
-
     /**
      * Whether or not the extended-checkbox was checked.
      *
@@ -207,9 +181,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
     {
         return $this->check_all->isExtendedSelected();
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this check-all row.
@@ -272,9 +243,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
         $tr_tag->close();
     }
 
-    // }}}
-    // {{{ public function getInlineJavaScript()
-
     /**
      * Gets the inline JavaScript required for this check-all row.
      *
@@ -296,9 +264,6 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
         );
     }
 
-    // }}}
-    // {{{ private function createEmbeddedWidgets()
-
     /**
      * Creates internal widgets required for this check-all row.
      */
@@ -311,6 +276,4 @@ class SwatTableViewCheckAllRow extends SwatTableViewRow
             $this->widgets_created = true;
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatTableViewCheckboxColumn.php
+++ b/Swat/SwatTableViewCheckboxColumn.php
@@ -17,8 +17,6 @@
  */
 class SwatTableViewCheckboxColumn extends SwatTableViewColumn
 {
-    // {{{ public properties
-
     /**
      * Whether to show a check-all row for this checkbox column.
      *
@@ -88,9 +86,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
      */
     public $highlight_row = true;
 
-    // }}}
-    // {{{ private properties
-
     /**
      * The selected rows of this checkbox column after processing this column.
      *
@@ -110,9 +105,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
      */
     private $check_all;
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this checkbox column.
      */
@@ -127,9 +119,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
             $this->parent->appendRow($this->check_all);
         }
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this checkbox column.
@@ -153,9 +142,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
         }
     }
 
-    // }}}
-    // {{{ public function isExtendedCheckAllSelected()
-
     /**
      * Whether or not the extended-check-all check-box was checked.
      *
@@ -165,9 +151,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
     {
         return $this->check_all->isExtendedSelected();
     }
-
-    // }}}
-    // {{{ public function displayHeader()
 
     /**
      * Displays the contents of the header cell for this column.
@@ -186,9 +169,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
         parent::displayHeader();
     }
 
-    // }}}
-    // {{{ public function getItems()
-
     /**
      * Gets the selected rows of this checkbox column.
      *
@@ -203,9 +183,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
         return $this->items;
     }
 
-    // }}}
-    // {{{ public function getCheckboxRendererId()
-
     /**
      * Gets the identifier of the first checkbox cell renderer in this column.
      *
@@ -216,9 +193,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
     {
         return $this->getCheckboxRenderer()->id;
     }
-
-    // }}}
-    // {{{ public function getCheckboxRenderer()
 
     private function getCheckboxRenderer()
     {
@@ -234,9 +208,6 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
         );
     }
 
-    // }}}
-    // {{{ public function extendedCheckAllSelected()
-
     /**
      * Whether or not the extended-check-all check-box was checked.
      *
@@ -247,14 +218,9 @@ class SwatTableViewCheckboxColumn extends SwatTableViewColumn
         return $this->check_all->extendedSelected();
     }
 
-    // }}}
-    // {{{ private function createEmbeddedWidgets()
-
     private function createEmbeddedWidgets()
     {
         $renderer_id = $this->getCheckboxRendererId();
         $this->check_all = new SwatTableViewCheckAllRow($this, $renderer_id);
     }
-
-    // }}}
 }

--- a/Swat/SwatTableViewColumn.php
+++ b/Swat/SwatTableViewColumn.php
@@ -15,8 +15,6 @@
  */
 class SwatTableViewColumn extends SwatCellRendererContainer
 {
-    // {{{ public properties
-
     /**
      * Unique identifier of this column.
      *
@@ -85,9 +83,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
      */
     public $show_renderer_classes = true;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * An optional {@link SwatInputCell} object for this column.
      *
@@ -109,9 +104,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
      */
     protected $has_auto_id = false;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new table-view column.
      *
@@ -123,9 +115,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         $this->id = $id;
         parent::__construct();
     }
-
-    // }}}
-    // {{{ public function init()
 
     /**
      * Initializes this column.
@@ -160,18 +149,12 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         }
     }
 
-    // }}}
-    // {{{ public function process()
-
     public function process()
     {
         foreach ($this->renderers as $renderer) {
             $renderer->process();
         }
     }
-
-    // }}}
-    // {{{ public function hasHeader()
 
     /**
      * Whether this column has a header to display.
@@ -180,9 +163,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
     {
         return $this->visible && $this->title != '';
     }
-
-    // }}}
-    // {{{ public function displayHeaderCell()
 
     /**
      * Displays the table-view header cell for this column.
@@ -205,9 +185,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         $this->displayHeader();
         $th_tag->close();
     }
-
-    // }}}
-    // {{{ public function displayHeader()
 
     /**
      * Displays the contents of the header cell for this column.
@@ -241,9 +218,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         }
     }
 
-    // }}}
-    // {{{ public function display()
-
     /**
      * Displays this column using a data object.
      *
@@ -262,9 +236,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         $this->setupRenderers($row);
         $this->displayRenderers($row);
     }
-
-    // }}}
-    // {{{ public function getMessages()
 
     /**
      * Gathers all messages from this column for the given data object.
@@ -287,9 +258,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 
         return $messages;
     }
-
-    // }}}
-    // {{{ public function hasMessage()
 
     /**
      * Gets whether or not this column has any messages for the given data
@@ -318,9 +286,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         return $has_message;
     }
 
-    // }}}
-    // {{{ public function getInlineJavaScript()
-
     /**
      * Gets the inline JavaScript required by this column.
      *
@@ -333,9 +298,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
     {
         return '';
     }
-
-    // }}}
-    // {{{ public function setInputCell()
 
     /**
      * Sets the input cell of this column.
@@ -350,9 +312,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         $this->input_cell = $cell;
         $cell->parent = $this;
     }
-
-    // }}}
-    // {{{ public function getTrAttributes()
 
     /**
      * Gets TR-tag attributes.
@@ -373,9 +332,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         return [];
     }
 
-    // }}}
-    // {{{ public function getInputCell()
-
     /**
      * Gets the input cell of this column.
      *
@@ -393,9 +349,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
     {
         return $this->input_cell;
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Add a child object to this object.
@@ -428,9 +381,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
             );
         }
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -499,9 +449,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -531,9 +478,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         return $out;
     }
 
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this column.
      *
@@ -552,9 +496,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this column.
@@ -577,9 +518,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         return $set;
     }
 
-    // }}}
-    // {{{ public function getTdAttributes()
-
     /**
      * Gets the TD tag attributes for this column.
      *
@@ -593,9 +531,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
             'class' => $this->getCSSClassString(),
         ];
     }
-
-    // }}}
-    // {{{ public function getThAttributes()
 
     /**
      * Gets the TH tag attributes for this column.
@@ -611,9 +546,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         ];
     }
 
-    // }}}
-    // {{{ public function getXhtmlColspan()
-
     /**
      * Gets how many XHTML table columns this column object spans on display.
      *
@@ -624,9 +556,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
     {
         return 1;
     }
-
-    // }}}
-    // {{{ public function hasVisibleRenderer()
 
     /**
      * Whether or not this column has one or more visible cell renderers.
@@ -653,9 +582,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
 
         return $visible_renderers;
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -685,9 +611,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         return $copy;
     }
 
-    // }}}
-    // {{{ protected function displayRenderers()
-
     /**
      * Renders each cell renderer in this column inside a wrapping XHTML
      * element.
@@ -708,9 +631,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         $this->displayRenderersInternal($data);
         $td_tag->close();
     }
-
-    // }}}
-    // {{{ protected function displayRenderersInternal()
 
     /**
      * Renders each cell renderer in this column.
@@ -770,9 +690,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         }
     }
 
-    // }}}
-    // {{{ protected function setupRenderers()
-
     /**
      * Sets properties of renderers using data from current row.
      *
@@ -795,9 +712,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
             $renderer->sensitive = $renderer->sensitive && $sensitive;
         }
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this table-view column.
@@ -873,9 +787,6 @@ class SwatTableViewColumn extends SwatCellRendererContainer
         return $classes;
     }
 
-    // }}}
-    // {{{ protected function getBaseCSSClassNames()
-
     /**
      * Gets the base CSS class names of this table-view column.
      *
@@ -889,6 +800,4 @@ class SwatTableViewColumn extends SwatCellRendererContainer
     {
         return [];
     }
-
-    // }}}
 }

--- a/Swat/SwatTableViewGroup.php
+++ b/Swat/SwatTableViewGroup.php
@@ -14,17 +14,12 @@
  */
 class SwatTableViewGroup extends SwatTableViewColumn
 {
-    // {{{ public properties
-
     /**
      * The field of the table store to group rows by.
      *
      * @var string
      */
     public $group_by;
-
-    // }}}
-    // {{{ private properties
 
     /**
      * The current value of the group_by field of the table model for the
@@ -49,9 +44,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
      * @var mixed
      */
     private $footer_current;
-
-    // }}}
-    // {{{ public function displayFooter()
 
     /**
      * Displays the grouping footer of this table-view group.
@@ -83,9 +75,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
         }
     }
 
-    // }}}
-    // {{{ protected function displayGroupHeader()
-
     /**
      * Displays the group header for this grouping column.
      *
@@ -109,9 +98,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
         $tr_tag->close();
     }
 
-    // }}}
-    // {{{ protected function displayGroupFooter()
-
     /**
      * Displays the group footer for this grouping column.
      *
@@ -123,9 +109,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
      *                   in the table store for this group
      */
     protected function displayGroupFooter($row) {}
-
-    // }}}
-    // {{{ protected function displayRenderers()
 
     /**
      * Displays the renderers for this column.
@@ -156,9 +139,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
         }
     }
 
-    // }}}
-    // {{{ protected function isEqual()
-
     /**
      * Compares the value of the current row to the value of the current
      * group to see if the value has changed.
@@ -181,9 +161,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
         return $group_value === $row_value;
     }
 
-    // }}}
-    // {{{ protected function resetSubGroups()
-
     /**
      * Resets grouping columns below this one.
      *
@@ -205,9 +182,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
         }
     }
 
-    // }}}
-    // {{{ protected function reset()
-
     /**
      * Resets the current value of this grouping column.
      *
@@ -222,9 +196,6 @@ class SwatTableViewGroup extends SwatTableViewColumn
         $this->header_current = null;
     }
 
-    // }}}
-    // {{{ protected function getBaseCSSClassNames()
-
     /**
      * Gets the base CSS class names of this table-view group.
      *
@@ -235,6 +206,4 @@ class SwatTableViewGroup extends SwatTableViewColumn
     {
         return ['swat-table-view-group'];
     }
-
-    // }}}
 }

--- a/Swat/SwatTableViewInputRow.php
+++ b/Swat/SwatTableViewInputRow.php
@@ -18,8 +18,6 @@
  */
 class SwatTableViewInputRow extends SwatTableViewRow
 {
-    // {{{ public properties
-
     /**
      * The text to display in the link to enter a new row.
      *
@@ -55,9 +53,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
      * @var bool
      */
     public $show_row_messages = true;
-
-    // }}}
-    // {{{ private properties
 
     /**
      * The tool-link to create another row.
@@ -97,9 +92,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
      */
     private $replicators = [];
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new input row.
      */
@@ -114,9 +106,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
             'packages/swat/javascript/swat-table-view-input-row.js',
         );
     }
-
-    // }}}
-    // {{{ public function init()
 
     /**
      * Initializes this input row.
@@ -166,9 +155,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
         }
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this input row.
      *
@@ -187,9 +173,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
         }
     }
 
-    // }}}
-    // {{{ public function addInputCell()
-
     /**
      * Adds an input cell to this row from a column.
      *
@@ -207,9 +190,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
     {
         $this->input_cells[$column_id] = $cell;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this row.
@@ -251,9 +231,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
         $this->displayEnterAnotherRow();
     }
 
-    // }}}
-    // {{{ public function addReplication()
-
     /**
      * Add a replicator id.
      *
@@ -267,9 +244,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 
         return end($this->replicators);
     }
-
-    // }}}
-    // {{{ public function getReplicators()
 
     /**
      * Gets the replicator ids of this input row.
@@ -288,9 +262,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
     {
         return $this->replicators;
     }
-
-    // }}}
-    // {{{ public function getWidget()
 
     /**
      * Gets a particular widget in this row.
@@ -327,9 +298,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
         );
     }
 
-    // }}}
-    // {{{ public function getPrototypeWidget()
-
     /**
      * Gets the prototype widget for a column attached to this row.
      *
@@ -364,9 +332,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
         );
     }
 
-    // }}}
-    // {{{ public function removeReplicatedRow()
-
     /**
      * Removes a row from this input row by its replicator id.
      *
@@ -382,9 +347,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
             $cell->unsetWidget($replicator_id);
         }
     }
-
-    // }}}
-    // {{{ public function getVisibleByCount()
 
     /**
      * Gets whether or not to show this row based on a count of rows.
@@ -402,9 +364,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
     {
         return $this->visible;
     }
-
-    // }}}
-    // {{{ public function rowHasMessage()
 
     /**
      * Gets whether or not a given replicated row has messages.
@@ -429,9 +388,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
         return $row_has_message;
     }
 
-    // }}}
-    // {{{ public function getMessages()
-
     /**
      * Gathers all messages from this table-view row.
      *
@@ -452,9 +408,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 
         return $messages;
     }
-
-    // }}}
-    // {{{ public function hasMessage()
 
     /**
      * Gets whether or not the widgets in this row have any messages.
@@ -477,9 +430,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 
         return $has_message;
     }
-
-    // }}}
-    // {{{ public function getInlineJavaScript()
 
     /**
      * Creates a JavaScript object to control the client behaviour of this
@@ -517,9 +467,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
         );
     }
 
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this input row.
      *
@@ -537,9 +484,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this input row.
@@ -561,9 +505,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
         return $set;
     }
 
-    // }}}
-    // {{{ private function getId()
-
     private function getId()
     {
         $id = $this->id;
@@ -574,9 +515,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
 
         return $id;
     }
-
-    // }}}
-    // {{{ private function displayInputRows()
 
     /**
      * Displays the actual XHTML input rows for this input row.
@@ -678,9 +616,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
         }
     }
 
-    // }}}
-    // {{{ private function createEmbeddedWidgets()
-
     /**
      * Instantiates the tool-link for this input row.
      */
@@ -696,9 +631,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
             $this->widgets_created = true;
         }
     }
-
-    // }}}
-    // {{{ private function displayEnterAnotherRow()
 
     /**
      * Displays the enter-another-row row.
@@ -761,9 +693,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
         $tr_tag->close();
     }
 
-    // }}}
-    // {{{ private function getRowString()
-
     /**
      * Gets this input row as an XHTML table row with the row identifier as a
      * placeholder '%s'.
@@ -810,9 +739,6 @@ class SwatTableViewInputRow extends SwatTableViewRow
         return ob_get_clean();
     }
 
-    // }}}
-    // {{{ private function getForm()
-
     /**
      * Gets the form this row's view is contained in.
      *
@@ -833,6 +759,4 @@ class SwatTableViewInputRow extends SwatTableViewRow
 
         return $form;
     }
-
-    // }}}
 }

--- a/Swat/SwatTableViewOrderableColumn.php
+++ b/Swat/SwatTableViewOrderableColumn.php
@@ -14,8 +14,6 @@
  */
 class SwatTableViewOrderableColumn extends SwatTableViewColumn
 {
-    // {{{ constants
-
     /**
      * Indicates no ordering is done.
      */
@@ -40,9 +38,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
      * Indicates ascending ordering is done.
      */
     public const NULLS_LAST = 2;
-
-    // }}}
-    // {{{ public properties
 
     /**
      * The base of the link used when building column header links.
@@ -82,9 +77,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
      */
     public $unset_get_vars = [];
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * The direction of ordering.
      *
@@ -114,9 +106,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
      */
     protected $default_direction = self::ORDER_BY_DIR_NONE;
 
-    // }}}
-    // {{{ private properties
-
     /**
      * The mode of ordering.
      *
@@ -126,9 +115,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
      * @var int
      */
     // private $mode = SwatTableViewOrderableColumn::ORDER_MODE_TRISTATE;
-
-    // }}}
-    // {{{ public function init()
 
     /**
      * Initializes this column.
@@ -140,9 +126,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
         parent::init();
         $this->initFromGetVariables();
     }
-
-    // }}}
-    // {{{ public function setDirection()
 
     /**
      * Sets the direction of ordering.
@@ -169,9 +152,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 
         $this->initFromGetVariables();
     }
-
-    // }}}
-    // {{{ public function displayHeader()
 
     /**
      * Displays the column header for this table view column.
@@ -213,9 +193,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
 
         $anchor->close();
     }
-
-    // }}}
-    // {{{ public function getDirectionAsString()
 
     /**
      * Gets the direction of ordering as a string.
@@ -286,9 +263,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
         return $direction;
     }
 
-    // }}}
-    // {{{ protected function displayTitle()
-
     protected function displayTitle($title, $content_type)
     {
         // Display last word of the title in its own span so it can be styled
@@ -314,9 +288,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
         $span_tag->display();
     }
 
-    // }}}
-    // {{{ protected function getBaseCSSClassNames()
-
     /**
      * Gets the base CSS class names of this orderable table-view column.
      *
@@ -334,9 +305,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
         return $classes;
     }
 
-    // }}}
-    // {{{ protected function getLinkPrefix()
-
     /**
      * Gets the prefix for GET var links.
      *
@@ -347,9 +315,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
         // TODO: is id a required field of table views?
         return $this->view->id . '_';
     }
-
-    // }}}
-    // {{{ protected function getNextDirection()
 
     /**
      * Gets the next direction or ordering in the rotation.
@@ -380,9 +345,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
         }
     }
 
-    // }}}
-    // {{{ private function setDirectionByString()
-
     /**
      * Sets direction of ordering by a string.
      *
@@ -412,9 +374,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
                 $this->direction = self::ORDER_BY_DIR_NONE;
         }
     }
-
-    // }}}
-    // {{{ private function getLink()
 
     /**
      * Gets the link for this column's header.
@@ -467,9 +426,6 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
         return $link;
     }
 
-    // }}}
-    // {{{ private function initFromGetVariables()
-
     /**
      * Process GET variables and set class variables.
      */
@@ -486,6 +442,4 @@ class SwatTableViewOrderableColumn extends SwatTableViewColumn
             }
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatTableViewRow.php
+++ b/Swat/SwatTableViewRow.php
@@ -8,8 +8,6 @@
  */
 abstract class SwatTableViewRow extends SwatUIObject
 {
-    // {{{ public properties
-
     /**
      * The {@link SwatTableView} associated with this row.
      *
@@ -23,9 +21,6 @@ abstract class SwatTableViewRow extends SwatUIObject
      * @param string
      */
     public $id;
-
-    // }}}
-    // {{{ protected properties
 
     /**
      * Whether or not this row has been processed.
@@ -45,9 +40,6 @@ abstract class SwatTableViewRow extends SwatUIObject
      */
     protected $displayed = false;
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this row.
      *
@@ -58,9 +50,6 @@ abstract class SwatTableViewRow extends SwatUIObject
      * initialized after columns.
      */
     public function init() {}
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this row.
@@ -76,9 +65,6 @@ abstract class SwatTableViewRow extends SwatUIObject
         $this->processed = true;
     }
 
-    // }}}
-    // {{{ public function display()
-
     /**
      * Displays this row.
      */
@@ -86,9 +72,6 @@ abstract class SwatTableViewRow extends SwatUIObject
     {
         $this->displayed = true;
     }
-
-    // }}}
-    // {{{ public function isProcessed()
 
     /**
      * Whether or not this row is processed.
@@ -100,9 +83,6 @@ abstract class SwatTableViewRow extends SwatUIObject
         return $this->processed;
     }
 
-    // }}}
-    // {{{ public function isDisplayed()
-
     /**
      * Whether or not this row is displayed.
      *
@@ -112,9 +92,6 @@ abstract class SwatTableViewRow extends SwatUIObject
     {
         return $this->displayed;
     }
-
-    // }}}
-    // {{{ public function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript required by this row.
@@ -128,9 +105,6 @@ abstract class SwatTableViewRow extends SwatUIObject
     {
         return '';
     }
-
-    // }}}
-    // {{{ public function getVisibleByCount()
 
     /**
      * Gets whether or not to show this row based on a count of rows.
@@ -147,9 +121,6 @@ abstract class SwatTableViewRow extends SwatUIObject
     {
         return $count > 0;
     }
-
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this row.
@@ -171,9 +142,6 @@ abstract class SwatTableViewRow extends SwatUIObject
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this row.
      *
@@ -185,9 +153,6 @@ abstract class SwatTableViewRow extends SwatUIObject
         return new SwatHtmlHeadEntrySet($this->html_head_entry_set);
     }
 
-    // }}}
-    // {{{ public function getMessages()
-
     /**
      * Gathers all messages from this table-view row.
      *
@@ -197,9 +162,6 @@ abstract class SwatTableViewRow extends SwatUIObject
     {
         return [];
     }
-
-    // }}}
-    // {{{ public function hasMessage()
 
     /**
      * Gets whether or this row has any messages.
@@ -211,9 +173,6 @@ abstract class SwatTableViewRow extends SwatUIObject
     {
         return false;
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -236,6 +195,4 @@ abstract class SwatTableViewRow extends SwatUIObject
 
         return $copy;
     }
-
-    // }}}
 }

--- a/Swat/SwatTableViewSpanningColumn.php
+++ b/Swat/SwatTableViewSpanningColumn.php
@@ -8,17 +8,12 @@
  */
 class SwatTableViewSpanningColumn extends SwatTableViewColumn
 {
-    // {{{ public properties
-
     /**
      * The number of columns to offset to the right.
      *
      * @var int
      */
     public $offset = 0;
-
-    // }}}
-    // {{{ protected function displayRenderers()
 
     /**
      * Renders each cell renderer in this column inside a wrapping XHTML
@@ -59,9 +54,6 @@ class SwatTableViewSpanningColumn extends SwatTableViewColumn
         $td_tag->close();
     }
 
-    // }}}
-    // {{{ public function getXhtmlColspan()
-
     /**
      * Gets how many XHTML table columns this column object spans on display.
      *
@@ -80,6 +72,4 @@ class SwatTableViewSpanningColumn extends SwatTableViewColumn
 
         return $colspan;
     }
-
-    // }}}
 }

--- a/Swat/SwatTableViewWidgetRow.php
+++ b/Swat/SwatTableViewWidgetRow.php
@@ -8,8 +8,6 @@
  */
 class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 {
-    // {{{ class constants
-
     /**
      * Display the widget in the left cell.
      */
@@ -19,9 +17,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
      * Display the widget in the right cell.
      */
     public const POSITION_RIGHT = 1;
-
-    // }}}
-    // {{{ public properties
 
     /**
      * How far from the end of the row the widget should be displayed measured
@@ -49,9 +44,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
      */
     public $position = self::POSITION_LEFT;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * The contained widget.
      *
@@ -60,9 +52,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
      * @see SwatTableViewWidgetRow::setWidget()
      */
     protected $widget;
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Adds a child object.
@@ -101,9 +90,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 
         $this->setWidget($child);
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -152,9 +138,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -184,9 +167,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -207,9 +187,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
         return $states;
     }
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -227,9 +204,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ public function setWidget()
 
     /**
      * Sets the widget contained in this row.
@@ -251,9 +225,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
         $widget->parent = $this;
     }
 
-    // }}}
-    // {{{ public function getWidget()
-
     /**
      * Gets the widget contained in this row.
      *
@@ -265,9 +236,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
         return $this->widget;
     }
 
-    // }}}
-    // {{{ public function init()
-
     public function init()
     {
         parent::init();
@@ -277,9 +245,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function process()
-
     public function process()
     {
         parent::process();
@@ -288,9 +253,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
             $this->widget->process();
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     public function display()
     {
@@ -322,9 +284,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
         $tr_tag->close();
     }
 
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this row.
      *
@@ -345,9 +304,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this row.
      *
@@ -364,9 +320,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -392,9 +345,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
         return $copy;
     }
 
-    // }}}
-    // {{{ public function getMessages()
-
     /**
      * Gathers all messages from this table-view-row.
      *
@@ -410,9 +360,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 
         return $messages;
     }
-
-    // }}}
-    // {{{ public function hasMessage()
 
     /**
      * Gets whether or not the widgets in this row have any messages.
@@ -433,9 +380,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
         return $has_message;
     }
 
-    // }}}
-    // {{{ protected function displayOffsetCell()
-
     protected function displayOffsetCell($offset)
     {
         $td_tag = new SwatHtmlTag('td');
@@ -445,9 +389,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
         echo '&nbsp;';
         $td_tag->close();
     }
-
-    // }}}
-    // {{{ protected function displayWidgetCell()
 
     protected function displayWidgetCell()
     {
@@ -460,9 +401,6 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
         $td_tag->close();
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this row.
      *
@@ -474,6 +412,4 @@ class SwatTableViewWidgetRow extends SwatTableViewRow implements SwatUIParent
 
         return array_merge($classes, $this->classes);
     }
-
-    // }}}
 }

--- a/Swat/SwatTextCellRenderer.php
+++ b/Swat/SwatTextCellRenderer.php
@@ -8,8 +8,6 @@
  */
 class SwatTextCellRenderer extends SwatCellRenderer
 {
-    // {{{ public properties
-
     /**
      * The textual content to place within this cell.
      *
@@ -47,9 +45,6 @@ class SwatTextCellRenderer extends SwatCellRenderer
      */
     public $value;
 
-    // }}}
-    // {{{ public function render()
-
     /**
      * Renders the contents of this cell.
      *
@@ -77,6 +72,4 @@ class SwatTextCellRenderer extends SwatCellRenderer
             echo $text;
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatTextarea.php
+++ b/Swat/SwatTextarea.php
@@ -8,8 +8,6 @@
  */
 class SwatTextarea extends SwatInputControl implements SwatState
 {
-    // {{{ public properties
-
     /**
      * Text content of the widget.
      *
@@ -98,9 +96,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
      */
     public $placeholder;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new textarea widget.
      *
@@ -115,9 +110,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
         parent::__construct($id);
         $this->addStyleSheet('packages/swat/styles/swat-textarea.css');
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this textarea.
@@ -141,9 +133,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
 
         $div_tag->close();
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this textarea.
@@ -182,9 +171,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
         }
     }
 
-    // }}}
-    // {{{ public function getState()
-
     /**
      * Gets the current state of this textarea.
      *
@@ -197,9 +183,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
         return $this->value;
     }
 
-    // }}}
-    // {{{ public function setState()
-
     /**
      * Sets the current state of this textarea.
      *
@@ -211,9 +194,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
     {
         $this->value = $state;
     }
-
-    // }}}
-    // {{{ public function getFocusableHtmlId()
 
     /**
      * Gets the id attribute of the XHTML element displayed by this widget
@@ -229,9 +209,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
     {
         return $this->visible ? $this->id : null;
     }
-
-    // }}}
-    // {{{ protected function getTextareaTag()
 
     /**
      * Gets the textarea tag used to display this textarea control.
@@ -275,9 +252,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
         return $textarea_tag;
     }
 
-    // }}}
-    // {{{ protected function getValueLength()
-
     /**
      * Gets the computed length of the value of this textarea.
      *
@@ -297,9 +271,6 @@ class SwatTextarea extends SwatInputControl implements SwatState
         return $length;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this textarea.
      *
@@ -315,6 +286,4 @@ class SwatTextarea extends SwatInputControl implements SwatState
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -12,13 +12,8 @@
  */
 class SwatTextareaEditor extends SwatTextarea
 {
-    // {{{ class constants
-
     public const MODE_VISUAL = 1;
     public const MODE_SOURCE = 2;
-
-    // }}}
-    // {{{ public properties
 
     public static $tiny_mce_api_key;
 
@@ -134,9 +129,6 @@ class SwatTextareaEditor extends SwatTextarea
      */
     public $basehref;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new what-you-see-is-what-you-get XHTML textarea editor.
      *
@@ -165,9 +157,6 @@ class SwatTextareaEditor extends SwatTextarea
             'packages/swat/javascript/swat-z-index-manager.js',
         );
     }
-
-    // }}}
-    // {{{ public function display()
 
     public function display()
     {
@@ -232,9 +221,6 @@ class SwatTextareaEditor extends SwatTextarea
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ public function getFocusableHtmlId()
-
     /**
      * Gets the id attribute of the XHTML element displayed by this widget
      * that should receive focus.
@@ -249,9 +235,6 @@ class SwatTextareaEditor extends SwatTextarea
     {
         return null;
     }
-
-    // }}}
-    // {{{ protected function getConfig()
 
     protected function getConfig()
     {
@@ -294,9 +277,6 @@ class SwatTextareaEditor extends SwatTextarea
         ];
     }
 
-    // }}}
-    // {{{ protected function getConfigButtons()
-
     protected function getConfigButtons()
     {
         return [
@@ -323,9 +303,6 @@ class SwatTextareaEditor extends SwatTextarea
         ];
     }
 
-    // }}}
-    // {{{ protected function displayColorMap()
-
     protected function displayColorMap()
     {
         if (self::$color_map !== null) {
@@ -338,9 +315,6 @@ class SwatTextareaEditor extends SwatTextarea
             echo "    ],\n";
         }
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     protected function getInlineJavaScript()
     {
@@ -497,9 +471,6 @@ class SwatTextareaEditor extends SwatTextarea
         return ob_get_clean();
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this textarea.
      *
@@ -511,6 +482,4 @@ class SwatTextareaEditor extends SwatTextarea
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatTile.php
+++ b/Swat/SwatTile.php
@@ -11,8 +11,6 @@
  */
 class SwatTile extends SwatCellRendererContainer
 {
-    // {{{ public properties
-
     /**
      * Whether or not to include CSS classes from the first cell renderer
      * of this tile in this tile's CSS classes.
@@ -21,18 +19,12 @@ class SwatTile extends SwatCellRendererContainer
      */
     public $show_renderer_classes = true;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * Messages affixed to this tile.
      *
      * @var array
      */
     protected $messages = [];
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this tile using a data object.
@@ -50,9 +42,6 @@ class SwatTile extends SwatCellRendererContainer
         $this->displayRenderers($data);
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this tile.
      *
@@ -65,9 +54,6 @@ class SwatTile extends SwatCellRendererContainer
         }
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this tile.
      *
@@ -79,9 +65,6 @@ class SwatTile extends SwatCellRendererContainer
             $renderer->process();
         }
     }
-
-    // }}}
-    // {{{ public function getMessages()
 
     /**
      * Gathers all messages from this tile.
@@ -99,9 +82,6 @@ class SwatTile extends SwatCellRendererContainer
         return $messages;
     }
 
-    // }}}
-    // {{{ public function addMessages()
-
     /**
      * Adds a message to this tile.
      *
@@ -113,9 +93,6 @@ class SwatTile extends SwatCellRendererContainer
     {
         $this->messages[] = $message;
     }
-
-    // }}}
-    // {{{ public function hasMessage()
 
     /**
      * Gets whether or not this tile has any messages.
@@ -136,9 +113,6 @@ class SwatTile extends SwatCellRendererContainer
 
         return $has_message;
     }
-
-    // }}}
-    // {{{ protected function setupRenderers()
 
     /**
      * Sets properties of renderers using data from current row.
@@ -163,9 +137,6 @@ class SwatTile extends SwatCellRendererContainer
         }
     }
 
-    // }}}
-    // {{{ protected function displayRenderers()
-
     /**
      * Renders cell renderers.
      *
@@ -180,9 +151,6 @@ class SwatTile extends SwatCellRendererContainer
         $this->displayRenderersInternal($data);
         $div_tag->close();
     }
-
-    // }}}
-    // {{{ protected function displayRenderersInternal()
 
     /**
      * Renders each cell renderer in this tile.
@@ -228,9 +196,6 @@ class SwatTile extends SwatCellRendererContainer
             }
         }
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this tile.
@@ -295,9 +260,6 @@ class SwatTile extends SwatCellRendererContainer
         return $classes;
     }
 
-    // }}}
-    // {{{ protected function getBaseCSSClassNames()
-
     /**
      * Gets the base CSS class names of this tile.
      *
@@ -310,6 +272,4 @@ class SwatTile extends SwatCellRendererContainer
     {
         return ['swat-tile'];
     }
-
-    // }}}
 }

--- a/Swat/SwatTileView.php
+++ b/Swat/SwatTileView.php
@@ -15,8 +15,6 @@
  */
 class SwatTileView extends SwatView implements SwatUIParent
 {
-    // {{{ public properties
-
     /**
      * Whether to show a "check all" widget.
      *
@@ -106,9 +104,6 @@ class SwatTileView extends SwatView implements SwatUIParent
      */
     public $no_records_message_type = 'text/plain';
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * The groups of this tile-view indexed by their unique identifier.
      *
@@ -131,18 +126,12 @@ class SwatTileView extends SwatView implements SwatUIParent
      */
     protected $groups = [];
 
-    // }}}
-    // {{{ private properties
-
     /**
      * The tile of this tile view.
      *
      * @var SwatTile
      */
     private $tile;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new tile view.
@@ -158,9 +147,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         $this->addStyleSheet('packages/swat/styles/swat-tile-view.css');
         $this->addJavaScript('packages/swat/javascript/swat-tile-view.js');
     }
-
-    // }}}
-    // {{{ public function init()
 
     /**
      * Initializes this tile view.
@@ -185,9 +171,6 @@ class SwatTileView extends SwatView implements SwatUIParent
             }
         }
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this tile view.
@@ -214,9 +197,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function isExtendedCheckAllSelected()
-
     /**
      * Whether or not the extended-check-all check-box was checked.
      *
@@ -228,9 +208,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 
         return $check_all->isExtendedSelected();
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this tile view.
@@ -295,9 +272,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         Swat::displayInlineJavaScript($this->getInlineJavaScript());
     }
 
-    // }}}
-    // {{{ public function displayTiles()
-
     /**
      * Displays the tiles of this tile view.
      */
@@ -359,9 +333,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function displayTile()
-
     /**
      * Displays a simgle tile of this tile view.
      *
@@ -373,9 +344,6 @@ class SwatTileView extends SwatView implements SwatUIParent
     {
         $this->tile->display($record);
     }
-
-    // }}}
-    // {{{ public function displayTileGroupHeaders()
 
     /**
      * Displays tile group headers.
@@ -391,9 +359,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function displayTileGroupFooters()
-
     /**
      * Displays tile group footers.
      *
@@ -407,9 +372,6 @@ class SwatTileView extends SwatView implements SwatUIParent
             $group->displayFooter($record, $next_record);
         }
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Adds a child object.
@@ -451,9 +413,6 @@ class SwatTileView extends SwatView implements SwatUIParent
             );
         }
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -516,9 +475,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -548,9 +504,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         return $out;
     }
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -571,9 +524,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         return $states;
     }
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -592,9 +542,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         }
     }
 
-    // }}}
-    // {{{ public function getMessages()
-
     /**
      * Gathers all messages from this tile view.
      *
@@ -609,9 +556,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 
         return $messages;
     }
-
-    // }}}
-    // {{{ public function hasMessage()
 
     /**
      * Gets whether or not this tile view has any messages.
@@ -628,9 +572,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 
         return $has_message;
     }
-
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this tile view.
@@ -655,9 +596,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this tile view.
      *
@@ -680,9 +618,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -720,9 +655,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 
         return $copy;
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript required for this tile view.
@@ -768,9 +700,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         return $javascript;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this tile view.
      *
@@ -783,9 +712,6 @@ class SwatTileView extends SwatView implements SwatUIParent
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function showCheckAll()
 
     /**
      * Whether or not a check-all widget is to be displayed for the tiles
@@ -817,9 +743,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         return $show;
     }
 
-    // }}}
-    // {{{ protected function getCheckboxCellRenderer()
-
     /**
      * Gets the first checkbox cell renderer in this tile view's tile.
      *
@@ -841,9 +764,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         return $checkbox_cell_renderer;
     }
 
-    // }}}
-    // {{{ protected function createCompositeWidgets()
-
     /**
      * Creates the composite check-all widget used by this tile view.
      */
@@ -855,10 +775,7 @@ class SwatTileView extends SwatView implements SwatUIParent
         }
     }
 
-    // }}}
-
     // tile methods
-    // {{{ public function getTile()
 
     /**
      * Gets a reference to a tile contained in the view.
@@ -869,9 +786,6 @@ class SwatTileView extends SwatView implements SwatUIParent
     {
         return $this->tile;
     }
-
-    // }}}
-    // {{{ public function setTile()
 
     /**
      * Sets a tile of this tile view.
@@ -889,10 +803,7 @@ class SwatTileView extends SwatView implements SwatUIParent
         $tile->parent = $this;
     }
 
-    // }}}
-
     // grouping methods
-    // {{{ public function appendGroup()
 
     /**
      * Appends a grouping object to this tile-view.
@@ -925,9 +836,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         $group->parent = $this;
     }
 
-    // }}}
-    // {{{ public function hasGroup()
-
     /**
      * Returns true if a group with the given id exists within this tile-view.
      *
@@ -941,9 +849,6 @@ class SwatTileView extends SwatView implements SwatUIParent
     {
         return array_key_exists($id, $this->groups_by_id);
     }
-
-    // }}}
-    // {{{ public function getGroup()
 
     /**
      * Gets a group in this tile-view by the group's id.
@@ -966,9 +871,6 @@ class SwatTileView extends SwatView implements SwatUIParent
         return $this->groups_by_id[$id];
     }
 
-    // }}}
-    // {{{ public function getGroups()
-
     /**
      * Gets all groups of this tile-view as an array.
      *
@@ -978,9 +880,6 @@ class SwatTileView extends SwatView implements SwatUIParent
     {
         return $this->groups;
     }
-
-    // }}}
-    // {{{ protected function validateGroup()
 
     /**
      * Ensures a group added to this tile-view is valid for this tile-view.
@@ -1005,6 +904,4 @@ class SwatTileView extends SwatView implements SwatUIParent
             }
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatTileViewGroup.php
+++ b/Swat/SwatTileViewGroup.php
@@ -14,8 +14,6 @@
  */
 class SwatTileViewGroup extends SwatTile
 {
-    // {{{ public properties
-
     /**
      * Unique identifier of this group.
      *
@@ -30,9 +28,6 @@ class SwatTileViewGroup extends SwatTile
      */
     public $group_by;
 
-    // }}}
-    // {{{ private properties
-
     /**
      * The current value of the group_by field of the tile view for the
      * grouping header.
@@ -44,9 +39,6 @@ class SwatTileViewGroup extends SwatTile
      * @var mixed
      */
     private $header_current;
-
-    // }}}
-    // {{{ public function displayFooter()
 
     /**
      * Displays the grouping footer of this tile-view group.
@@ -78,9 +70,6 @@ class SwatTileViewGroup extends SwatTile
         }
     }
 
-    // }}}
-    // {{{ protected function displayGroupHeader()
-
     /**
      * Displays the group header for this grouping tile.
      *
@@ -108,9 +97,6 @@ class SwatTileViewGroup extends SwatTile
         $div_tag->close();
     }
 
-    // }}}
-    // {{{ protected function displayGroupFooter()
-
     /**
      * Displays the group footer for this grouping tile.
      *
@@ -122,9 +108,6 @@ class SwatTileViewGroup extends SwatTile
      *                   in the table model for this group
      */
     protected function displayGroupFooter($row) {}
-
-    // }}}
-    // {{{ protected function displayRenderers()
 
     /**
      * Displays the renderers for this tile.
@@ -155,9 +138,6 @@ class SwatTileViewGroup extends SwatTile
         }
     }
 
-    // }}}
-    // {{{ protected function isEqual()
-
     /**
      * Compares the value of the current row to the value of the current
      * group to see if the value has changed.
@@ -180,9 +160,6 @@ class SwatTileViewGroup extends SwatTile
         return $group_value === $row_value;
     }
 
-    // }}}
-    // {{{ protected function resetSubGroups()
-
     /**
      * Resets grouping tiles below this one.
      *
@@ -204,9 +181,6 @@ class SwatTileViewGroup extends SwatTile
         }
     }
 
-    // }}}
-    // {{{ protected function reset()
-
     /**
      * Resets the current value of this grouping tile.
      *
@@ -220,6 +194,4 @@ class SwatTileViewGroup extends SwatTile
     {
         $this->header_current = null;
     }
-
-    // }}}
 }

--- a/Swat/SwatTimeEntry.php
+++ b/Swat/SwatTimeEntry.php
@@ -10,14 +10,9 @@
  */
 class SwatTimeEntry extends SwatInputControl implements SwatState
 {
-    // {{{ constants
-
     public const HOUR = 1;
     public const MINUTE = 2;
     public const SECOND = 4;
-
-    // }}}
-    // {{{ public properties
 
     /**
      * Time of this time entry widget.
@@ -102,9 +97,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
      */
     public $use_current_time = true;
 
-    // }}}
-    // {{{ private properties
-
     /**
      * Default year value used for time value.
      *
@@ -131,9 +123,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
      * @var int
      */
     private static $date_day = 1;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new time entry widget.
@@ -169,9 +158,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
             = preg_match('/(%T|%R|%k|.*%H.*)/', $locale_format) === 0;
     }
 
-    // }}}
-    // {{{ public function __clone()
-
     /**
      * Clones the valid time range of this time entry.
      */
@@ -180,9 +166,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         $this->valid_range_start = clone $this->valid_range_start;
         $this->valid_range_end = clone $this->valid_range_end;
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this time entry.
@@ -269,9 +252,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 
         $div_tag->close();
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this time entry.
@@ -409,9 +389,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         }
     }
 
-    // }}}
-    // {{{ public function getState()
-
     /**
      * Gets the current state of this time entry widget.
      *
@@ -428,9 +405,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         return $this->value->getDate();
     }
 
-    // }}}
-    // {{{ public function setState()
-
     /**
      * Sets the current state of this time entry widget.
      *
@@ -442,9 +416,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
     {
         $this->value = new SwatDate($state);
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this time entry widget.
@@ -458,9 +429,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function getInlineJavaScript()
 
     /**
      * Gets the inline JavaScript required for this control.
@@ -538,9 +506,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         return $javascript;
     }
 
-    // }}}
-    // {{{ protected function validateRanges()
-
     /**
      * Makes sure the date the user entered is within the valid range.
      *
@@ -572,9 +537,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         }
     }
 
-    // }}}
-    // {{{ protected function isStartTimeValid()
-
     /**
      * Checks if the entered time is valid with respect to the valid start
      * time.
@@ -597,9 +559,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         ) >= 0;
     }
 
-    // }}}
-    // {{{ protected function isEndTimeValid()
-
     /**
      * Checks if the entered time is valid with respect to the valid end time.
      *
@@ -617,9 +576,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         return SwatDate::compare($this->value, $this->valid_range_end, true)
             <= 0;
     }
-
-    // }}}
-    // {{{ protected function createCompositeWidgets()
 
     /**
      * Creates the composite widgets used by this time entry.
@@ -657,9 +613,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         }
     }
 
-    // }}}
-    // {{{ private function createHourFlydown()
-
     /**
      * Creates the hour flydown for this time entry.
      *
@@ -683,9 +636,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         return $flydown;
     }
 
-    // }}}
-    // {{{ private function createMinuteFlydown()
-
     /**
      * Creates the minute flydown for this time entry.
      *
@@ -702,9 +652,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 
         return $flydown;
     }
-
-    // }}}
-    // {{{ private function createSecondFlydown()
 
     /**
      * Creates the second flydown for this time entry.
@@ -723,9 +670,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         return $flydown;
     }
 
-    // }}}
-    // {{{ private function createAmPmFlydown()
-
     /**
      * Creates the am/pm flydown for this time entry.
      *
@@ -742,9 +686,6 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 
         return $flydown;
     }
-
-    // }}}
-    // {{{ private function getFormattedTime()
 
     /**
      * Formats a time for display in error messages.
@@ -781,6 +722,4 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
 
         return $time->formatLikeIntl($format);
     }
-
-    // }}}
 }

--- a/Swat/SwatTimeZoneEntry.php
+++ b/Swat/SwatTimeZoneEntry.php
@@ -8,8 +8,6 @@
  */
 class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 {
-    // {{{ public properties
-
     /**
      * Time zone identifier.
      *
@@ -18,9 +16,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
      * @var string
      */
     public $value;
-
-    // }}}
-    // {{{ private properties
 
     /**
      * Time zone areas available for this time zone entry widget.
@@ -39,9 +34,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
      * @var array
      */
     private $regions = [];
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new time zone selector widget.
@@ -71,9 +63,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
         $time_zone_list = $this->parseAreaWhitelist($area_whitelist);
         $this->setAreas($time_zone_list);
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this time zone entry widget.
@@ -105,9 +94,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 
         $div_tag->close();
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this time zone entry widget.
@@ -150,9 +136,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
         }
     }
 
-    // }}}
-    // {{{ public function getState()
-
     /**
      * Gets the current state of this time zone entry widget.
      *
@@ -165,9 +148,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
         return $this->value;
     }
 
-    // }}}
-    // {{{ public function setState()
-
     /**
      * Sets the current state of this time zone entry widget.
      *
@@ -179,9 +159,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
     {
         $this->value = $state;
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this time zone entry
@@ -196,9 +173,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
-    // {{{ protected function createCompositeWidgets()
 
     /**
      * Creates all internal widgets required for this time zone entry.
@@ -218,9 +192,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
         $regions_flydown->width = '15em';
         $this->addCompositeWidget($regions_flydown, 'regions_flydown');
     }
-
-    // }}}
-    // {{{ private function parseAreaWhitelist()
 
     /**
      * Parses a whitelist of valid areas.
@@ -258,9 +229,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
         return $areas;
     }
 
-    // }}}
-    // {{{ private function setAreas()
-
     /**
      * Sets areas.
      *
@@ -285,9 +253,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
             $this->setRegions($regions, $area);
         }
     }
-
-    // }}}
-    // {{{ private function setRegions()
 
     /**
      * Builds the internal array of {@link SwatOption} objects for the
@@ -319,9 +284,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
         }
     }
 
-    // }}}
-    // {{{ private function getArea()
-
     /**
      * Gets an area from a time zone identifier.
      *
@@ -345,9 +307,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
         return $area;
     }
 
-    // }}}
-    // {{{ private function getRegion()
-
     /**
      * Gets a region from a time zone identifier.
      *
@@ -370,9 +329,6 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
         return $region;
     }
 
-    // }}}
-    // {{{ private function getRegionTitle()
-
     /**
      * Gets a formatted region title from the region part of a time zone
      * identifier.
@@ -393,6 +349,4 @@ class SwatTimeZoneEntry extends SwatInputControl implements SwatState
 
         return $title;
     }
-
-    // }}}
 }

--- a/Swat/SwatTitleable.php
+++ b/Swat/SwatTitleable.php
@@ -10,17 +10,12 @@
  */
 interface SwatTitleable
 {
-    // {{{ public function getTitle()
-
     /**
      * Gets the title of this object.
      *
      * @return string the title of this object
      */
     public function getTitle();
-
-    // }}}
-    // {{{ public function getTitleContentType()
 
     /**
      * Gets the content-type of the title of this object.
@@ -30,6 +25,4 @@ interface SwatTitleable
      *                plain text.
      */
     public function getTitleContentType();
-
-    // }}}
 }

--- a/Swat/SwatToolLink.php
+++ b/Swat/SwatToolLink.php
@@ -8,8 +8,6 @@
  */
 class SwatToolLink extends SwatControl
 {
-    // {{{ public properties
-
     /**
      * The href attribute in the XHTML anchor tag.
      *
@@ -92,18 +90,12 @@ class SwatToolLink extends SwatControl
      */
     public $target;
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * A CSS class set by the stock_id of this tool link.
      *
      * @var string
      */
     protected $stock_class;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new toollink.
@@ -118,9 +110,6 @@ class SwatToolLink extends SwatControl
 
         $this->addStyleSheet('packages/swat/styles/swat-tool-link.css');
     }
-
-    // }}}
-    // {{{ public function init()
 
     /**
      * Initializes this widget.
@@ -137,9 +126,6 @@ class SwatToolLink extends SwatControl
             $this->setFromStock($this->stock_id, false);
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this tool link.
@@ -178,9 +164,6 @@ class SwatToolLink extends SwatControl
 
         $tag->close();
     }
-
-    // }}}
-    // {{{ public function setFromStock()
 
     /**
      * Sets the values of this tool link to a stock type.
@@ -277,9 +260,6 @@ class SwatToolLink extends SwatControl
         $this->stock_class = $class;
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this tool link.
      *
@@ -300,9 +280,6 @@ class SwatToolLink extends SwatControl
 
         return array_merge($classes, $this->classes);
     }
-
-    // }}}
-    // {{{ protected function getSensitiveTag()
 
     /**
      * Gets the tag used to display this tool link when it is sensitive.
@@ -338,9 +315,6 @@ class SwatToolLink extends SwatControl
         return $tag;
     }
 
-    // }}}
-    // {{{ protected function getInsensitiveTag()
-
     /**
      * Gets the tag used to display this tool link when it is not sensitive.
      *
@@ -360,6 +334,4 @@ class SwatToolLink extends SwatControl
 
         return $tag;
     }
-
-    // }}}
 }

--- a/Swat/SwatToolbar.php
+++ b/Swat/SwatToolbar.php
@@ -8,8 +8,6 @@
  */
 class SwatToolbar extends SwatDisplayableContainer
 {
-    // {{{ public function __construct()
-
     /**
      * Creates a new toolbar.
      *
@@ -23,9 +21,6 @@ class SwatToolbar extends SwatDisplayableContainer
 
         $this->addStyleSheet('packages/swat/styles/swat-toolbar.css');
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this toolbar as an unordered list with each sub-item
@@ -48,9 +43,6 @@ class SwatToolbar extends SwatDisplayableContainer
         $toolbar_ul->close();
     }
 
-    // }}}
-    // {{{ public function setToolLinkValues()
-
     /**
      * Sets the value of all {@link SwatToolLink} objects within this toolbar.
      *
@@ -65,9 +57,6 @@ class SwatToolbar extends SwatDisplayableContainer
             $tool->value = $value;
         }
     }
-
-    // }}}
-    // {{{ public function getToolLinks()
 
     /**
      * Gets the tool links of this toolbar.
@@ -89,9 +78,6 @@ class SwatToolbar extends SwatDisplayableContainer
         return $tools;
     }
 
-    // }}}
-    // {{{ protected function displayChildren()
-
     /**
      * Displays the child widgets of this container.
      */
@@ -106,9 +92,6 @@ class SwatToolbar extends SwatDisplayableContainer
             }
         }
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this tool bar.
@@ -128,6 +111,4 @@ class SwatToolbar extends SwatDisplayableContainer
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatTreeFlydown.php
+++ b/Swat/SwatTreeFlydown.php
@@ -129,27 +129,16 @@ class SwatTreeFlydown extends SwatFlydown
      * @param SwatDataTreeNode|SwatTreeFlydownNode $tree the tree to use for
      *                                                   display
      */
-    public function setTree($tree): void
+    public function setTree(SwatDataTreeNode|SwatTreeFlydownNode $tree): void
     {
-        if ($tree instanceof SwatDataTreeNode) {
-            $tree = SwatTreeFlydownNode::convertFromDataTree($tree);
-        } elseif (!$tree instanceof SwatTreeFlydownNode) {
-            throw new SwatInvalidClassException(
-                'Tree must be an intance of '
-                    . 'either SwatDataTreeNode or SwatTreeFlydownNode.',
-                0,
-                $tree,
-            );
-        }
-
-        $this->tree = $tree;
+        $this->tree = $this->normalizeTree($tree);
     }
 
     /**
      * Gets the tree collection of {@link SwatTreeFlydownNode} objects for this
      * tree flydown.
      *
-     * @return SwatFlydowTreeNode Tree of nodes
+     * @return SwatTreeFlydownNode Tree of nodes
      */
     public function getTree()
     {
@@ -173,5 +162,23 @@ class SwatTreeFlydown extends SwatFlydown
             $this->path = $this->value;
             $this->value = end($this->path);
         }
+    }
+
+    /**
+     * Normalizes a data tree node or a tree flydown node to always be a tree
+     * flydown node.
+     *
+     * @param SwatDataTreeNode|SwatTreeFlydownNode $tree the tree to normalize
+     *
+     * @return SwatTreeFlydownNode the normalized tree
+     */
+    protected function normalizeTree(
+        SwatDataTreeNode|SwatTreeFlydownNode $tree
+    ): SwatTreeFlydownNode {
+        if ($tree instanceof SwatDataTreeNode) {
+            return SwatTreeFlydownNode::convertFromDataTree($tree);
+        }
+
+        return $tree;
     }
 }

--- a/Swat/SwatTreeFlydown.php
+++ b/Swat/SwatTreeFlydown.php
@@ -9,8 +9,6 @@
  */
 class SwatTreeFlydown extends SwatFlydown
 {
-    // {{{ public properties
-
     /**
      * An array containing the branch of the selected node formed by node
      * values.
@@ -20,9 +18,6 @@ class SwatTreeFlydown extends SwatFlydown
      * @var array
      */
     public $path = [];
-
-    // }}}
-    // {{{ protected properties
 
     /**
      * A tree collection of {@link SwatTreeFlydownNode} objects for this
@@ -37,9 +32,6 @@ class SwatTreeFlydown extends SwatFlydown
      */
     protected $tree;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new tree flydown control.
      *
@@ -52,9 +44,6 @@ class SwatTreeFlydown extends SwatFlydown
         parent::__construct($id);
         $this->setTree(new SwatTreeFlydownNode(null, 'root'));
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this tree flydown.
@@ -81,9 +70,6 @@ class SwatTreeFlydown extends SwatFlydown
         $this->value = $actual_value;
     }
 
-    // }}}
-    // {{{ protected function &getOptions()
-
     /**
      * Gets this flydown's tree as a flat array used in the
      * {@link SwatFlydown::display()} method.
@@ -101,9 +87,6 @@ class SwatTreeFlydown extends SwatFlydown
 
         return $options;
     }
-
-    // }}}
-    // {{{ private function flattenTree()
 
     /**
      * Flattens this flydown's tree into an array of flydown options.
@@ -140,9 +123,6 @@ class SwatTreeFlydown extends SwatFlydown
         }
     }
 
-    // }}}
-    // {{{ public function setTree()
-
     /**
      * Sets the tree to use for display.
      *
@@ -165,9 +145,6 @@ class SwatTreeFlydown extends SwatFlydown
         $this->tree = $tree;
     }
 
-    // }}}
-    // {{{ public function getTree()
-
     /**
      * Gets the tree collection of {@link SwatTreeFlydownNode} objects for this
      * tree flydown.
@@ -178,9 +155,6 @@ class SwatTreeFlydown extends SwatFlydown
     {
         return $this->tree;
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this tree flydown.
@@ -200,6 +174,4 @@ class SwatTreeFlydown extends SwatFlydown
             $this->value = end($this->path);
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatTreeFlydown.php
+++ b/Swat/SwatTreeFlydown.php
@@ -129,7 +129,7 @@ class SwatTreeFlydown extends SwatFlydown
      * @param SwatDataTreeNode|SwatTreeFlydownNode $tree the tree to use for
      *                                                   display
      */
-    public function setTree($tree)
+    public function setTree($tree): void
     {
         if ($tree instanceof SwatDataTreeNode) {
             $tree = SwatTreeFlydownNode::convertFromDataTree($tree);

--- a/Swat/SwatTreeFlydownNode.php
+++ b/Swat/SwatTreeFlydownNode.php
@@ -73,7 +73,7 @@ class SwatTreeFlydownNode extends SwatTreeNode
      *
      * @param SwatTreeNode $child the child node to add to this node
      */
-    public function addChild($child)
+    public function addChild($child): void
     {
         if ($child instanceof SwatDataTreeNode) {
             $child = self::convertFromDataTree($child);
@@ -82,7 +82,7 @@ class SwatTreeFlydownNode extends SwatTreeNode
         parent::addChild($child);
     }
 
-    public static function convertFromDataTree(SwatDataTreeNode $tree)
+    public static function convertFromDataTree(SwatDataTreeNode $tree): SwatTreeFlydownNode
     {
         $new_tree = new SwatTreeFlydownNode($tree->value, $tree->title);
 

--- a/Swat/SwatTreeFlydownNode.php
+++ b/Swat/SwatTreeFlydownNode.php
@@ -10,17 +10,12 @@
  */
 class SwatTreeFlydownNode extends SwatTreeNode
 {
-    // {{{ protected properties
-
     /**
      * The flydown option for this node.
      *
      * @var SwatOption
      */
     protected $flydown_option;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new tree flydown node.
@@ -61,9 +56,6 @@ class SwatTreeFlydownNode extends SwatTreeNode
         }
     }
 
-    // }}}
-    // {{{ public function getOption()
-
     /**
      * Gets the option for this node.
      *
@@ -73,9 +65,6 @@ class SwatTreeFlydownNode extends SwatTreeNode
     {
         return $this->flydown_option;
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Adds a child node to this node.
@@ -93,9 +82,6 @@ class SwatTreeFlydownNode extends SwatTreeNode
         parent::addChild($child);
     }
 
-    // }}}
-    // {{{ public staticfunction convertFromDataTree()
-
     public static function convertFromDataTree(SwatDataTreeNode $tree)
     {
         $new_tree = new SwatTreeFlydownNode($tree->value, $tree->title);
@@ -106,6 +92,4 @@ class SwatTreeFlydownNode extends SwatTreeNode
 
         return $new_tree;
     }
-
-    // }}}
 }

--- a/Swat/SwatTreeNode.php
+++ b/Swat/SwatTreeNode.php
@@ -14,10 +14,8 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      * An array of children tree nodes.
      *
      * This array is indexed numerically and starts at 0.
-     *
-     * @var array
      */
-    protected $children = [];
+    protected array $children = [];
 
     /**
      * The parent tree node of this tree node.
@@ -31,10 +29,8 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      *
      * The index of this node is used like an identifier and is used when
      * building paths in the tree.
-     *
-     * @var int
      */
-    private $index = 0;
+    private int $index = 0;
 
     /**
      * Adds a child node to this node.
@@ -105,8 +101,9 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      *
      * This method is needed to fulfill the RecursiveIterator interface.
      *
-     * @return $this node's children
+     * @return array this node's children
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         return $this->children;
@@ -120,7 +117,7 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      * @return bool true if this node has children or false if this node
      *              does not have children
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return count($this->children) > 0;
     }
@@ -144,6 +141,7 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      *               {@link SwatTreeNode} object. If the current child node is
      *               invalid, false is returned.
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->children);
@@ -154,8 +152,9 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      *
      * This method is needed to fulfill the RecursiveIterator interface.
      *
-     * @reutrn integer the key (index) of the current child node in this node.
+     * @return int the key (index) of the current child node in this node
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->children);
@@ -171,6 +170,7 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      *               {@link SwatTreeNode} object. If the next child node is
      *               invalid, false is returned.
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->children);
@@ -186,6 +186,7 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      *               {@link SwatTreeNode} object. If there are no child nodes,
      *               false is returned.
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->children);
@@ -199,7 +200,7 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      * @return bool true if the current child node is valid and false if it
      *              is not
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->current() !== false;
     }

--- a/Swat/SwatTreeNode.php
+++ b/Swat/SwatTreeNode.php
@@ -7,6 +7,10 @@
  *
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
+ * @template T of SwatTreeNode
+ *
+ * @implements RecursiveIterator<int, T>
  */
 abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Countable
 {
@@ -14,13 +18,15 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      * An array of children tree nodes.
      *
      * This array is indexed numerically and starts at 0.
+     *
+     * @var list<T>
      */
     protected array $children = [];
 
     /**
      * The parent tree node of this tree node.
      *
-     * @var SwatTreeNode
+     * @var T
      */
     private $parent;
 
@@ -37,9 +43,9 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      *
      * The parent of the child node is set to this node.
      *
-     * @param SwatTreeNode $child the child node to add to this node
+     * @param T $child the child node to add to this node
      */
-    public function addChild($child)
+    public function addChild($child): void
     {
         $child->parent = $this;
         $child->index = count($this->children);
@@ -52,9 +58,9 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      * Identical to addChild() except that it removes the root node from
      * the passed tree.
      *
-     * @param SwatTreeNode $tree the tree to add to this node
+     * @param T $tree the tree to add to this node
      */
-    public function addTree($tree)
+    public function addTree($tree): void
     {
         foreach ($tree->getChildren() as $child) {
             $this->addChild($child);
@@ -70,7 +76,7 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      * @return array an array of indexes that is the path to the given node
      *               from the root of the current tree
      */
-    public function &getPath()
+    public function &getPath(): array
     {
         $path = [$this->index];
 
@@ -89,7 +95,7 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
     /**
      * Gets the parent node of this node.
      *
-     * @return SwatTreeNode the parent node of this node
+     * @return T the parent node of this node
      */
     public function getParent()
     {
@@ -101,10 +107,9 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      *
      * This method is needed to fulfill the RecursiveIterator interface.
      *
-     * @return array this node's children
+     * @return ?RecursiveIterator<T> this node's children
      */
-    #[ReturnTypeWillChange]
-    public function getChildren()
+    public function getChildren(): ?RecursiveIterator
     {
         return $this->children;
     }
@@ -127,7 +132,7 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      *
      * @return int this node's index
      */
-    public function getIndex()
+    public function getIndex(): int
     {
         return $this->index;
     }
@@ -137,12 +142,11 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      *
      * This method is needed to fulfill the RecursiveIterator interface.
      *
-     * @return mixed the current child node in this node as a
-     *               {@link SwatTreeNode} object. If the current child node is
-     *               invalid, false is returned.
+     * @return T the current child node in this node as a
+     *           {@link SwatTreeNode} object. If the current child node is
+     *           invalid, false is returned.
      */
-    #[ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         return current($this->children);
     }
@@ -154,8 +158,7 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      *
      * @return int the key (index) of the current child node in this node
      */
-    #[ReturnTypeWillChange]
-    public function key()
+    public function key(): int
     {
         return key($this->children);
     }
@@ -165,15 +168,10 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      * pointer forward.
      *
      * This method is needed to fulfill the RecursiveIterator interface.
-     *
-     * @return mixed the next child node in this node as a
-     *               {@link SwatTreeNode} object. If the next child node is
-     *               invalid, false is returned.
      */
-    #[ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
-        return next($this->children);
+        next($this->children);
     }
 
     /**
@@ -181,15 +179,10 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      * beginning.
      *
      * This method is needed to fulfill the RecursiveIterator interface.
-     *
-     * @return mixed the first child node in this node as a
-     *               {@link SwatTreeNode} object. If there are no child nodes,
-     *               false is returned.
      */
-    #[ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
-        return reset($this->children);
+        reset($this->children);
     }
 
     /**

--- a/Swat/SwatTreeNode.php
+++ b/Swat/SwatTreeNode.php
@@ -10,8 +10,6 @@
  */
 abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Countable
 {
-    // {{{ protected properties
-
     /**
      * An array of children tree nodes.
      *
@@ -20,9 +18,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      * @var array
      */
     protected $children = [];
-
-    // }}}
-    // {{{ private properties
 
     /**
      * The parent tree node of this tree node.
@@ -41,9 +36,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      */
     private $index = 0;
 
-    // }}}
-    // {{{ public function addChild()
-
     /**
      * Adds a child node to this node.
      *
@@ -57,9 +49,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
         $child->index = count($this->children);
         $this->children[] = $child;
     }
-
-    // }}}
-    // {{{ public function addTree()
 
     /**
      * Adds a full tree structure to this node.
@@ -75,9 +64,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
             $this->addChild($child);
         }
     }
-
-    // }}}
-    // {{{ public function getPath()
 
     /**
      * Gets the path to this node.
@@ -104,9 +90,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
         return $path;
     }
 
-    // }}}
-    // {{{ public function getParent()
-
     /**
      * Gets the parent node of this node.
      *
@@ -116,9 +99,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
     {
         return $this->parent;
     }
-
-    // }}}
-    // {{{ public function getChildren()
 
     /**
      * Gets this node's children.
@@ -131,9 +111,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
     {
         return $this->children;
     }
-
-    // }}}
-    // {{{ public function hasChildren()
 
     /**
      * Whether or not this tree node has children.
@@ -148,9 +125,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
         return count($this->children) > 0;
     }
 
-    // }}}
-    // {{{ public function getIndex()
-
     /**
      * Gets this node's index.
      *
@@ -160,9 +134,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
     {
         return $this->index;
     }
-
-    // }}}
-    // {{{ public function current()
 
     /**
      * Gets the current child node in this node.
@@ -178,9 +149,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
         return current($this->children);
     }
 
-    // }}}
-    // {{{ public function key()
-
     /**
      * Gets the key of the current child node in this node.
      *
@@ -192,9 +160,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
     {
         return key($this->children);
     }
-
-    // }}}
-    // {{{ public function next()
 
     /**
      * Gets the next child node in this node and moves the internal array
@@ -211,9 +176,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
         return next($this->children);
     }
 
-    // }}}
-    // {{{ public function rewind()
-
     /**
      * Sets the internal pointer in the child nodes array back to the
      * beginning.
@@ -229,9 +191,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
         return reset($this->children);
     }
 
-    // }}}
-    // {{{ public function valid()
-
     /**
      * Whether the current child node in this node is valid.
      *
@@ -244,9 +203,6 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
     {
         return $this->current() !== false;
     }
-
-    // }}}
-    // {{{ public function count()
 
     /**
      * Gets the number of nodes in this tree or subtree.
@@ -264,6 +220,4 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
 
         return $count;
     }
-
-    // }}}
 }

--- a/Swat/SwatUI.php
+++ b/Swat/SwatUI.php
@@ -8,8 +8,6 @@
  */
 class SwatUI extends SwatObject
 {
-    // {{{ private properties
-
     /**
      * An associative array of class-prefix-to-filename-mappings.
      *
@@ -72,9 +70,6 @@ class SwatUI extends SwatObject
      */
     private static $validate_mode = true;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new UI.
      *
@@ -97,9 +92,6 @@ class SwatUI extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ public static function mapClassPrefixToPath()
-
     /**
      * Maps a class prefix to a path for filename lookup in this UI.
      *
@@ -115,9 +107,6 @@ class SwatUI extends SwatObject
     {
         self::$class_map[$class_prefix] = $path;
     }
-
-    // }}}
-    // {{{ public static function setValidateMode()
 
     /**
      * Sets the default validation mode used by {@link SwatUI::loadFromXML()}.
@@ -145,9 +134,6 @@ class SwatUI extends SwatObject
     {
         self::$validate_mode = (bool) $mode;
     }
-
-    // }}}
-    // {{{ public function loadFromXML()
 
     /**
      * Loads a UI tree from an XML file.
@@ -291,9 +277,6 @@ class SwatUI extends SwatObject
         $this->parseUI($document->documentElement, $container);
     }
 
-    // }}}
-    // {{{ public function hasWidget()
-
     /**
      * Checks whether this UI tree contains a specified widget.
      *
@@ -306,9 +289,6 @@ class SwatUI extends SwatObject
     {
         return array_key_exists($id, $this->widgets);
     }
-
-    // }}}
-    // {{{ public function getWidget()
 
     /**
      * Retrieves a widget from the internal widget list.
@@ -334,9 +314,6 @@ class SwatUI extends SwatObject
         );
     }
 
-    // }}}
-    // {{{ public function getRoot()
-
     /**
      * Retrieves the topmost widget.
      *
@@ -350,9 +327,6 @@ class SwatUI extends SwatObject
         return $this->root;
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this interface.
      *
@@ -362,9 +336,6 @@ class SwatUI extends SwatObject
     {
         $this->root->init();
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this interface.
@@ -376,9 +347,6 @@ class SwatUI extends SwatObject
         $this->root->process();
     }
 
-    // }}}
-    // {{{ public function display()
-
     /**
      * Displays this interface.
      *
@@ -388,9 +356,6 @@ class SwatUI extends SwatObject
     {
         $this->root->display();
     }
-
-    // }}}
-    // {{{ public function displayTidy()
 
     /**
      * Displays this interface with tidy XHTML.
@@ -412,9 +377,6 @@ class SwatUI extends SwatObject
         $tidy = str_replace("\n\n", "\n", $tidy);
         echo $tidy;
     }
-
-    // }}}
-    // {{{ public function setTranslationCallback()
 
     /**
      * Sets the translation callback function for this UI.
@@ -443,9 +405,6 @@ class SwatUI extends SwatObject
             );
         }
     }
-
-    // }}}
-    // {{{ private function parseUI()
 
     /**
      * Recursively parses an XML node into a widget tree.
@@ -501,9 +460,6 @@ class SwatUI extends SwatObject
 
         array_pop($this->stack);
     }
-
-    // }}}
-    // {{{ private function checkParsedObject()
 
     /**
      * Does some error checking on a parsed object.
@@ -563,9 +519,6 @@ class SwatUI extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ private function attachToParent()
-
     /**
      * Attaches a widget to a parent widget in the widget tree.
      *
@@ -589,9 +542,6 @@ class SwatUI extends SwatObject
             );
         }
     }
-
-    // }}}
-    // {{{ private function parseObject()
 
     /**
      * Parses an XML object or widget element node into a PHP object.
@@ -633,9 +583,6 @@ class SwatUI extends SwatObject
 
         return $object;
     }
-
-    // }}}
-    // {{{ private function parseProperty()
 
     /**
      * Parses a single XML property node and applies it to an object.
@@ -727,9 +674,6 @@ class SwatUI extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ private function parseValue()
-
     /**
      * Parses the value of a property.
      *
@@ -808,9 +752,6 @@ class SwatUI extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ private function parseMapping()
-
     /**
      * Handle a 'data' type property value by parsing it into a mapping object.
      *
@@ -854,9 +795,6 @@ class SwatUI extends SwatObject
         );
     }
 
-    // }}}
-    // {{{ private function translateValue()
-
     /**
      * Translates a property value if possible.
      *
@@ -879,9 +817,6 @@ class SwatUI extends SwatObject
 
         return $value;
     }
-
-    // }}}
-    // {{{ private function parseConstantExpression()
 
     /**
      * Evaluate a constant property value.
@@ -1058,6 +993,4 @@ class SwatUI extends SwatObject
 
         return array_pop($eval_stack);
     }
-
-    // }}}
 }

--- a/Swat/SwatUIObject.php
+++ b/Swat/SwatUIObject.php
@@ -11,8 +11,6 @@
  */
 abstract class SwatUIObject extends SwatObject
 {
-    // {{{ public properties
-
     /**
      * The object which contains this object.
      *
@@ -50,9 +48,6 @@ abstract class SwatUIObject extends SwatObject
      */
     public $data_attributes = [];
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * A set of HTML head entries needed by this user-interface element.
      *
@@ -63,16 +58,10 @@ abstract class SwatUIObject extends SwatObject
      */
     protected $html_head_entry_set;
 
-    // }}}
-    // {{{ public function __construct()
-
     public function __construct()
     {
         $this->html_head_entry_set = new SwatHtmlHeadEntrySet();
     }
-
-    // }}}
-    // {{{ public function addStyleSheet()
 
     /**
      * Adds a stylesheet to the list of stylesheets needed by this
@@ -99,9 +88,6 @@ abstract class SwatUIObject extends SwatObject
         );
     }
 
-    // }}}
-    // {{{ public function addJavaScript()
-
     /**
      * Adds a JavaScript include to the list of JavaScript includes needed
      * by this user-interface element.
@@ -127,9 +113,6 @@ abstract class SwatUIObject extends SwatObject
         );
     }
 
-    // }}}
-    // {{{ public function addExternalJavaScript()
-
     public function addExternalJavaScript($url)
     {
         if ($this->html_head_entry_set === null) {
@@ -148,9 +131,6 @@ abstract class SwatUIObject extends SwatObject
             new SwatExternalJavaScriptHtmlHeadEntry($url),
         );
     }
-
-    // }}}
-    // {{{ public function addComment()
 
     /**
      * Adds a comment to the list of HTML head entries needed by this user-
@@ -177,16 +157,10 @@ abstract class SwatUIObject extends SwatObject
         );
     }
 
-    // }}}
-    // {{{ public function addInlineScript()
-
     public function addInlineScript($script)
     {
         $this->inline_scripts->add($script);
     }
-
-    // }}}
-    // {{{ public function getFirstAncestor()
 
     /**
      * Gets the first ancestor object of a specific class.
@@ -218,9 +192,6 @@ abstract class SwatUIObject extends SwatObject
         return $out;
     }
 
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this UI object.
      *
@@ -241,9 +212,6 @@ abstract class SwatUIObject extends SwatObject
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects that MAY needed by this UI object.
      *
@@ -257,9 +225,6 @@ abstract class SwatUIObject extends SwatObject
     {
         return new SwatHtmlHeadEntrySet($this->html_head_entry_set);
     }
-
-    // }}}
-    // {{{ public function isVisible()
 
     /**
      * Gets whether or not this UI object is visible.
@@ -280,9 +245,6 @@ abstract class SwatUIObject extends SwatObject
         return $this->visible;
     }
 
-    // }}}
-    // {{{ public function __toString()
-
     /**
      * Gets this object as a string.
      *
@@ -300,9 +262,6 @@ abstract class SwatUIObject extends SwatObject
         // set parent back again
         $this->parent = $parent;
     }
-
-    // }}}
-    // {{{ public function copy()
 
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
@@ -329,9 +288,6 @@ abstract class SwatUIObject extends SwatObject
 
         return $copy;
     }
-
-    // }}}
-    // {{{ protected function getCSSClassNames()
 
     /**
      * Gets the array of CSS classes that are applied to this user-interface
@@ -361,9 +317,6 @@ abstract class SwatUIObject extends SwatObject
         return $data;
     }
 
-    // }}}
-    // {{{ protected function getInlineJavaScript()
-
     /**
      * Gets inline JavaScript used by this user-interface object.
      *
@@ -373,9 +326,6 @@ abstract class SwatUIObject extends SwatObject
     {
         return '';
     }
-
-    // }}}
-    // {{{ protected final function getCSSClassString()
 
     /**
      * Gets the string representation of this user-interface object's list of
@@ -400,9 +350,6 @@ abstract class SwatUIObject extends SwatObject
         return $class_string;
     }
 
-    // }}}
-    // {{{ protected final function getUniqueId()
-
     /**
      * Generates a unique id for this UI object.
      *
@@ -423,6 +370,4 @@ abstract class SwatUIObject extends SwatObject
 
         return get_class($this) . $counter;
     }
-
-    // }}}
 }

--- a/Swat/SwatUIParent.php
+++ b/Swat/SwatUIParent.php
@@ -8,8 +8,6 @@
  */
 interface SwatUIParent
 {
-    // {{{ public function addChild()
-
     /**
      * Adds a child object to this parent object.
      *
@@ -20,9 +18,6 @@ interface SwatUIParent
      * @param SwatObject $child the child object to add to this parent object
      */
     public function addChild(SwatObject $child);
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -41,9 +36,6 @@ interface SwatUIParent
      */
     public function getDescendants($class_name = null);
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -60,9 +52,6 @@ interface SwatUIParent
      */
     public function getFirstDescendant($class_name);
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -74,9 +63,6 @@ interface SwatUIParent
      */
     public function getDescendantStates();
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -87,6 +73,4 @@ interface SwatUIParent
      *                      identifiers as array keys
      */
     public function setDescendantStates(array $states);
-
-    // }}}
 }

--- a/Swat/SwatUriEntry.php
+++ b/Swat/SwatUriEntry.php
@@ -13,8 +13,6 @@
  */
 class SwatUriEntry extends SwatEntry
 {
-    // {{{ public properties
-
     /**
      * Whether or not to require the scheme for the URI.
      *
@@ -38,9 +36,6 @@ class SwatUriEntry extends SwatEntry
      * @var array
      */
     public $valid_schemes = ['http', 'https', 'ftp'];
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this URI entry.
@@ -81,9 +76,6 @@ class SwatUriEntry extends SwatEntry
         }
     }
 
-    // }}}
-    // {{{ protected function validateUri()
-
     /**
      * Validates a URI.
      *
@@ -122,9 +114,6 @@ class SwatUriEntry extends SwatEntry
 
         return preg_match($regexp, $value) === 1;
     }
-
-    // }}}
-    // {{{ protected function getValidationMessage()
 
     /**
      * Gets a validation message for this entry.
@@ -171,9 +160,6 @@ class SwatUriEntry extends SwatEntry
         return new SwatMessage($text, 'error');
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS classes that are applied to this entry.
      *
@@ -186,6 +172,4 @@ class SwatUriEntry extends SwatEntry
 
         return array_merge($classes, parent::getCSSClassNames());
     }
-
-    // }}}
 }

--- a/Swat/SwatView.php
+++ b/Swat/SwatView.php
@@ -8,8 +8,6 @@
  */
 abstract class SwatView extends SwatControl
 {
-    // {{{ public properties
-
     /**
      * A data structure that holds the data to display in this view.
      *
@@ -32,9 +30,6 @@ abstract class SwatView extends SwatControl
      */
     public $checked_items = [];
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * The selections of this view.
      *
@@ -55,9 +50,6 @@ abstract class SwatView extends SwatControl
      */
     protected $selectors = [];
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new recordset view.
      *
@@ -74,9 +66,6 @@ abstract class SwatView extends SwatControl
         $this->addJavaScript('packages/swat/javascript/swat-view.js');
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this view.
      */
@@ -92,9 +81,6 @@ abstract class SwatView extends SwatControl
             }
         }
     }
-
-    // }}}
-    // {{{ public function getSelection()
 
     /**
      * Gets a selection of this view.
@@ -162,9 +148,6 @@ abstract class SwatView extends SwatControl
 
         return $this->selections[$selector->getId()];
     }
-
-    // }}}
-    // {{{ public function setSelection()
 
     /**
      * Sets a selection of this view.
@@ -234,9 +217,6 @@ abstract class SwatView extends SwatControl
         $this->selections[$selector->getId()] = $selection;
     }
 
-    // }}}
-    // {{{ protected final function addSelector()
-
     /**
      * This method should be called internally by the
      * {@link SwatView::init() method on all descendant UI-objects that are
@@ -247,6 +227,4 @@ abstract class SwatView extends SwatControl
         $this->selections[$selector->getId()] = new SwatViewSelection([]);
         $this->selectors[$selector->getId()] = $selector;
     }
-
-    // }}}
 }

--- a/Swat/SwatViewSelection.php
+++ b/Swat/SwatViewSelection.php
@@ -26,11 +26,15 @@
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  *
  * @see       SwatView::getSelection()
+ *
+ * @implements Iterator<int, string>
  */
 class SwatViewSelection extends SwatObject implements Countable, Iterator
 {
     /**
      * The selected items of this selection.
+     *
+     * @var list<string>
      */
     private array $selected_items = [];
 
@@ -55,11 +59,8 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
 
     /**
      * Returns the current selected item.
-     *
-     * @return mixed the current selected item
      */
-    #[ReturnTypeWillChange]
-    public function current()
+    public function current(): string
     {
         return $this->selected_items[$this->current_index];
     }
@@ -130,7 +131,7 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
      * @return bool true if this selection contains the specified item and
      *              false if it does not
      */
-    public function contains($item)
+    public function contains($item): bool
     {
         return in_array($item, $this->selected_items);
     }

--- a/Swat/SwatViewSelection.php
+++ b/Swat/SwatViewSelection.php
@@ -29,8 +29,6 @@
  */
 class SwatViewSelection extends SwatObject implements Countable, Iterator
 {
-    // {{{ private properties
-
     /**
      * The selected items of this selection.
      *
@@ -47,9 +45,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
      */
     private $current_index = 0;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new selection object.
      *
@@ -62,9 +57,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
         $this->selected_items = array_values($selected_items);
     }
 
-    // }}}
-    // {{{ public function current()
-
     /**
      * Returns the current selected item.
      *
@@ -74,9 +66,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
     {
         return $this->selected_items[$this->current_index];
     }
-
-    // }}}
-    // {{{ public function key()
 
     /**
      * Returns the key of the current selected item.
@@ -88,9 +77,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
         return $this->current_index;
     }
 
-    // }}}
-    // {{{ public function next()
-
     /**
      * Moves forward to the next selected item.
      */
@@ -98,9 +84,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
     {
         $this->current_index++;
     }
-
-    // }}}
-    // {{{ public function prev()
 
     /**
      * Moves forward to the previous selected item.
@@ -110,9 +93,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
         $this->current_index--;
     }
 
-    // }}}
-    // {{{ public function rewind()
-
     /**
      * Rewinds this iterator to the first selected item.
      */
@@ -120,9 +100,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
     {
         $this->current_index = 0;
     }
-
-    // }}}
-    // {{{ public function valid()
 
     /**
      * Checks is there is a current selected item after calls to rewind() and
@@ -136,9 +113,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
         return isset($this->selected_items[$this->current_index]);
     }
 
-    // }}}
-    // {{{ public funciton count()
-
     /**
      * Gets the number of items in this selection.
      *
@@ -150,9 +124,6 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
     {
         return count($this->selected_items);
     }
-
-    // }}}
-    // {{{ public function contains()
 
     /**
      * Checks whether or not this selection contains an item.
@@ -166,6 +137,4 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
     {
         return in_array($item, $this->selected_items);
     }
-
-    // }}}
 }

--- a/Swat/SwatViewSelection.php
+++ b/Swat/SwatViewSelection.php
@@ -31,19 +31,15 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
 {
     /**
      * The selected items of this selection.
-     *
-     * @var array
      */
-    private $selected_items = [];
+    private array $selected_items = [];
 
     /**
      * Current array index of the selected items of this selection.
      *
      * Used for implementing the Iterator interface.
-     *
-     * @var int
      */
-    private $current_index = 0;
+    private int $current_index = 0;
 
     /**
      * Creates a new selection object.
@@ -62,6 +58,7 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
      *
      * @return mixed the current selected item
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->selected_items[$this->current_index];
@@ -72,7 +69,7 @@ class SwatViewSelection extends SwatObject implements Countable, Iterator
      *
      * @return int the key of the current selected item
      */
-    public function key()
+    public function key(): int
     {
         return $this->current_index;
     }

--- a/Swat/SwatViewSelector.php
+++ b/Swat/SwatViewSelector.php
@@ -11,14 +11,10 @@
  */
 interface SwatViewSelector
 {
-    // {{{ public function getId()
-
     /**
      * Gets the identifier of this selector.
      *
      * @return string the identifier of this selector
      */
     public function getId();
-
-    // }}}
 }

--- a/Swat/SwatWidget.php
+++ b/Swat/SwatWidget.php
@@ -32,8 +32,6 @@
  */
 abstract class SwatWidget extends SwatUIObject
 {
-    // {{{ public properties
-
     /**
      * A non-visible unique id for this widget, or null.
      *
@@ -67,9 +65,6 @@ abstract class SwatWidget extends SwatUIObject
      */
     public $stylesheet;
 
-    // }}}
-    // {{{ private properties
-
     /**
      * Composite widgets of this widget.
      *
@@ -88,9 +83,6 @@ abstract class SwatWidget extends SwatUIObject
      * @var bool
      */
     private $composite_widgets_created = false;
-
-    // }}}
-    // {{{ protected properties
 
     /**
      * Messages affixed to this widget.
@@ -138,9 +130,6 @@ abstract class SwatWidget extends SwatUIObject
      */
     protected $displayed = false;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new widget.
      *
@@ -153,9 +142,6 @@ abstract class SwatWidget extends SwatUIObject
         $this->id = $id;
         $this->addStylesheet('packages/swat/styles/swat.css');
     }
-
-    // }}}
-    // {{{ public function init()
 
     /**
      * Initializes this widget.
@@ -192,9 +178,6 @@ abstract class SwatWidget extends SwatUIObject
         $this->initialized = true;
     }
 
-    // }}}
-    // {{{ public function process()
-
     /**
      * Processes this widget.
      *
@@ -219,9 +202,6 @@ abstract class SwatWidget extends SwatUIObject
         $this->processed = true;
     }
 
-    // }}}
-    // {{{ public function display()
-
     /**
      * Displays this widget.
      *
@@ -240,9 +220,6 @@ abstract class SwatWidget extends SwatUIObject
         $this->displayed = true;
     }
 
-    // }}}
-    // {{{ public function displayHtmlHeadEntries()
-
     /**
      * Displays the HTML head entries for this widget.
      *
@@ -254,9 +231,6 @@ abstract class SwatWidget extends SwatUIObject
         $set = $this->getHtmlHeadEntrySet();
         $set->display();
     }
-
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this widget.
@@ -282,9 +256,6 @@ abstract class SwatWidget extends SwatUIObject
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this widget.
      *
@@ -302,9 +273,6 @@ abstract class SwatWidget extends SwatUIObject
         return $set;
     }
 
-    // }}}
-    // {{{ public function addMessage()
-
     /**
      * Adds a message to this widget.
      *
@@ -317,9 +285,6 @@ abstract class SwatWidget extends SwatUIObject
     {
         $this->messages[] = $message;
     }
-
-    // }}}
-    // {{{ public function getMessages()
 
     /**
      * Gets all messages.
@@ -340,9 +305,6 @@ abstract class SwatWidget extends SwatUIObject
 
         return $messages;
     }
-
-    // }}}
-    // {{{ public function hasMessage()
 
     /**
      * Checks for the presence of messages.
@@ -366,9 +328,6 @@ abstract class SwatWidget extends SwatUIObject
         return $has_message;
     }
 
-    // }}}
-    // {{{ public function isSensitive()
-
     /**
      * Determines the sensitivity of this widget.
      *
@@ -388,9 +347,6 @@ abstract class SwatWidget extends SwatUIObject
         return $this->sensitive;
     }
 
-    // }}}
-    // {{{ public function isInitialized()
-
     /**
      * Whether or not this widget is initialized.
      *
@@ -400,9 +356,6 @@ abstract class SwatWidget extends SwatUIObject
     {
         return $this->initialized;
     }
-
-    // }}}
-    // {{{ public function isProcessed()
 
     /**
      * Whether or not this widget is processed.
@@ -414,9 +367,6 @@ abstract class SwatWidget extends SwatUIObject
         return $this->processed;
     }
 
-    // }}}
-    // {{{ public function isDisplayed()
-
     /**
      * Whether or not this widget is displayed.
      *
@@ -426,9 +376,6 @@ abstract class SwatWidget extends SwatUIObject
     {
         return $this->displayed;
     }
-
-    // }}}
-    // {{{ public function getFocusableHtmlId()
 
     /**
      * Gets the id attribute of the XHTML element displayed by this widget
@@ -451,9 +398,6 @@ abstract class SwatWidget extends SwatUIObject
     {
         return null;
     }
-
-    // }}}
-    // {{{ public function replaceWithContainer()
 
     /**
      * Replace this widget with a new container.
@@ -487,9 +431,6 @@ abstract class SwatWidget extends SwatUIObject
         return $container;
     }
 
-    // }}}
-    // {{{ public function copy()
-
     /**
      * Performs a deep copy of the UI tree starting with this UI object.
      *
@@ -521,16 +462,10 @@ abstract class SwatWidget extends SwatUIObject
         return $copy;
     }
 
-    // }}}
-    // {{{ abstract public function printWidgetTree()
-
     /**
      * @todo document me
      */
     abstract public function printWidgetTree();
-
-    // }}}
-    // {{{ protected function validateId()
 
     /**
      * Ensures the id for this widget is valid.
@@ -558,9 +493,6 @@ abstract class SwatWidget extends SwatUIObject
         }
     }
 
-    // }}}
-    // {{{ protected function getCSSClassNames()
-
     /**
      * Gets the array of CSS  classes that are applied  to this widget.
      *
@@ -577,9 +509,6 @@ abstract class SwatWidget extends SwatUIObject
         return array_merge($classes, parent::getCSSClassNames());
     }
 
-    // }}}
-    // {{{ protected function createCompositeWidgets()
-
     /**
      * Creates and adds composite widgets of this widget.
      *
@@ -587,9 +516,6 @@ abstract class SwatWidget extends SwatUIObject
      * {@link SwatWidget::addCompositeWidget()}.
      */
     protected function createCompositeWidgets() {}
-
-    // }}}
-    // {{{ protected final function addCompositeWidget()
 
     /**
      * Adds a composite a widget to this widget.
@@ -631,9 +557,6 @@ abstract class SwatWidget extends SwatUIObject
         $widget->parent = $this;
     }
 
-    // }}}
-    // {{{ protected final function getCompositeWidget()
-
     /**
      * Gets a composite widget of this widget by the composite widget's key.
      *
@@ -667,9 +590,6 @@ abstract class SwatWidget extends SwatUIObject
 
         return $this->composite_widgets[$key];
     }
-
-    // }}}
-    // {{{ protected final function getCompositeWidgets()
 
     /**
      * Gets all composite widgets added to this widget.
@@ -711,9 +631,6 @@ abstract class SwatWidget extends SwatUIObject
         return $out;
     }
 
-    // }}}
-    // {{{ protected final function confirmCompositeWidgets()
-
     /**
      * Confirms composite widgets have been created.
      *
@@ -733,6 +650,4 @@ abstract class SwatWidget extends SwatUIObject
             $this->composite_widgets_created = true;
         }
     }
-
-    // }}}
 }

--- a/Swat/SwatWidgetCellRenderer.php
+++ b/Swat/SwatWidgetCellRenderer.php
@@ -6,8 +6,6 @@
  */
 class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, SwatTitleable
 {
-    // {{{ public properties
-
     /**
      * Identifier of this widget cell renderer.
      *
@@ -23,9 +21,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
      * If null, no replicating is done and the prototype widget is used.
      */
     public $replicator_id;
-
-    // }}}
-    // {{{ private properties
 
     /**
      * A reference to the prototype widget for this cell renderer.
@@ -60,9 +55,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
      */
     private $using_null_replication = false;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new radio button cell renderer.
      */
@@ -75,9 +67,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         // auto-generate an id to use if no id is set
         $this->id = $this->getUniqueId();
     }
-
-    // }}}
-    // {{{ public function addChild()
 
     /**
      * Fulfills SwatUIParent::addChild().
@@ -94,9 +83,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
             );
         }
     }
-
-    // }}}
-    // {{{ public function getPropertyNameToMap()
 
     public function getPropertyNameToMap(SwatUIObject $object, $name)
     {
@@ -125,9 +111,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         return $mangled_name;
     }
 
-    // }}}
-    // {{{ public function init()
-
     /**
      * Initializes this cell renderer.
      *
@@ -154,9 +137,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
             $this->prototype_widget->init();
         }
     }
-
-    // }}}
-    // {{{ public function process()
 
     public function process()
     {
@@ -185,9 +165,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
             }
         }
     }
-
-    // }}}
-    // {{{ public function render()
 
     /**
      * @throws SwatException
@@ -257,17 +234,11 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         }
     }
 
-    // }}}
-    // {{{ public function setPrototypeWidget()
-
     public function setPrototypeWidget(SwatWidget $widget)
     {
         $this->prototype_widget = $widget;
         $widget->parent = $this;
     }
-
-    // }}}
-    // {{{ public function getPrototypeWidget()
 
     /**
      * Gets the prototype widget of this widget cell renderer.
@@ -278,9 +249,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
     {
         return $this->prototype_widget;
     }
-
-    // }}}
-    // {{{ public function getWidget()
 
     /**
      * Retrieves a reference to a replicated widget.
@@ -308,9 +276,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
 
         return $widget;
     }
-
-    // }}}
-    // {{{ public function getWidgets()
 
     /**
      * Gets an array of replicated widgets indexed by the replicator_id.
@@ -368,9 +333,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         return $widgets;
     }
 
-    // }}}
-    // {{{ public function getClonedWidgets()
-
     /**
      * Gets an array of cloned widgets indexed by the replicator_id.
      *
@@ -407,9 +369,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         return $clones;
     }
 
-    // }}}
-    // {{{ public function getDataSpecificCSSClassNames()
-
     /**
      * Gets the data specific CSS class names for this widget cell renderer.
      *
@@ -432,9 +391,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
 
         return $classes;
     }
-
-    // }}}
-    // {{{ public function getMessages()
 
     /**
      * Gathers all messages from the widget of this cell renderer for the given
@@ -461,9 +417,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
 
         return $messages;
     }
-
-    // }}}
-    // {{{ public function hasMessage()
 
     /**
      * Gets whether or not this widget cell renderer has messages.
@@ -492,9 +445,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         return $has_message;
     }
 
-    // }}}
-    // {{{ public function getTitle()
-
     /**
      * Gets the title of this widget cell renderer.
      *
@@ -514,9 +464,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         return $title;
     }
 
-    // }}}
-    // {{{ public function getTitleContentType()
-
     /**
      * Gets the title content-type of this widget cell renderer.
      *
@@ -534,9 +481,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
 
         return $title_content_type;
     }
-
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
 
     /**
      * Gets the SwatHtmlHeadEntry objects needed by this widget cell renderer.
@@ -564,9 +508,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         return $set;
     }
 
-    // }}}
-    // {{{ public function getAvailableHtmlHeadEntrySet()
-
     /**
      * Gets the SwatHtmlHeadEntry objects that may be needed by this widget
      * cell renderer.
@@ -593,9 +534,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
 
         return $set;
     }
-
-    // }}}
-    // {{{ public function getDescendants()
 
     /**
      * Gets descendant UI-objects.
@@ -647,9 +585,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         return $out;
     }
 
-    // }}}
-    // {{{ public function getFirstDescendant()
-
     /**
      * Gets the first descendant UI-object of a specific class.
      *
@@ -688,9 +623,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         return $out;
     }
 
-    // }}}
-    // {{{ public function getDescendantStates()
-
     /**
      * Gets descendant states.
      *
@@ -711,9 +643,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         return $states;
     }
 
-    // }}}
-    // {{{ public function setDescendantStates()
-
     /**
      * Sets descendant states.
      *
@@ -731,9 +660,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
             }
         }
     }
-
-    // }}}
-    // {{{ public function __set()
 
     /**
      * Maps a data field to a property of a widget in the widget tree.
@@ -753,9 +679,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         }
     }
 
-    // }}}
-    // {{{ protected function getReplicatorFieldName()
-
     protected function getReplicatorFieldName()
     {
         $name = $this->id . '_replicators';
@@ -768,9 +691,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         return $name;
     }
 
-    // }}}
-    // {{{ private function getForm()
-
     /**
      * Gets the form.
      *
@@ -781,9 +701,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         return $this->getFirstAncestor('SwatForm');
     }
 
-    // }}}
-    // {{{ private function getClonedWidget()
-
     private function getClonedWidget($replicator)
     {
         if (!isset($this->clones[$replicator])) {
@@ -793,9 +710,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         return $this->clones[$replicator];
     }
 
-    // }}}
-    // {{{ private function applyPropertyValuesToPrototypeWidget()
-
     private function applyPropertyValuesToPrototypeWidget()
     {
         foreach ($this->property_values as $name => $value) {
@@ -804,9 +718,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
             $object->{$property} = $value;
         }
     }
-
-    // }}}
-    // {{{ private function applyPropertyValuesToClonedWidget()
 
     private function applyPropertyValuesToClonedWidget($cloned_widget)
     {
@@ -852,9 +763,6 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
         }
     }
 
-    // }}}
-    // {{{ private function createClonedWidget()
-
     private function createClonedWidget($replicator)
     {
         if ($this->prototype_widget === null) {
@@ -890,6 +798,4 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
 
         $this->clones[$replicator] = $new_widget;
     }
-
-    // }}}
 }

--- a/Swat/SwatXHTMLTextarea.php
+++ b/Swat/SwatXHTMLTextarea.php
@@ -9,8 +9,6 @@
  */
 class SwatXHTMLTextarea extends SwatTextarea
 {
-    // {{{ public properties
-
     /**
      * Whether or not to allow the user to ignore validation errors.
      *
@@ -21,9 +19,6 @@ class SwatXHTMLTextarea extends SwatTextarea
      * @var bool
      */
     public $allow_ignore_validation_errors = false;
-
-    // }}}
-    // {{{ protected properties
 
     /**
      * Whether or not this XHTML entry has validation errors or not.
@@ -39,13 +34,8 @@ class SwatXHTMLTextarea extends SwatTextarea
      */
     protected $ignore_errors_checkbox;
 
-    // }}}
-    // {{{ public function process()
-
     public function process()
     {
-        // {{{ defines the xhtml template
-
         static $xhtml_template = '';
 
         if ($xhtml_template == '') {
@@ -73,8 +63,6 @@ class SwatXHTMLTextarea extends SwatTextarea
                     XHTML;
         }
 
-        // }}}
-
         parent::process();
 
         $ignore_validation_errors
@@ -101,9 +89,6 @@ class SwatXHTMLTextarea extends SwatTextarea
         }
     }
 
-    // }}}
-    // {{{ public function display()
-
     public function display()
     {
         if (!$this->visible) {
@@ -121,9 +106,6 @@ class SwatXHTMLTextarea extends SwatTextarea
             $ignore_field->display();
         }
     }
-
-    // }}}
-    // {{{ protected function getValidationErrorMessage()
 
     /**
      * Gets a human readable error message for XHTML validation errors on
@@ -207,9 +189,6 @@ class SwatXHTMLTextarea extends SwatTextarea
         return $message;
     }
 
-    // }}}
-    // {{{ protected function createCompositeWidgets()
-
     /**
      * Creates the composite checkbox used by this XHTML textarea.
      *
@@ -228,13 +207,8 @@ class SwatXHTMLTextarea extends SwatTextarea
         $this->addCompositeWidget($ignore_field, 'ignore_field');
     }
 
-    // }}}
-    // {{{ protected function getXHTMLContent()
-
     protected function getXHTMLContent()
     {
         return $this->value;
     }
-
-    // }}}
 }

--- a/Swat/SwatYUI.php
+++ b/Swat/SwatYUI.php
@@ -36,8 +36,6 @@
  */
 class SwatYUI extends SwatObject
 {
-    // {{{ private static properties
-
     /**
      * Static component definitions.
      *
@@ -50,18 +48,12 @@ class SwatYUI extends SwatObject
      */
     private static $components = [];
 
-    // }}}
-    // {{{ private properties
-
     /**
      * The {@link SwatHtmlHeadEntrySet} required for this SwaYUI object.
      *
      * @var SwatHtmlHeadEntrySet
      */
     private $html_head_entry_set;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new SwatYUI HTML head entry set building object.
@@ -86,9 +78,6 @@ class SwatYUI extends SwatObject
         );
     }
 
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
-
     /**
      * Gets the HTML head entry set required for the YUI components of this
      * object.
@@ -99,9 +88,6 @@ class SwatYUI extends SwatObject
     {
         return $this->html_head_entry_set;
     }
-
-    // }}}
-    // {{{ private function buildHtmlHeadEntrySet()
 
     /**
      * Builds the HTML head entry set required for the YUI components of this
@@ -129,9 +115,6 @@ class SwatYUI extends SwatObject
         return $set;
     }
 
-    // }}}
-    // {{{ private function getAttributionHtmlHeadEntry()
-
     private function getAttributionHtmlHeadEntry()
     {
         $comment
@@ -140,9 +123,6 @@ class SwatYUI extends SwatObject
 
         return new SwatCommentHtmlHeadEntry($comment);
     }
-
-    // }}}
-    // {{{ private static function buildComponents()
 
     /**
      * Builds the YUI component definitions and dependency information.
@@ -463,6 +443,4 @@ class SwatYUI extends SwatObject
 
         $components_built = true;
     }
-
-    // }}}
 }

--- a/Swat/SwatYUIComponent.php
+++ b/Swat/SwatYUIComponent.php
@@ -13,15 +13,10 @@
  */
 class SwatYUIComponent extends SwatObject
 {
-    // {{{ private properties
-
     private $id;
     private $dependencies = [];
     private $html_head_entries = [];
     private $beta = false;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new YUI component.
@@ -45,9 +40,6 @@ class SwatYUIComponent extends SwatObject
         $this->html_head_entry_set['min'] = new SwatHtmlHeadEntrySet();
     }
 
-    // }}}
-    // {{{ public function addDependency()
-
     /**
      * Adds a YUI component dependency to this YUI component.
      *
@@ -57,9 +49,6 @@ class SwatYUIComponent extends SwatObject
     {
         $this->dependencies[] = $component;
     }
-
-    // }}}
-    // {{{ public function addJavaScript()
 
     /**
      * Adds a {@link SwatJavaScriptHtmlHeadEntry} to this YUI component.
@@ -119,9 +108,6 @@ class SwatYUIComponent extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ public function addStyleSheet()
-
     /**
      * Adds a {@link SwatStyleSheetHtmlHeadEntry} to this YUI component.
      *
@@ -177,9 +163,6 @@ class SwatYUIComponent extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ public function getHtmlHeadEntrySet()
-
     /**
      * Gets the set of {@link SwatHtmlHeadEntry} objects required for this
      * YUI component.
@@ -201,6 +184,4 @@ class SwatYUIComponent extends SwatObject
 
         return $set;
     }
-
-    // }}}
 }

--- a/Swat/SwatYesNoFlydown.php
+++ b/Swat/SwatYesNoFlydown.php
@@ -8,13 +8,8 @@
  */
 class SwatYesNoFlydown extends SwatFlydown
 {
-    // {{{ constants
-
     public const NO = false;
     public const YES = true;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new yes/no flydown.
@@ -31,6 +26,4 @@ class SwatYesNoFlydown extends SwatFlydown
         $this->addOption(self::NO, Swat::_('No'));
         $this->addOption(self::YES, Swat::_('Yes'));
     }
-
-    // }}}
 }

--- a/Swat/SwatYesNoRadioList.php
+++ b/Swat/SwatYesNoRadioList.php
@@ -8,13 +8,8 @@
  */
 class SwatYesNoRadioList extends SwatRadioList
 {
-    // {{{ constants
-
     public const NO = false;
     public const YES = true;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new yes/no radio list.
@@ -31,6 +26,4 @@ class SwatYesNoRadioList extends SwatRadioList
         $this->addOption(self::NO, Swat::_('No'));
         $this->addOption(self::YES, Swat::_('Yes'));
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatClassNotFoundException.php
+++ b/Swat/exceptions/SwatClassNotFoundException.php
@@ -8,17 +8,12 @@
  */
 class SwatClassNotFoundException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The name of the class that is not found.
      *
      * @var string
      */
     protected $class_name;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new class not found exception.
@@ -33,9 +28,6 @@ class SwatClassNotFoundException extends SwatException
         $this->class_name = $class_name;
     }
 
-    // }}}
-    // {{{ public function getClassName()
-
     /**
      * Gets the name of the class that is not found.
      *
@@ -45,6 +37,4 @@ class SwatClassNotFoundException extends SwatException
     {
         return $this->class_name;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatCrossSiteRequestForgeryException.php
+++ b/Swat/exceptions/SwatCrossSiteRequestForgeryException.php
@@ -14,17 +14,12 @@
  */
 class SwatCrossSiteRequestForgeryException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The form that did not authenticate.
      *
      * @var SwatForm
      */
     protected $form;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new cross-site request forgery exception.
@@ -39,9 +34,6 @@ class SwatCrossSiteRequestForgeryException extends SwatException
         $this->form = $form;
     }
 
-    // }}}
-    // {{{ public function getForm()
-
     /**
      * Gets the form that did not authenticate.
      *
@@ -51,6 +43,4 @@ class SwatCrossSiteRequestForgeryException extends SwatException
     {
         return $this->form;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatDoesNotImplementException.php
+++ b/Swat/exceptions/SwatDoesNotImplementException.php
@@ -8,17 +8,12 @@
  */
 class SwatDoesNotImplementException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The object that does not implement a required interface.
      *
      * @var mixed
      */
     protected $object;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new does not implement exception.
@@ -34,9 +29,6 @@ class SwatDoesNotImplementException extends SwatException
         $this->object = $object;
     }
 
-    // }}}
-    // {{{ public function getObject()
-
     /**
      * Gets the object that does not implement a required interface.
      *
@@ -46,6 +38,4 @@ class SwatDoesNotImplementException extends SwatException
     {
         return $this->object;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatDuplicateIdException.php
+++ b/Swat/exceptions/SwatDuplicateIdException.php
@@ -8,17 +8,12 @@
  */
 class SwatDuplicateIdException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The id that is colliding.
      *
      * @var string
      */
     protected $id;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new duplicate id exception.
@@ -33,9 +28,6 @@ class SwatDuplicateIdException extends SwatException
         $this->id = $id;
     }
 
-    // }}}
-    // {{{ public function getId()
-
     /**
      * Gets the id that is colliding.
      *
@@ -45,6 +37,4 @@ class SwatDuplicateIdException extends SwatException
     {
         return $this->id;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatException.php
+++ b/Swat/exceptions/SwatException.php
@@ -37,8 +37,6 @@
  */
 class SwatException extends Exception
 {
-    // {{{ protected properties
-
     protected $backtrace;
     protected $class;
 
@@ -52,18 +50,12 @@ class SwatException extends Exception
      */
     protected static $loggers = [];
 
-    // }}}
-    // {{{ private properties
-
     /**
      * Whether or not this excception was manually handled.
      *
      * @var bool
      */
     private $handled = false;
-
-    // }}}
-    // {{{ public static function setLogger()
 
     /**
      * Sets the object that logs SwatException objects when they are processed.
@@ -79,9 +71,6 @@ class SwatException extends Exception
     {
         self::$loggers = [$logger];
     }
-
-    // }}}
-    // {{{ public static function addLogger()
 
     /**
      * Adds an object to the array of objects that log SwatException objects
@@ -100,9 +89,6 @@ class SwatException extends Exception
         self::$loggers[] = $logger;
     }
 
-    // }}}
-    // {{{ public static function setDisplayer()
-
     /**
      * Sets the object that displays SwatException objects when they are
      * processed.
@@ -120,9 +106,6 @@ class SwatException extends Exception
         self::$displayer = $displayer;
     }
 
-    // }}}
-    // {{{ public static function setupHandler()
-
     /**
      * Set the PHP exception handler to use SwatException.
      *
@@ -133,9 +116,6 @@ class SwatException extends Exception
     {
         set_exception_handler([$class, 'handle']);
     }
-
-    // }}}
-    // {{{ public function __construct()
 
     public function __construct($message = null, $code = 0)
     {
@@ -154,9 +134,6 @@ class SwatException extends Exception
             $this->class = get_class($this);
         }
     }
-
-    // }}}
-    // {{{ public function process()
 
     /**
      * Processes this exception.
@@ -189,9 +166,6 @@ class SwatException extends Exception
         }
     }
 
-    // }}}
-    // {{{ public function processAndContinue()
-
     /**
      * Processes this exception and continues execution.
      *
@@ -203,9 +177,6 @@ class SwatException extends Exception
         $this->process(false, true);
     }
 
-    // }}}
-    // {{{ public function processAndExit()
-
     /**
      * Processes this exception and stops execution.
      *
@@ -216,9 +187,6 @@ class SwatException extends Exception
     {
         $this->process(true, true);
     }
-
-    // }}}
-    // {{{ public function log()
 
     /**
      * Logs this exception.
@@ -235,9 +203,6 @@ class SwatException extends Exception
             }
         }
     }
-
-    // }}}
-    // {{{ public function display()
 
     /**
      * Displays this exception.
@@ -261,9 +226,6 @@ class SwatException extends Exception
             $displayer->display($this);
         }
     }
-
-    // }}}
-    // {{{ public function getSummary()
 
     /**
      * Gets a one-line short text summary of this exception.
@@ -289,9 +251,6 @@ class SwatException extends Exception
 
         return ob_get_clean();
     }
-
-    // }}}
-    // {{{ public function toString()
 
     /**
      * Gets this exception as a nicely formatted text block.
@@ -352,9 +311,6 @@ class SwatException extends Exception
 
         return ob_get_clean();
     }
-
-    // }}}
-    // {{{ public function toXHTML()
 
     /**
      * Gets this exception as a nicely formatted XHTML fragment.
@@ -425,9 +381,6 @@ class SwatException extends Exception
         return ob_get_clean();
     }
 
-    // }}}
-    // {{{ public function getClass()
-
     /**
      * Gets the name of the class this exception represents.
      *
@@ -440,9 +393,6 @@ class SwatException extends Exception
         return $this->class;
     }
 
-    // }}}
-    // {{{ public function wasHandled()
-
     /**
      * Gets whether or not this exception was manually handled.
      *
@@ -453,9 +403,6 @@ class SwatException extends Exception
     {
         return $this->handled;
     }
-
-    // }}}
-    // {{{ public static function handle()
 
     /**
      * Handles an exception.
@@ -475,9 +422,6 @@ class SwatException extends Exception
         $e->process(true, false);
     }
 
-    // }}}
-    // {{{ protected function getMessageAsHtml()
-
     /**
      * Formats the exception's message as Html.
      *
@@ -487,9 +431,6 @@ class SwatException extends Exception
     {
         return nl2br(htmlspecialchars($this->getMessage()));
     }
-
-    // }}}
-    // {{{ protected function getArguments()
 
     /**
      * Formats a method call's arguments.
@@ -547,9 +488,6 @@ class SwatException extends Exception
         return implode(', ', $formatted_values);
     }
 
-    // }}}
-    // {{{ protected function formatSensitiveParam()
-
     /**
      * Removes sensitive information from a parameter value and formats
      * the parameter as a string.
@@ -569,9 +507,6 @@ class SwatException extends Exception
     {
         return '[$' . $name . ' FILTERED]';
     }
-
-    // }}}
-    // {{{ protected function formatValue()
 
     /**
      * Formats a parameter value for display in a stack trace.
@@ -634,9 +569,6 @@ class SwatException extends Exception
         return $formatted_value;
     }
 
-    // }}}
-    // {{{ protected function displayStyleSheet()
-
     /**
      * Displays style sheet required for XHMTL exception formatting.
      *
@@ -667,9 +599,6 @@ class SwatException extends Exception
             $displayed = true;
         }
     }
-
-    // }}}
-    // {{{ protected function isSensitiveParameter()
 
     /**
      * Detects whether or not a parameter is sensitive from the method-level
@@ -716,6 +645,4 @@ class SwatException extends Exception
 
         return $sensitive;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatFileNotFoundException.php
+++ b/Swat/exceptions/SwatFileNotFoundException.php
@@ -8,17 +8,12 @@
  */
 class SwatFileNotFoundException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The filename that caused this exception to be thrown.
      *
      * @var string
      */
     protected $filename = '';
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new file not found exception.
@@ -33,9 +28,6 @@ class SwatFileNotFoundException extends SwatException
         $this->filename = $filename;
     }
 
-    // }}}
-    // {{{ public function getFilename()
-
     /**
      * Gets the filename of that caused this exception to be thrown.
      *
@@ -45,6 +37,4 @@ class SwatFileNotFoundException extends SwatException
     {
         return $this->filename;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatIntegerOverflowException.php
+++ b/Swat/exceptions/SwatIntegerOverflowException.php
@@ -8,8 +8,6 @@
  */
 class SwatIntegerOverflowException extends OverflowException
 {
-    // {{{ protected properties
-
     /**
      * Sign.
      *
@@ -18,9 +16,6 @@ class SwatIntegerOverflowException extends OverflowException
      * @var int
      */
     protected $sign;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new invalid type exception.
@@ -37,9 +32,6 @@ class SwatIntegerOverflowException extends OverflowException
         $this->sign = $sign;
     }
 
-    // }}}
-    // {{{ public function getSign()
-
     /**
      * Gets the sign of the integer.
      *
@@ -49,6 +41,4 @@ class SwatIntegerOverflowException extends OverflowException
     {
         return $this->sign;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatInvalidCallbackException.php
+++ b/Swat/exceptions/SwatInvalidCallbackException.php
@@ -9,17 +9,12 @@
  */
 class SwatInvalidCallbackException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The value the user tried to set the callback to.
      *
      * @var mixed
      */
     protected $callback;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new invalid callback exception.
@@ -34,9 +29,6 @@ class SwatInvalidCallbackException extends SwatException
         $this->callback = $callback;
     }
 
-    // }}}
-    // {{{ public function getCallback()
-
     /**
      * Gets the value the user tried to set the callback to.
      *
@@ -46,6 +38,4 @@ class SwatInvalidCallbackException extends SwatException
     {
         return $this->callback;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatInvalidClassException.php
+++ b/Swat/exceptions/SwatInvalidClassException.php
@@ -8,17 +8,12 @@
  */
 class SwatInvalidClassException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The object that is of the wrong class.
      *
      * @var mixed
      */
     protected $object;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new invalid class exception.
@@ -33,9 +28,6 @@ class SwatInvalidClassException extends SwatException
         $this->object = $object;
     }
 
-    // }}}
-    // {{{ public function getObject()
-
     /**
      * Gets the object that is of the wrong class.
      *
@@ -45,6 +37,4 @@ class SwatInvalidClassException extends SwatException
     {
         return $this->object;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatInvalidConstantExpressionException.php
+++ b/Swat/exceptions/SwatInvalidConstantExpressionException.php
@@ -8,17 +8,12 @@
  */
 class SwatInvalidConstantExpressionException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The constant expression that is invalid.
      *
      * @var string
      */
     protected $expression;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new class not found exception.
@@ -33,9 +28,6 @@ class SwatInvalidConstantExpressionException extends SwatException
         $this->expression = $expression;
     }
 
-    // }}}
-    // {{{ public function getExpression()
-
     /**
      * Gets the constant expression that is invalid.
      *
@@ -45,6 +37,4 @@ class SwatInvalidConstantExpressionException extends SwatException
     {
         return $this->expression;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatInvalidPropertyException.php
+++ b/Swat/exceptions/SwatInvalidPropertyException.php
@@ -8,8 +8,6 @@
  */
 class SwatInvalidPropertyException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The name of the property that is invalid.
      *
@@ -23,9 +21,6 @@ class SwatInvalidPropertyException extends SwatException
      * @var mixed
      */
     protected $object;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new invalid class exception.
@@ -46,9 +41,6 @@ class SwatInvalidPropertyException extends SwatException
         $this->property = $property;
     }
 
-    // }}}
-    // {{{ public function getObject()
-
     /**
      * Gets the object the property is invalid for.
      *
@@ -59,9 +51,6 @@ class SwatInvalidPropertyException extends SwatException
         return $this->object;
     }
 
-    // }}}
-    // {{{ public function getProperty()
-
     /**
      * Gets the name of the property that is invalid.
      *
@@ -71,6 +60,4 @@ class SwatInvalidPropertyException extends SwatException
     {
         return $this->property;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatInvalidPropertyTypeException.php
+++ b/Swat/exceptions/SwatInvalidPropertyTypeException.php
@@ -8,8 +8,6 @@
  */
 class SwatInvalidPropertyTypeException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The name of the type that is invalid.
      *
@@ -23,9 +21,6 @@ class SwatInvalidPropertyTypeException extends SwatException
      * @var mixed
      */
     protected $object;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new invalid class exception.
@@ -46,9 +41,6 @@ class SwatInvalidPropertyTypeException extends SwatException
         $this->type = $type;
     }
 
-    // }}}
-    // {{{ public function getObject()
-
     /**
      * Gets the object the property is invalid for.
      *
@@ -59,9 +51,6 @@ class SwatInvalidPropertyTypeException extends SwatException
         return $this->object;
     }
 
-    // }}}
-    // {{{ public function getType()
-
     /**
      * Gets the name of the type that is invalid.
      *
@@ -71,6 +60,4 @@ class SwatInvalidPropertyTypeException extends SwatException
     {
         return $this->type;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatInvalidSerializedDataException.php
+++ b/Swat/exceptions/SwatInvalidSerializedDataException.php
@@ -8,17 +8,12 @@
  */
 class SwatInvalidSerializedDataException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The unsafe serialized data.
      *
      * @var string
      */
     protected $data;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new invalid serialized data exception.
@@ -33,9 +28,6 @@ class SwatInvalidSerializedDataException extends SwatException
         $this->data = $data;
     }
 
-    // }}}
-    // {{{ public function getData()
-
     /**
      * Gets the unsafe serialized data.
      *
@@ -45,6 +37,4 @@ class SwatInvalidSerializedDataException extends SwatException
     {
         return $this->data;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatInvalidSwatMLException.php
+++ b/Swat/exceptions/SwatInvalidSwatMLException.php
@@ -11,17 +11,12 @@
  */
 class SwatInvalidSwatMLException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The filename of the SwatML file that caused this exception to be thrown.
      *
      * @var string
      */
     protected $filename = '';
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new invalid SwatML exception.
@@ -36,9 +31,6 @@ class SwatInvalidSwatMLException extends SwatException
         $this->filename = $filename;
     }
 
-    // }}}
-    // {{{ public function getFilename()
-
     /**
      * Gets the filename of the SwatML file that caused this exception to be
      * thrown.
@@ -50,6 +42,4 @@ class SwatInvalidSwatMLException extends SwatException
     {
         return $this->filename;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatInvalidTypeException.php
+++ b/Swat/exceptions/SwatInvalidTypeException.php
@@ -8,17 +8,12 @@
  */
 class SwatInvalidTypeException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The value that is of the wrong type.
      *
      * @var mixed
      */
     protected $value;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new invalid type exception.
@@ -33,9 +28,6 @@ class SwatInvalidTypeException extends SwatException
         $this->value = $value;
     }
 
-    // }}}
-    // {{{ public function getValue()
-
     /**
      * Gets the value that is of the wrong type.
      *
@@ -45,6 +37,4 @@ class SwatInvalidTypeException extends SwatException
     {
         return $this->value;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatObjectNotFoundException.php
+++ b/Swat/exceptions/SwatObjectNotFoundException.php
@@ -8,17 +8,12 @@
  */
 class SwatObjectNotFoundException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The object id that was searched for.
      *
      * @var string
      */
     protected $object_id;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new object not found exception.
@@ -33,9 +28,6 @@ class SwatObjectNotFoundException extends SwatException
         $this->object_id = $object_id;
     }
 
-    // }}}
-    // {{{ public function getObjectId()
-
     /**
      * Gets the object id that was searched for.
      *
@@ -45,6 +37,4 @@ class SwatObjectNotFoundException extends SwatException
     {
         return $this->object_id;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatUndefinedConstantException.php
+++ b/Swat/exceptions/SwatUndefinedConstantException.php
@@ -8,17 +8,12 @@
  */
 class SwatUndefinedConstantException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The name of the constant that is undefined.
      *
      * @var string
      */
     protected $constant_name;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new undefined constant exception.
@@ -36,9 +31,6 @@ class SwatUndefinedConstantException extends SwatException
         $this->constant_name = $constant_name;
     }
 
-    // }}}
-    // {{{ public function getConstantName()
-
     /**
      * Gets the name of the constant that is undefined.
      *
@@ -48,6 +40,4 @@ class SwatUndefinedConstantException extends SwatException
     {
         return $this->constant_name;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatUndefinedMessageTypeException.php
+++ b/Swat/exceptions/SwatUndefinedMessageTypeException.php
@@ -8,17 +8,12 @@
  */
 class SwatUndefinedMessageTypeException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The name of the message type that is undefined.
      *
      * @var string
      */
     protected $message_type;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new undefined message type exception.
@@ -36,9 +31,6 @@ class SwatUndefinedMessageTypeException extends SwatException
         $this->message_type = $message_type;
     }
 
-    // }}}
-    // {{{ public function getMessageType()
-
     /**
      * Gets the name of the message type that is undefined.
      *
@@ -48,6 +40,4 @@ class SwatUndefinedMessageTypeException extends SwatException
     {
         return $this->message_type;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatUndefinedStockTypeException.php
+++ b/Swat/exceptions/SwatUndefinedStockTypeException.php
@@ -8,17 +8,12 @@
  */
 class SwatUndefinedStockTypeException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The name of the stock type that is undefined.
      *
      * @var string
      */
     protected $stock_type;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new undefined stock type exception.
@@ -33,9 +28,6 @@ class SwatUndefinedStockTypeException extends SwatException
         $this->stock_type = $stock_type;
     }
 
-    // }}}
-    // {{{ public function getStockType()
-
     /**
      * Gets the name of the stock type that is undefined.
      *
@@ -45,6 +37,4 @@ class SwatUndefinedStockTypeException extends SwatException
     {
         return $this->stock_type;
     }
-
-    // }}}
 }

--- a/Swat/exceptions/SwatWidgetNotFoundException.php
+++ b/Swat/exceptions/SwatWidgetNotFoundException.php
@@ -8,17 +8,12 @@
  */
 class SwatWidgetNotFoundException extends SwatException
 {
-    // {{{ protected properties
-
     /**
      * The widget id that was searched for.
      *
      * @var string
      */
     protected $widget_id;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new widget not found exception.
@@ -33,9 +28,6 @@ class SwatWidgetNotFoundException extends SwatException
         $this->widget_id = $widget_id;
     }
 
-    // }}}
-    // {{{ public function getWidgetId()
-
     /**
      * Gets the widget id that was searched for.
      *
@@ -45,6 +37,4 @@ class SwatWidgetNotFoundException extends SwatException
     {
         return $this->widget_id;
     }
-
-    // }}}
 }

--- a/SwatDB/SwatDB.php
+++ b/SwatDB/SwatDB.php
@@ -10,15 +10,10 @@
  */
 class SwatDB extends SwatObject
 {
-    // {{{ protected static properties
-
     protected static $query_count = 0;
     protected static $debug = false;
     protected static $debug_info = [];
     protected static $debug_wrapper_depth = 0;
-
-    // }}}
-    // {{{ public static function setDebug()
 
     /**
      * Sets the debug mode used by SwatDB.
@@ -30,9 +25,6 @@ class SwatDB extends SwatObject
     {
         self::$debug = (bool) $debug;
     }
-
-    // }}}
-    // {{{ public static function connect()
 
     /**
      * Connects to a database.
@@ -56,9 +48,6 @@ class SwatDB extends SwatObject
 
         return $db;
     }
-
-    // }}}
-    // {{{ public static function query()
 
     /**
      * Performs an SQL query.
@@ -118,9 +107,6 @@ class SwatDB extends SwatObject
         return $rs;
     }
 
-    // }}}
-    // {{{ public static function exec()
-
     /**
      * Execute a data manipulation SQL statement.
      *
@@ -137,9 +123,6 @@ class SwatDB extends SwatObject
     {
         return self::executeQuery($db, 'exec', [$sql]);
     }
-
-    // }}}
-    // {{{ public static function updateColumn()
 
     /**
      * Update a column.
@@ -210,9 +193,6 @@ class SwatDB extends SwatObject
         return self::exec($db, $sql);
     }
 
-    // }}}
-    // {{{ public static function queryColumn()
-
     /**
      * Query a column.
      *
@@ -265,9 +245,6 @@ class SwatDB extends SwatObject
         return self::executeQuery($db, 'queryCol', [$sql, $field->type]);
     }
 
-    // }}}
-    // {{{ public static function queryOne()
-
     /**
      * Query a single value.
      *
@@ -288,9 +265,6 @@ class SwatDB extends SwatObject
 
         return self::executeQuery($db, 'queryOne', [$sql, $mdb2_type]);
     }
-
-    // }}}
-    // {{{ public static function queryRow()
 
     /**
      * Query a single row.
@@ -315,9 +289,6 @@ class SwatDB extends SwatObject
             MDB2_FETCHMODE_OBJECT,
         ]);
     }
-
-    // }}}
-    // {{{ public static function queryOneFromTable()
 
     /**
      * Query a single value from a specified table and column.
@@ -368,9 +339,6 @@ class SwatDB extends SwatObject
 
         return self::queryOne($db, $sql, $field->type);
     }
-
-    // }}}
-    // {{{ public static function queryRowFromTable()
 
     /**
      * Query a single row from a specified table and column.
@@ -423,9 +391,6 @@ class SwatDB extends SwatObject
 
         return $row;
     }
-
-    // }}}
-    // {{{ public static function executeStoredProc()
 
     /**
      * Performs a stored procedure.
@@ -493,9 +458,6 @@ class SwatDB extends SwatObject
         return $rs;
     }
 
-    // }}}
-    // {{{ public static function executeStoredProcOne()
-
     /**
      * Execute a stored procedure that returns a single value.
      *
@@ -522,9 +484,6 @@ class SwatDB extends SwatObject
 
         return current($row);
     }
-
-    // }}}
-    // {{{ public static function updateBinding()
 
     /**
      * Update a binding table.
@@ -629,9 +588,6 @@ class SwatDB extends SwatObject
         $transaction->commit();
     }
 
-    // }}}
-    // {{{ public static function insertRow()
-
     /**
      * Insert a row.
      *
@@ -712,9 +668,6 @@ class SwatDB extends SwatObject
         return $ret;
     }
 
-    // }}}
-    // {{{ public static function updateRow()
-
     /**
      * Update a row.
      *
@@ -776,9 +729,6 @@ class SwatDB extends SwatObject
         self::exec($db, $sql);
     }
 
-    // }}}
-    // {{{ public static function deleteRow()
-
     /**
      * Delete a row.
      *
@@ -809,9 +759,6 @@ class SwatDB extends SwatObject
 
         self::exec($db, $sql);
     }
-
-    // }}}
-    // {{{ public static function getOptionArray()
 
     /**
      * Query for an option array.
@@ -883,9 +830,6 @@ class SwatDB extends SwatObject
 
         return $options;
     }
-
-    // }}}
-    // {{{ public static function getCascadeOptionArray()
 
     /**
      * Query for an option array cascaded by a field.
@@ -977,9 +921,6 @@ class SwatDB extends SwatObject
 
         return $options;
     }
-
-    // }}}
-    // {{{ public static function getGroupedOptionArray()
 
     /**
      * Queries for a grouped option array.
@@ -1102,9 +1043,6 @@ class SwatDB extends SwatObject
         return $base_parent;
     }
 
-    // }}}
-    // {{{ public static function getFieldMax()
-
     /**
      * Get max field value.
      *
@@ -1134,9 +1072,6 @@ class SwatDB extends SwatObject
         return self::queryOne($db, $sql);
     }
 
-    // }}}
-    // {{{ public static function equalityOperator()
-
     /**
      * Get proper conditional operator.
      *
@@ -1163,9 +1098,6 @@ class SwatDB extends SwatObject
 
         return '=';
     }
-
-    // }}}
-    // {{{ public static function getDataTree()
 
     /**
      * Get a tree of data nodes.
@@ -1230,9 +1162,6 @@ class SwatDB extends SwatObject
         return $base_parent;
     }
 
-    // }}}
-    // {{{ public static function implodeSelection()
-
     /**
      * Implodes a view selection object.
      *
@@ -1259,9 +1188,6 @@ class SwatDB extends SwatObject
         return implode(',', $quoted_ids);
     }
 
-    // }}}
-    // {{{ private static function executeQuery()
-
     private static function executeQuery($db, $method, array $args)
     {
         self::$query_count++;
@@ -1275,9 +1201,6 @@ class SwatDB extends SwatObject
 
         return $ret;
     }
-
-    // }}}
-    // {{{ private static function getFieldNameArray()
 
     private static function getFieldNameArray($fields)
     {
@@ -1294,9 +1217,6 @@ class SwatDB extends SwatObject
         return $names;
     }
 
-    // }}}
-    // {{{ private static function getFieldTypeArray()
-
     private static function getFieldTypeArray($fields)
     {
         if (count($fields) === 0) {
@@ -1311,9 +1231,6 @@ class SwatDB extends SwatObject
 
         return $types;
     }
-
-    // }}}
-    // {{{ private static function initFields()
 
     /**
      * Transforms an array of text field identifiers ('type:name') into
@@ -1336,9 +1253,6 @@ class SwatDB extends SwatObject
             $field = new SwatDBField($field, 'text');
         }
     }
-
-    // }}}
-    // {{{ private static function initArray()
 
     /**
      * Noramlizes Iterator objects into simple arrays.
@@ -1369,9 +1283,6 @@ class SwatDB extends SwatObject
 
         throw new SwatDBException('Value is not an array');
     }
-
-    // }}}
-    // {{{ private static function debugStart()
 
     private static function debugStart($message)
     {
@@ -1416,9 +1327,6 @@ class SwatDB extends SwatObject
             self::$debug_wrapper_depth++;
         }
     }
-
-    // }}}
-    // {{{ private static function debugEnd()
 
     private static function debugEnd()
     {
@@ -1494,6 +1402,4 @@ class SwatDB extends SwatObject
             }
         }
     }
-
-    // }}}
 }

--- a/SwatDB/SwatDBCacheNsFlushable.php
+++ b/SwatDB/SwatDBCacheNsFlushable.php
@@ -8,14 +8,10 @@
  */
 interface SwatDBCacheNsFlushable
 {
-    // {{{ public function flushNs()
-
     /**
      * Flushes a cache name-space.
      *
      * @param string $ns The name-space to flush
      */
     public function flushNs($ns);
-
-    // }}}
 }

--- a/SwatDB/SwatDBDataObject.php
+++ b/SwatDB/SwatDBDataObject.php
@@ -8,8 +8,6 @@
  */
 class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecordable, SwatDBMarshallable, SwatDBFlushable
 {
-    // {{{ private properties
-
     /**
      * @var array
      */
@@ -55,9 +53,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
      */
     private $deprecated_properties = [];
 
-    // }}}
-    // {{{ protected properties
-
     /**
      * @var MDB2
      */
@@ -78,18 +73,12 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
      */
     protected $flushable_cache;
 
-    // }}}
-    // {{{ private properties
-
     /**
      * Cache of public property names indexed by class name.
      *
      * @var array
      */
     private static $public_properties_cache = [];
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * @param mixed $data
@@ -111,9 +100,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         $this->generatePropertyHashes();
     }
 
-    // }}}
-    // {{{ public function setTable()
-
     /**
      * @param string $table Database table
      */
@@ -121,9 +107,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
     {
         $this->table = $table;
     }
-
-    // }}}
-    // {{{ public function getModifiedProperties()
 
     /**
      * Gets a list of all the modified properties of this object.
@@ -150,9 +133,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
 
         return $modified_properties;
     }
-
-    // }}}
-    // {{{ public function __get()
 
     public function __get($key)
     {
@@ -199,9 +179,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
 
         return $value;
     }
-
-    // }}}
-    // {{{ public function __set()
 
     public function __set($key, $value)
     {
@@ -256,9 +233,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         }
     }
 
-    // }}}
-    // {{{ public function __isset()
-
     public function __isset($key)
     {
         $is_set = false;
@@ -273,9 +247,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
 
         return $is_set;
     }
-
-    // }}}
-    // {{{ public function __toString()
 
     /**
      * Gets a string representation of this data-object.
@@ -352,9 +323,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return $string;
     }
 
-    // }}}
-    // {{{ public function getInternalValue()
-
     public function getInternalValue($name)
     {
         if (array_key_exists($name, $this->internal_properties)) {
@@ -364,16 +332,10 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return null;
     }
 
-    // }}}
-    // {{{ public function hasInternalValue()
-
     public function hasInternalValue($name)
     {
         return array_key_exists($name, $this->internal_properties);
     }
-
-    // }}}
-    // {{{ public function hasPublicProperty()
 
     /**
      * Whether or not a public property exists for the given property name.
@@ -392,9 +354,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return array_key_exists($name, $public_properties);
     }
 
-    // }}}
-    // {{{ public function hasDateProperty()
-
     /**
      * Whether or not a registered date property exists for the given property
      * name.
@@ -410,9 +369,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
     {
         return in_array($name, $this->date_properties);
     }
-
-    // }}}
-    // {{{ public function duplicate()
 
     /**
      * Duplicates this object.
@@ -488,9 +444,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return $new_object;
     }
 
-    // }}}
-    // {{{ public function getAttributes()
-
     /**
      * Returns an array of the public and protected properties of this object.
      *
@@ -512,9 +465,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         );
     }
 
-    // }}}
-    // {{{ protected function setInternalValue()
-
     protected function setInternalValue($name, $value)
     {
         if (array_key_exists($name, $this->internal_properties)) {
@@ -522,21 +472,12 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         }
     }
 
-    // }}}
-    // {{{ protected function init()
-
     protected function init() {}
-
-    // }}}
-    // {{{ protected function registerDateProperty()
 
     protected function registerDateProperty($name)
     {
         $this->date_properties[] = $name;
     }
-
-    // }}}
-    // {{{ protected function registerInternalProperty()
 
     protected function registerInternalProperty(
         $name,
@@ -550,16 +491,10 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         $this->internal_property_classes[$name] = $class;
     }
 
-    // }}}
-    // {{{ protected function registerDeprecatedProperty()
-
     protected function registerDeprecatedProperty($name)
     {
         $this->deprecated_properties[] = $name;
     }
-
-    // }}}
-    // {{{ protected function initFromRow()
 
     /**
      * Takes a data row and sets the properties of this object according to
@@ -613,9 +548,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         $this->loaded_from_database = true;
     }
 
-    // }}}
-    // {{{ protected function generatePropertyHashes()
-
     /**
      * Generates the set of md5 hashes for this data object.
      *
@@ -637,9 +569,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         }
     }
 
-    // }}}
-    // {{{ protected function generatePropertyHash()
-
     /**
      * Generates the MD5 hash for a property of this object.
      *
@@ -660,9 +589,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         }
     }
 
-    // }}}
-    // {{{ protected function getHashValue()
-
     /**
      * Gets the hash of a value.
      *
@@ -676,9 +602,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
     {
         return md5(serialize($value));
     }
-
-    // }}}
-    // {{{ protected function getId()
 
     protected function getId()
     {
@@ -697,16 +620,10 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return $this->{$temp};
     }
 
-    // }}}
-    // {{{ protected function getSubDataObject()
-
     protected function getSubDataObject($name)
     {
         return $this->sub_data_objects[$name];
     }
-
-    // }}}
-    // {{{ protected function setSubDataObject()
 
     protected function setSubDataObject($name, $value)
     {
@@ -718,16 +635,10 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         }
     }
 
-    // }}}
-    // {{{ protected function unsetSubDataObject()
-
     protected function unsetSubDataObject($name)
     {
         unset($this->sub_data_objects[$name]);
     }
-
-    // }}}
-    // {{{ protected function hasSubDataObject()
 
     /**
      * Whether or not a sub data object is loaded for the given key.
@@ -742,21 +653,12 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return isset($this->sub_data_objects[(string) $key]);
     }
 
-    // }}}
-    // {{{ protected function setDeprecatedProperty()
-
     protected function setDeprecatedProperty($key, $value) {}
-
-    // }}}
-    // {{{ protected function getDeprecatedProperty()
 
     protected function getDeprecatedProperty($key)
     {
         return null;
     }
-
-    // }}}
-    // {{{ protected function getProtectedPropertyList()
 
     /**
      * Gets a list of all protected properties of this data-object.
@@ -774,9 +676,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
     {
         return [];
     }
-
-    // }}}
-    // {{{ private function getPublicProperties()
 
     /**
      * Gets the public properties of this data-object.
@@ -815,9 +714,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return $properties;
     }
 
-    // }}}
-    // {{{ private function getSerializableProtectedProperties()
-
     /**
      * Gets the serializable protected properties of this data-object.
      *
@@ -840,9 +736,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return $properties;
     }
 
-    // }}}
-    // {{{ private function getProtectedProperties()
-
     /**
      * Gets the protected properties of this data-object using the getter
      * accessor.
@@ -863,9 +756,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
 
         return $properties;
     }
-
-    // }}}
-    // {{{ private function getProperties()
 
     /**
      * Gets all the modifyable properties of this data-object.
@@ -889,9 +779,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return $property_array;
     }
 
-    // }}}
-    // {{{ private function getLoaderMethod()
-
     private function getLoaderMethod($key)
     {
         /*
@@ -909,9 +796,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
 
         return $cache[$key];
     }
-
-    // }}}
-    // {{{ private function getUsingLoaderMethod()
 
     private function getUsingLoaderMethod($key)
     {
@@ -936,9 +820,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
 
         return $value;
     }
-
-    // }}}
-    // {{{ private function getUsingInternalProperty()
 
     private function getUsingInternalProperty($key)
     {
@@ -989,10 +870,7 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return $value;
     }
 
-    // }}}
-
     // database loading and saving
-    // {{{ public function setDatabase()
 
     /**
      * Sets the database driver for this data-object.
@@ -1025,9 +903,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
             }
         }
     }
-
-    // }}}
-    // {{{ public function save()
 
     /**
      * Saves this object to the database.
@@ -1069,9 +944,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         $this->generatePropertyHashes();
     }
 
-    // }}}
-    // {{{ public function load()
-
     /**
      * Loads this object's properties from the database given an id.
      *
@@ -1094,9 +966,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
 
         return true;
     }
-
-    // }}}
-    // {{{ public function delete()
 
     /**
      * Deletes this object from the database.
@@ -1124,9 +993,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
             throw $e;
         }
     }
-
-    // }}}
-    // {{{ public function isModified()
 
     /**
      * Returns true if this object has been modified since it was loaded.
@@ -1180,9 +1046,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return false;
     }
 
-    // }}}
-    // {{{ protected function checkDB()
-
     protected function checkDB()
     {
         if ($this->db === null) {
@@ -1195,9 +1058,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
             );
         }
     }
-
-    // }}}
-    // {{{ protected function loadInternal()
 
     /**
      * Loads this object's properties from the database given an id.
@@ -1227,9 +1087,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
 
         return null;
     }
-
-    // }}}
-    // {{{ protected function saveInternal()
 
     /**
      * Saves this object to the database.
@@ -1331,9 +1188,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         $this->flushCacheNamespaces();
     }
 
-    // }}}
-    // {{{ protected function saveInternalProperties()
-
     protected function saveInternalProperties()
     {
         foreach ($this->internal_property_autosave as $name => $autosave) {
@@ -1344,9 +1198,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
             }
         }
     }
-
-    // }}}
-    // {{{ protected function saveSubDataObjects()
 
     protected function saveSubDataObjects()
     {
@@ -1375,9 +1226,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
             }
         }
     }
-
-    // }}}
-    // {{{ protected function deleteInternal()
 
     /**
      * Deletes this object from the database.
@@ -1411,9 +1259,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         }
     }
 
-    // }}}
-    // {{{ protected function saveNewBinding()
-
     /**
      * Saves a new binding object without an id to the database.
      *
@@ -1440,9 +1285,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         SwatDB::insertRow($this->db, $this->table, $fields, $values);
         $this->flushCacheNamespaces();
     }
-
-    // }}}
-    // {{{ protected function guessType()
 
     protected function guessType($name, $value)
     {
@@ -1472,9 +1314,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         }
     }
 
-    // }}}
-    // {{{ protected function rollback()
-
     protected function rollback(
         SwatDBTransaction $transaction,
         array $rollback_property_hashes,
@@ -1483,10 +1322,7 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         $transaction->rollback();
     }
 
-    // }}}
-
     // cache flushing
-    // {{{ public function setFlushableCache()
 
     /**
      * Sets the flushable cache to use for this dataobject.
@@ -1502,9 +1338,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         $this->flushable_cache = $cache;
     }
 
-    // }}}
-    // {{{ public function getCacheNamespaces()
-
     /**
      * Gets the name-spaces that should be flushed for this dataobject.
      *
@@ -1514,9 +1347,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
     {
         return [];
     }
-
-    // }}}
-    // {{{ public function getAvailableCacheNamespaces()
 
     /**
      * Gets all available name-spaces that should be flushed for this dataobject
@@ -1528,9 +1358,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
     {
         return [];
     }
-
-    // }}}
-    // {{{ public function flushCacheNamespaces()
 
     /**
      * Flushes the cache name-spaces for this object.
@@ -1557,9 +1384,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         }
     }
 
-    // }}}
-    // {{{ public function flushAvailableCacheNamespaces()
-
     /**
      * Flushes all possible cache name-spaces for this object.
      *
@@ -1573,27 +1397,18 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         $this->flushCacheNamespaces($namespaces);
     }
 
-    // }}}
-
     // serialization
-    // {{{ public function serialize()
 
     public function serialize(): string
     {
         return serialize($this->__serialize());
     }
 
-    // }}}
-    // {{{ public function unserialize()
-
     public function unserialize(string $data): void
     {
         $data = unserialize($data);
         $this->__unserialize($data);
     }
-
-    // }}}
-    // {{{ public function __serialize()
 
     public function __serialize(): array
     {
@@ -1636,9 +1451,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return $data;
     }
 
-    // }}}
-    // {{{ public function __unserialize()
-
     public function __unserialize(array $data): void
     {
         $this->init();
@@ -1662,9 +1474,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
             }
         }
     }
-
-    // }}}
-    // {{{ public function marshall()
 
     public function marshall(array $tree = [])
     {
@@ -1731,9 +1540,6 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         return $data;
     }
 
-    // }}}
-    // {{{ public function unmarshall()
-
     public function unmarshall(array $data = [])
     {
         // public properties
@@ -1790,16 +1596,10 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
         }
     }
 
-    // }}}
-    // {{{ protected function getSerializableSubDataObjects()
-
     protected function getSerializableSubDataObjects()
     {
         return [];
     }
-
-    // }}}
-    // {{{ protected function getSerializablePrivateProperties()
 
     protected function getSerializablePrivateProperties()
     {
@@ -1813,6 +1613,4 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
             'read_only',
         ];
     }
-
-    // }}}
 }

--- a/SwatDB/SwatDBDefaultRecordsetWrapper.php
+++ b/SwatDB/SwatDBDefaultRecordsetWrapper.php
@@ -10,13 +10,9 @@
  */
 class SwatDBDefaultRecordsetWrapper extends SwatDBRecordsetWrapper
 {
-    // {{{ public function __construct()
-
     public function __construct($rs = null)
     {
         $this->row_wrapper_class = null;
         parent::__construct($rs);
     }
-
-    // }}}
 }

--- a/SwatDB/SwatDBField.php
+++ b/SwatDB/SwatDBField.php
@@ -10,8 +10,6 @@
  */
 class SwatDBField extends SwatObject
 {
-    // {{{ public properties
-
     /**
      * The name of the database field.
      *
@@ -27,9 +25,6 @@ class SwatDBField extends SwatObject
      * @var string
      */
     public $type;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * @param string $field        a string representation of a database field in the
@@ -52,9 +47,6 @@ class SwatDBField extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ public function __toString()
-
     /**
      * Get the field as a string.
      *
@@ -66,6 +58,4 @@ class SwatDBField extends SwatObject
     {
         return $this->type . ':' . $this->name;
     }
-
-    // }}}
 }

--- a/SwatDB/SwatDBFlushable.php
+++ b/SwatDB/SwatDBFlushable.php
@@ -8,8 +8,6 @@
  */
 interface SwatDBFlushable
 {
-    // {{{ public function setFlushableCache()
-
     /**
      * Sets the flushable cache to use for this object.
      *
@@ -19,6 +17,4 @@ interface SwatDBFlushable
      * @see SwatDBCacheNsFlushable
      */
     public function setFlushableCache(SwatDBCacheNsFlushable $cache);
-
-    // }}}
 }

--- a/SwatDB/SwatDBMarshallable.php
+++ b/SwatDB/SwatDBMarshallable.php
@@ -15,8 +15,6 @@
  */
 interface SwatDBMarshallable
 {
-    // {{{ public function marshall()
-
     /**
      * Marshalls this object.
      *
@@ -43,9 +41,6 @@ interface SwatDBMarshallable
      */
     public function marshall(array $tree = []);
 
-    // }}}
-    // {{{ public function unmarshall()
-
     /**
      * Unmarshalls this object using the specified data.
      *
@@ -58,6 +53,4 @@ interface SwatDBMarshallable
      * @param array $data optional. The marshalled object data.
      */
     public function unmarshall(array $data = []);
-
-    // }}}
 }

--- a/SwatDB/SwatDBRange.php
+++ b/SwatDB/SwatDBRange.php
@@ -17,8 +17,6 @@
  */
 class SwatDBRange extends SwatObject
 {
-    // {{{ private properties
-
     /**
      * The limit of this range.
      *
@@ -37,9 +35,6 @@ class SwatDBRange extends SwatObject
      */
     private $offset;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new database range.
      *
@@ -53,9 +48,6 @@ class SwatDBRange extends SwatObject
         $this->offset = intval($offset);
     }
 
-    // }}}
-    // {{{ public function getLimit()
-
     /**
      * Gets the limit of this range.
      *
@@ -65,9 +57,6 @@ class SwatDBRange extends SwatObject
     {
         return $this->limit;
     }
-
-    // }}}
-    // {{{ public function getOffset()
 
     /**
      * Gets the offset of this range.
@@ -79,9 +68,6 @@ class SwatDBRange extends SwatObject
         return $this->offset;
     }
 
-    // }}}
-    // {{{ public function addOffset()
-
     /**
      * Increases the offset of this range.
      *
@@ -91,9 +77,6 @@ class SwatDBRange extends SwatObject
     {
         $this->offset += intval($offset);
     }
-
-    // }}}
-    // {{{ public function combine()
 
     /**
      * Combines this range with another range forming a new range.
@@ -129,6 +112,4 @@ class SwatDBRange extends SwatObject
 
         return new SwatDBRange($limit, $offset);
     }
-
-    // }}}
 }

--- a/SwatDB/SwatDBReadaheadIterator.php
+++ b/SwatDB/SwatDBReadaheadIterator.php
@@ -23,8 +23,6 @@
  */
 class SwatDBReadaheadIterator extends SwatObject
 {
-    // {{{ private properties
-
     /**
      * The iterator object being iterated.
      *
@@ -45,9 +43,6 @@ class SwatDBReadaheadIterator extends SwatObject
      * @var mixed
      */
     private $key;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Creates a new readahead iterator.
@@ -75,9 +70,6 @@ class SwatDBReadaheadIterator extends SwatObject
         $this->rewind();
     }
 
-    // }}}
-    // {{{ public function getCurrent()
-
     /**
      * Gets the current item.
      *
@@ -89,9 +81,6 @@ class SwatDBReadaheadIterator extends SwatObject
     {
         return $this->current;
     }
-
-    // }}}
-    // {{{ public function getKey()
 
     /**
      * Gets the key of the current item.
@@ -105,9 +94,6 @@ class SwatDBReadaheadIterator extends SwatObject
     {
         return $this->key;
     }
-
-    // }}}
-    // {{{ public function getNext()
 
     /**
      * Gets the next item.
@@ -123,9 +109,6 @@ class SwatDBReadaheadIterator extends SwatObject
         return $this->isLast() ? null : $this->iterator->current();
     }
 
-    // }}}
-    // {{{ public function getNextKey()
-
     /**
      * Gets the next item key.
      *
@@ -139,9 +122,6 @@ class SwatDBReadaheadIterator extends SwatObject
         return $this->isLast() ? null : $this->iterator->key();
     }
 
-    // }}}
-    // {{{ public function isLast()
-
     /**
      * Gets whether the current item is the last item.
      *
@@ -152,9 +132,6 @@ class SwatDBReadaheadIterator extends SwatObject
     {
         return !$this->iterator->valid();
     }
-
-    // }}}
-    // {{{ public function iterate()
 
     /**
      * Iterates over this readahead iterator.
@@ -175,9 +152,6 @@ class SwatDBReadaheadIterator extends SwatObject
         return $valid;
     }
 
-    // }}}
-    // {{{ public function rewind()
-
     /**
      * Rewinds this readahead iterator back to the start.
      */
@@ -187,6 +161,4 @@ class SwatDBReadaheadIterator extends SwatObject
         $this->current = null;
         $this->key = null;
     }
-
-    // }}}
 }

--- a/SwatDB/SwatDBRecordable.php
+++ b/SwatDB/SwatDBRecordable.php
@@ -8,8 +8,6 @@
  */
 interface SwatDBRecordable
 {
-    // {{{ public function setDatabase()
-
     /**
      * Sets the database driver to use for this object.
      *
@@ -22,16 +20,10 @@ interface SwatDBRecordable
      */
     public function setDatabase(MDB2_Driver_Common $db, array $set = []);
 
-    // }}}
-    // {{{ public function save()
-
     /**
      * Saves this object to the database.
      */
     public function save();
-
-    // }}}
-    // {{{ public function load()
 
     /**
      * Loads this object from the database.
@@ -44,16 +36,10 @@ interface SwatDBRecordable
      */
     public function load($data);
 
-    // }}}
-    // {{{ public function delete()
-
     /**
      * Deletes this object from the database.
      */
     public function delete();
-
-    // }}}
-    // {{{ public function isModified()
 
     /**
      * Gets whether or not this object is modified.
@@ -61,6 +47,4 @@ interface SwatDBRecordable
      * @return bool true if this object is modified and false if it is not
      */
     public function isModified();
-
-    // }}}
 }

--- a/SwatDB/SwatDBRecordsetWrapper.php
+++ b/SwatDB/SwatDBRecordsetWrapper.php
@@ -26,8 +26,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
     SwatDBMarshallable,
     SwatDBFlushable
 {
-    // {{{ protected properties
-
     /**
      * The name of the row wrapper class to use for this recordset wrapper.
      *
@@ -60,9 +58,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
      * @see SwatDBRecordsetWrapper::setOptions()
      */
     protected $options = [];
-
-    // }}}
-    // {{{ private properties
 
     /**
      * Records contained in this recordset.
@@ -103,9 +98,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
      */
     private $current_index = 0;
 
-    // }}}
-    // {{{ public function __construct()
-
     /**
      * Creates a new recordset wrapper.
      *
@@ -125,9 +117,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
             $this->initializeFromResultSet($rs);
         }
     }
-
-    // }}}
-    // {{{ public function initializeFromResultSet()
 
     public function initializeFromResultSet(MDB2_Result_Common $rs)
     {
@@ -164,9 +153,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         } while ($rs->nextResult());
     }
 
-    // }}}
-    // {{{ public function duplicate()
-
     /**
      * Duplicates this record set wrapper.
      *
@@ -190,9 +176,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
 
         return $new_wrapper;
     }
-
-    // }}}
-    // {{{ public function setOptions()
 
     /**
      * Sets one or more options for this recordset wrapper.
@@ -230,9 +213,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return $this;
     }
 
-    // }}}
-    // {{{ public function getOption()
-
     /**
      * Gets an option value or a default value if the option is not set.
      *
@@ -254,9 +234,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return $value;
     }
 
-    // }}}
-    // {{{ public function copyEmpty()
-
     /**
      * Creates a new empty copy of this recordset wrapper.
      *
@@ -273,9 +250,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
 
         return $wrapper;
     }
-
-    // }}}
-    // {{{ protected function instantiateRowWrapperObject()
 
     /**
      * Creates a new dataobject.
@@ -300,9 +274,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return $object;
     }
 
-    // }}}
-    // {{{ protected function init()
-
     /**
      * Initializes this recordset wrapper.
      *
@@ -319,9 +290,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
      */
     protected function init() {}
 
-    // }}}
-    // {{{ protected function checkDB()
-
     protected function checkDB()
     {
         if ($this->db === null) {
@@ -335,10 +303,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         }
     }
 
-    // }}}
-
     // array access
-    // {{{ public function offsetExists()
 
     /**
      * Gets whether or not a value exists for the given offset.
@@ -358,9 +323,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
 
         return isset($this->objects_by_index[$offset]);
     }
-
-    // }}}
-    // {{{ public function offsetGet()
 
     /**
      * Gets a record in this recordset by an offset value.
@@ -389,9 +351,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
 
         return $this->objects_by_index[$offset];
     }
-
-    // }}}
-    // {{{ public function offsetSet()
 
     /**
      * Sets a record at a specified offset.
@@ -489,9 +448,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         }
     }
 
-    // }}}
-    // {{{ public function offsetUnset()
-
     /**
      * Unsets a record in this recordset at the specified offset.
      *
@@ -542,10 +498,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         }
     }
 
-    // }}}
-
     // iteration
-    // {{{ public function current()
 
     /**
      * Returns the current element.
@@ -556,9 +509,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
     {
         return $this->objects[$this->current_index];
     }
-
-    // }}}
-    // {{{ public function key()
 
     /**
      * Returns the key of the current record.
@@ -583,9 +533,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return $key;
     }
 
-    // }}}
-    // {{{ public function next()
-
     /**
      * Moves forward to the next element.
      */
@@ -594,9 +541,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         $this->current_index++;
     }
 
-    // }}}
-    // {{{ public function rewind()
-
     /**
      * Rewinds this iterator to the first element.
      */
@@ -604,9 +548,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
     {
         $this->current_index = 0;
     }
-
-    // }}}
-    // {{{ public function valid()
 
     /**
      * Checks is there is a current element after calls to rewind() and next().
@@ -619,10 +560,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return array_key_exists($this->current_index, $this->objects);
     }
 
-    // }}}
-
     // counting
-    // {{{ public function getCount()
 
     /**
      * Gets the number of records in this recordset.
@@ -637,9 +575,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return count($this);
     }
 
-    // }}}
-    // {{{ public function count()
-
     /**
      * Gets the number of records in this recordset.
      *
@@ -652,26 +587,17 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return count($this->objects);
     }
 
-    // }}}
-
     // serialization
-    // {{{ public function serialize()
 
     public function serialize(): string
     {
         return serialize($this->__serialize());
     }
 
-    // }}}
-    // {{{ public function unserialize()
-
     public function unserialize(string $data): void
     {
         $this->__unserialize(unserialize($data));
     }
-
-    // }}}
-    // {{{ public function __serialize()
 
     public function __serialize(): array
     {
@@ -692,18 +618,12 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return $data;
     }
 
-    // }}}
-    // {{{ public function __unserialize()
-
     public function __unserialize(array $data): void
     {
         foreach ($data as $property => $value) {
             $this->{$property} = $value;
         }
     }
-
-    // }}}
-    // {{{ public function marshall()
 
     public function marshall(array $tree = [])
     {
@@ -726,9 +646,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
 
         return $data;
     }
-
-    // }}}
-    // {{{ public function unmarshall()
 
     public function unmarshall(array $data = [])
     {
@@ -758,10 +675,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         }
     }
 
-    // }}}
-
     // manipulating of sub data objects
-    // {{{ public function getInternalValues()
 
     /**
      * Gets the values of an internal property for each record in this set.
@@ -794,9 +708,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
 
         return $values;
     }
-
-    // }}}
-    // {{{ public function loadAllSubDataObjects()
 
     /**
      * Loads all sub-data-objects for an internal property of the data-objects
@@ -848,9 +759,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return $sub_data_objects;
     }
 
-    // }}}
-    // {{{ public function attachSubDataObjects()
-
     /**
      * Attach existing sub-dataobjects for an internal property of the
      * dataobjects in this recordset.
@@ -880,10 +788,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         }
     }
 
-    // }}}
-
     // manipulating of sub-recordsets
-    // {{{ public function loadAllSubRecordsets()
 
     /**
      * Efficiently loads sub-recordsets for records in this recordset.
@@ -982,9 +887,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         );
     }
 
-    // }}}
-    // {{{ public function attachSubRecordset()
-
     /**
      * Efficiently loads sub-recordsets for records in this recordset.
      *
@@ -1043,10 +945,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return $recordset;
     }
 
-    // }}}
-
     // manipulating of objects
-    // {{{ public function getIndexes()
 
     /**
      * Gets the index values of the records in this recordset.
@@ -1068,9 +967,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return array_keys($this->objects_by_index);
     }
 
-    // }}}
-    // {{{ public function getArray()
-
     /**
      * Gets this recordset as an array of objects.
      *
@@ -1081,9 +977,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
     {
         return $this->objects;
     }
-
-    // }}}
-    // {{{ public function getFirst()
 
     /**
      * Retrieves the first object in this recordset.
@@ -1102,9 +995,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return $first;
     }
 
-    // }}}
-    // {{{ public function getLast()
-
     /**
      * Retrieves the last object in this recordset.
      *
@@ -1121,9 +1011,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
 
         return $last;
     }
-
-    // }}}
-    // {{{ public function getByIndex()
 
     /**
      * Retrieves a record in this recordset by index.
@@ -1148,9 +1035,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return $this[$index] ?? null;
     }
 
-    // }}}
-    // {{{ public function add()
-
     /**
      * Adds a record to this recordset.
      *
@@ -1168,9 +1052,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
     {
         $this[] = $object;
     }
-
-    // }}}
-    // {{{ public function remove()
 
     /**
      * Removes a record from this recordset.
@@ -1202,9 +1083,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         }
     }
 
-    // }}}
-    // {{{ public function removeByIndex()
-
     /**
      * Removes a record from this recordset given the record's index value.
      *
@@ -1224,9 +1102,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         unset($this[$index]);
     }
 
-    // }}}
-    // {{{ public function removeAll()
-
     /**
      * Removes all records from this recordset.
      */
@@ -1237,9 +1112,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         $this->objects_by_index = [];
         $this->current_index = 0;
     }
-
-    // }}}
-    // {{{ public function reindex()
 
     /**
      * Reindexes this recordset.
@@ -1260,9 +1132,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
             }
         }
     }
-
-    // }}}
-    // {{{ public function getPropertyValues()
 
     /**
      * Gets the values of a property for each record in this set.
@@ -1294,10 +1163,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return $values;
     }
 
-    // }}}
-
     // database loading and saving
-    // {{{ public function setDatabase()
 
     /**
      * Sets the database driver for this recordset.
@@ -1330,9 +1196,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
             }
         }
     }
-
-    // }}}
-    // {{{ public function save()
 
     /**
      * Saves this recordset to the database.
@@ -1372,9 +1235,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         $this->removed_objects = [];
         $this->reindex();
     }
-
-    // }}}
-    // {{{ public function load()
 
     /**
      * Loads a set of records into this recordset.
@@ -1451,9 +1311,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return $success;
     }
 
-    // }}}
-    // {{{ public function delete()
-
     /**
      * Deletes this recordset from the database.
      *
@@ -1465,9 +1322,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         $this->removeAll();
         $this->save();
     }
-
-    // }}}
-    // {{{ public function isModified()
 
     /**
      * Returns true if this recordset has been modified since it was loaded.
@@ -1494,9 +1348,6 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         return false;
     }
 
-    // }}}
-    // {{{ public function setFlushableCache()
-
     /**
      * Sets the flushable cache to use for this record-set.
      *
@@ -1514,6 +1365,4 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
             }
         }
     }
-
-    // }}}
 }

--- a/SwatDB/SwatDBTransaction.php
+++ b/SwatDB/SwatDBTransaction.php
@@ -18,17 +18,12 @@
  */
 class SwatDBTransaction extends SwatObject
 {
-    // {{{ private properties
-
     /**
      * The database driver object to perform the transaction with.
      *
      * @var MDB2_Driver_Common
      */
     private $db;
-
-    // }}}
-    // {{{ public function __construct()
 
     /**
      * Begins a new database transaction.
@@ -42,9 +37,6 @@ class SwatDBTransaction extends SwatObject
         $this->db->beginNestedTransaction();
     }
 
-    // }}}
-    // {{{ public function commit()
-
     /**
      * Commits this database transaction.
      */
@@ -52,9 +44,6 @@ class SwatDBTransaction extends SwatObject
     {
         $this->db->completeNestedTransaction();
     }
-
-    // }}}
-    // {{{ public function rollback()
 
     /**
      * Rolls-back this database transaction.
@@ -67,6 +56,4 @@ class SwatDBTransaction extends SwatObject
         // there is an error unless you pass the immediately param
         $this->db->completeNestedTransaction();
     }
-
-    // }}}
 }

--- a/SwatDB/exceptions/SwatDBException.php
+++ b/SwatDB/exceptions/SwatDBException.php
@@ -8,8 +8,6 @@
  */
 class SwatDBException extends SwatException
 {
-    // {{{ private function ___construct()
-
     public function __construct($message = null, $code = 0)
     {
         if (is_object($message) && $message instanceof PEAR_Error) {
@@ -21,6 +19,4 @@ class SwatDBException extends SwatException
 
         parent::__construct($message, $code);
     }
-
-    // }}}
 }

--- a/SwatDB/exceptions/SwatDBMarshallException.php
+++ b/SwatDB/exceptions/SwatDBMarshallException.php
@@ -9,15 +9,10 @@
  */
 class SwatDBMarshallException extends SwatDBException
 {
-    // {{{ protected properties
-
     /**
      * @var string
      */
     protected $property = '';
-
-    // }}}
-    // {{{ public function __construct()
 
     public function __construct($message, $code = 0, $property = '')
     {
@@ -25,13 +20,8 @@ class SwatDBMarshallException extends SwatDBException
         $this->property = $property;
     }
 
-    // }}}
-    // {{{ public function getProperty()
-
     public function getProperty()
     {
         return $this->property;
     }
-
-    // }}}
 }

--- a/SwatI18N/SwatI18NCurrencyFormat.php
+++ b/SwatI18N/SwatI18NCurrencyFormat.php
@@ -11,8 +11,6 @@
  */
 class SwatI18NCurrencyFormat extends SwatI18NNumberFormat
 {
-    // {{{ public properties
-
     /**
      * Number of fractional digits.
      *
@@ -111,9 +109,6 @@ class SwatI18NCurrencyFormat extends SwatI18NNumberFormat
      */
     public $symbol;
 
-    // }}}
-    // {{{ public function __toString()
-
     /**
      * Gets a string representation of this format.
      *
@@ -153,6 +148,4 @@ class SwatI18NCurrencyFormat extends SwatI18NNumberFormat
 
         return $string;
     }
-
-    // }}}
 }

--- a/SwatI18N/SwatI18NLocale.php
+++ b/SwatI18N/SwatI18NLocale.php
@@ -11,8 +11,6 @@
  */
 class SwatI18NLocale extends SwatObject
 {
-    // {{{ protected properties
-
     /**
      * The locale string or array specified in the constructor for this locale.
      *
@@ -68,9 +66,6 @@ class SwatI18NLocale extends SwatObject
      */
     protected $old_locale_by_category = [];
 
-    // }}}
-    // {{{ private properties
-
     /**
      * Cache of existing locale objects.
      *
@@ -82,9 +77,6 @@ class SwatI18NLocale extends SwatObject
      * @see SwatI18NLocale::get()
      */
     private static $locales = [];
-
-    // }}}
-    // {{{ public static function get()
 
     /**
      * Gets a locale object.
@@ -141,9 +133,6 @@ class SwatI18NLocale extends SwatObject
         return $locale_object;
     }
 
-    // }}}
-    // {{{ public static function setlocale()
-
     /**
      * Sets the current locale.
      *
@@ -198,9 +187,6 @@ class SwatI18NLocale extends SwatObject
         return $return;
     }
 
-    // }}}
-    // {{{ public function set()
-
     /**
      * Sets the system locale to this locale.
      *
@@ -219,9 +205,6 @@ class SwatI18NLocale extends SwatObject
         self::setlocale($category, $this->locale);
     }
 
-    // }}}
-    // {{{ public function reset()
-
     /**
      * Resets the system to the previous locale after a call to
      * {@link SwatI18NLocale::set()}.
@@ -235,9 +218,6 @@ class SwatI18NLocale extends SwatObject
     {
         self::setlocale($category, $this->old_locale_by_category[$category]);
     }
-
-    // }}}
-    // {{{ public function formatCurrency()
 
     /**
      * Formats a monetary value for this locale.
@@ -529,9 +509,6 @@ class SwatI18NLocale extends SwatObject
         return $formatted_value;
     }
 
-    // }}}
-    // {{{ public function formatNumber()
-
     /**
      * Formats a numeric value for this locale.
      *
@@ -582,9 +559,6 @@ class SwatI18NLocale extends SwatObject
         return $sign . $integer_part . $fractional_part;
     }
 
-    // }}}
-    // {{{ public function parseCurrency()
-
     /**
      * Parses a currency string formatted for this locale into a floating-point
      * number.
@@ -631,9 +605,6 @@ class SwatI18NLocale extends SwatObject
         return $value;
     }
 
-    // }}}
-    // {{{ public function parseFloat()
-
     /**
      * Parses a numeric string formatted for this locale into a floating-point
      * number.
@@ -673,9 +644,6 @@ class SwatI18NLocale extends SwatObject
 
         return $value;
     }
-
-    // }}}
-    // {{{ public function parseInteger()
 
     /**
      * Parses a numeric string formatted for this locale into an integer number.
@@ -738,9 +706,6 @@ class SwatI18NLocale extends SwatObject
         return $value;
     }
 
-    // }}}
-    // {{{ public function getNumberFormat()
-
     /**
      * Gets the number format for this locale.
      *
@@ -752,9 +717,6 @@ class SwatI18NLocale extends SwatObject
     {
         return clone $this->number_format;
     }
-
-    // }}}
-    // {{{ public function getNationalCurrencyFormat()
 
     /**
      * Gets the national currency format for this locale.
@@ -768,9 +730,6 @@ class SwatI18NLocale extends SwatObject
         return clone $this->national_currency_format;
     }
 
-    // }}}
-    // {{{ public function getInternationalCurrencyFormat()
-
     /**
      * Gets the international currency format for this locale.
      *
@@ -782,9 +741,6 @@ class SwatI18NLocale extends SwatObject
     {
         return clone $this->international_currency_format;
     }
-
-    // }}}
-    // {{{ public function getInternationalCurrencySymbol()
 
     /**
      * Gets the international currency symbol of this locale.
@@ -801,9 +757,6 @@ class SwatI18NLocale extends SwatObject
         return mb_substr($lc['int_curr_symbol'], 0, 3);
     }
 
-    // }}}
-    // {{{ public function getLocaleInfo()
-
     /**
      * Gets numeric formatting information for this locale.
      *
@@ -819,9 +772,6 @@ class SwatI18NLocale extends SwatObject
         return $this->locale_info;
     }
 
-    // }}}
-    // {{{ public function __toString()
-
     /**
      * Gets a string representation of this locale.
      *
@@ -833,9 +783,6 @@ class SwatI18NLocale extends SwatObject
     {
         return $this->preferred_locale;
     }
-
-    // }}}
-    // {{{ protected function detectCharacterEncoding()
 
     /**
      * Detects the character encoding used by this locale.
@@ -881,9 +828,6 @@ class SwatI18NLocale extends SwatObject
         return $encoding;
     }
 
-    // }}}
-    // {{{ protected function buildLocaleInfo()
-
     /**
      * Builds the locale info array for this locale.
      */
@@ -920,9 +864,6 @@ class SwatI18NLocale extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ protected function buildNumberFormat()
-
     /**
      * Builds the number format of this locale.
      */
@@ -938,9 +879,6 @@ class SwatI18NLocale extends SwatObject
 
         $this->number_format = $format;
     }
-
-    // }}}
-    // {{{ protected function buildNationalCurrencyFormat()
 
     /**
      * Builds the national currency format of this locale.
@@ -984,9 +922,6 @@ class SwatI18NLocale extends SwatObject
         $this->national_currency_format = $format;
     }
 
-    // }}}
-    // {{{ protected function buildInternationalCurrencyFormat()
-
     /**
      * Builds the internatiobal currency format for this locale.
      */
@@ -1016,9 +951,6 @@ class SwatI18NLocale extends SwatObject
 
         $this->international_currency_format = $format;
     }
-
-    // }}}
-    // {{{ protected function formatIntegerGroupings()
 
     /**
      * Formats the integer part of a value according to format-specific numeric
@@ -1129,9 +1061,6 @@ class SwatI18NLocale extends SwatObject
         );
     }
 
-    // }}}
-    // {{{ protected function formatFractionalPart()
-
     /**
      * Formats the fractional  part of a value.
      *
@@ -1168,9 +1097,6 @@ class SwatI18NLocale extends SwatObject
 
         return $formatted_value;
     }
-
-    // }}}
-    // {{{ protected function parseNegativeNotation
 
     /**
      * Parses the negative notation for a numeric string formatted in this
@@ -1241,9 +1167,6 @@ class SwatI18NLocale extends SwatObject
         return $string;
     }
 
-    // }}}
-    // {{{ protected function getFractionalPrecision()
-
     /**
      * Gets the fractional precision of a floating point number.
      *
@@ -1289,9 +1212,6 @@ class SwatI18NLocale extends SwatObject
         return $precision;
     }
 
-    // }}}
-    // {{{ protected function roundToEven()
-
     /**
      * Rounds a number to the specified number of fractional digits using the
      * round-to-even rounding method.
@@ -1326,9 +1246,6 @@ class SwatI18NLocale extends SwatObject
 
         return $value;
     }
-
-    // }}}
-    // {{{ private function __construct()
 
     /**
      * Creates a new locale object.
@@ -1376,9 +1293,6 @@ class SwatI18NLocale extends SwatObject
         }
     }
 
-    // }}}
-    // {{{ private function iconvArray()
-
     /**
      * Recursivly converts the character encoding of all strings in an array.
      *
@@ -1418,6 +1332,4 @@ class SwatI18NLocale extends SwatObject
 
         return $array;
     }
-
-    // }}}
 }

--- a/SwatI18N/SwatI18NNumberFormat.php
+++ b/SwatI18N/SwatI18NNumberFormat.php
@@ -11,8 +11,6 @@
  */
 class SwatI18NNumberFormat extends SwatObject
 {
-    // {{{ public properties
-
     /**
      * Decimal point character.
      *
@@ -33,9 +31,6 @@ class SwatI18NNumberFormat extends SwatObject
      * @var array
      */
     public $grouping;
-
-    // }}}
-    // {{{ public function override()
 
     /**
      * Gets a new number format object with certain properties overridden from
@@ -87,9 +82,6 @@ class SwatI18NNumberFormat extends SwatObject
         return $new_format;
     }
 
-    // }}}
-    // {{{ public function __toString()
-
     /**
      * Gets a string representation of this format.
      *
@@ -113,6 +105,4 @@ class SwatI18NNumberFormat extends SwatObject
 
         return $string;
     }
-
-    // }}}
 }

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "ext-pcre": "*",
     "pear/pear_exception": "^1.0.0",
     "silverorange/concentrate": "^2.0.0",
-    "silverorange/mdb2": "^3.1.1",
+    "silverorange/mdb2": "^3.1.2",
     "silverorange/yui": "^1.0.11"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -73,9 +73,11 @@
   },
   "scripts": {
     "phpcs": "./vendor/bin/php-cs-fixer check -v",
+    "phpcs:ci": "./vendor/bin/php-cs-fixer check --config=.php-cs-fixer.php --no-interaction --show-progress=none --diff --using-cache=no -vvv",
     "phpcs:write": "./vendor/bin/php-cs-fixer fix -v",
-    "phpstan": "./vendor/bin/phpstan analyse",
-    "phpstan:baseline": "./vendor/bin/phpstan analyse --generate-baseline"
+    "phpstan": "./vendor/bin/phpstan analyze",
+    "phpstan:ci": "./vendor/bin/phpstan analyze -vvv --no-progress --memory-limit 2G",
+    "phpstan:baseline": "./vendor/bin/phpstan analyze --generate-baseline"
   },
   "config": {
     "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2442fa536faabc4d3d7f23fb6281d0e",
+    "content-hash": "5564b1bb53919d76f07092ca03a12cf5",
     "packages": [
         {
             "name": "league/climate",
@@ -471,40 +471,61 @@
         },
         {
             "name": "silverorange/mdb2",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverorange/MDB2.git",
-                "reference": "35d0af9cc62c12fd9e27595434ab44361eb8c6fc"
+                "reference": "c80f69fe983faa46a9a8dcd34152550b2553cacb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://composer.silverorange.com/dist/silverorange/mdb2/silverorange-mdb2-35d0af9cc62c12fd9e27595434ab44361eb8c6fc-zip-9e28e8.zip",
-                "reference": "35d0af9cc62c12fd9e27595434ab44361eb8c6fc",
-                "shasum": "9fd724f2bcea500e041947678398e5e43f02f8b6"
+                "url": "https://composer.silverorange.com/dist/silverorange/mdb2/silverorange-mdb2-c80f69fe983faa46a9a8dcd34152550b2553cacb-zip-49436c.zip",
+                "reference": "c80f69fe983faa46a9a8dcd34152550b2553cacb",
+                "shasum": "dbcf06f1dc5e89cca4e2db4c27c26a7e9d5d3cea"
             },
             "require": {
+                "ext-mbstring": "*",
                 "pear/pear-core-minimal": "^1.9.0",
-                "php": ">=5.3.0"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "silverorange/coding-standard": "^0.6.0"
+                "friendsofphp/php-cs-fixer": "^3.64.0",
+                "phpstan/phpstan": "^1.12",
+                "rector/rector": "^1.2"
             },
             "type": "library",
             "autoload": {
                 "psr-0": {
                     "MDB2": ""
-                }
+                },
+                "files": [
+                    "MDB2.php"
+                ]
             },
             "scripts": {
-                "lint": [
-                    "./vendor/bin/phpcs"
+                "phpcs": [
+                    "./vendor/bin/php-cs-fixer check -v"
                 ],
-                "post-install-cmd": [
-                    "./vendor/bin/phpcs --config-set installed_paths vendor/silverorange/coding-standard/src"
+                "phpcs:ci": [
+                    "./vendor/bin/php-cs-fixer check --config=.php-cs-fixer.php --no-interaction --show-progress=none --diff --using-cache=no -vvv"
                 ],
-                "post-update-cmd": [
-                    "./vendor/bin/phpcs --config-set installed_paths vendor/silverorange/coding-standard/src"
+                "phpcs:write": [
+                    "./vendor/bin/php-cs-fixer fix -v"
+                ],
+                "phpstan": [
+                    "./vendor/bin/phpstan analyze"
+                ],
+                "phpstan:ci": [
+                    "./vendor/bin/phpstan analyze -vvv --no-progress --memory-limit 2G"
+                ],
+                "phpstan:baseline": [
+                    "./vendor/bin/phpstan analyze --generate-baseline"
+                ],
+                "rector": [
+                    "./vendor/bin/rector --dry-run"
+                ],
+                "rector:write": [
+                    "./vendor/bin/rector"
                 ]
             },
             "license": [
@@ -525,9 +546,9 @@
                 "orm"
             ],
             "support": {
-                "source": "https://github.com/silverorange/MDB2/tree/3.1.1"
+                "source": "https://github.com/silverorange/MDB2/tree/3.1.2"
             },
-            "time": "2017-12-05T18:20:09+00:00"
+            "time": "2025-07-29T17:08:37+00:00"
         },
         {
             "name": "silverorange/yui",

--- a/demo/include/DemoApplication.php
+++ b/demo/include/DemoApplication.php
@@ -10,8 +10,6 @@
  */
 class DemoApplication
 {
-    // {{{ private properties
-
     private $ui;
     private $demo;
 
@@ -55,9 +53,6 @@ class DemoApplication
         'YesNoFlydown'      => 'SwatYesNoFlydown',
     ];
 
-    // }}}
-    // {{{ public function run()
-
     /**
      * test.
      */
@@ -93,17 +88,11 @@ class DemoApplication
         $this->buildLayout();
     }
 
-    // }}}
-    // {{{ private function buildTitle()
-
     private function buildTitle()
     {
         $this->layout_ui->getWidget('main_frame')->title
             = sprintf(Swat::_('%s Demo'), $this->available_demos[$this->demo]);
     }
-
-    // }}}
-    // {{{ private function buildDemo()
 
     private function buildDemo()
     {
@@ -123,9 +112,6 @@ class DemoApplication
         }
     }
 
-    // }}}
-    // {{{ private function buildXmlSourceView()
-
     private function buildXmlSourceView()
     {
         $filename = '../include/demos/' . mb_strtolower($this->demo) . '.xml';
@@ -144,9 +130,6 @@ class DemoApplication
         }
     }
 
-    // }}}
-    // {{{ private function buildPhpSourceView()
-
     private function buildPhpSourceView()
     {
         $filename = '../include/demos/' . $this->demo . 'Demo.php';
@@ -164,17 +147,11 @@ class DemoApplication
         }
     }
 
-    // }}}
-    // {{{ private function buildDemoMenuBar()
-
     private function buildDemoMenuBar()
     {
         $this->layout_ui->getWidget('menu')->setEntries($this->available_demos);
         $this->layout_ui->getWidget('menu')->setSelectedEntry($this->demo);
     }
-
-    // }}}
-    // {{{ private function buildDemoNavBar()
 
     private function buildDemoNavBar()
     {
@@ -187,9 +164,6 @@ class DemoApplication
             $navbar->addEntry(new SwatNavBarEntry('Swat Demos'));
         }
     }
-
-    // }}}
-    // {{{ private function buildDemoDocumentationMenuBar()
 
     private function buildDemoDocumentationMenuBar()
     {
@@ -445,9 +419,6 @@ class DemoApplication
         $documentation_links->setEntries($entries);
     }
 
-    // }}}
-    // {{{ private function buildFrontPage()
-
     private function buildFrontPage()
     {
         $content_block = new SwatContentBlock();
@@ -460,9 +431,6 @@ class DemoApplication
         $main_frame->title = 'Swat Demos';
         $main_frame->add($content_block);
     }
-
-    // }}}
-    // {{{ private function buildLayout()
 
     private function buildLayout()
     {
@@ -489,9 +457,6 @@ class DemoApplication
         require '../include/layout.php';
     }
 
-    // }}}
-    // {{{ private function getDemo()
-
     /**
      * Gets the demo page.
      */
@@ -506,6 +471,4 @@ class DemoApplication
 
         return $demo;
     }
-
-    // }}}
 }

--- a/demo/include/demos/ButtonDemo.php
+++ b/demo/include/demos/ButtonDemo.php
@@ -13,8 +13,6 @@ require_once 'Demo.php';
  */
 class ButtonDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $submit = $ui->getWidget('submit_throbber_button');
@@ -27,6 +25,4 @@ class ButtonDemo extends Demo
             sleep(2);
         }
     }
-
-    // }}}
 }

--- a/demo/include/demos/CalendarDemo.php
+++ b/demo/include/demos/CalendarDemo.php
@@ -13,8 +13,6 @@ require_once 'Demo.php';
  */
 class CalendarDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $flydown = $ui->getWidget('flydown');
@@ -30,6 +28,4 @@ class CalendarDemo extends Demo
             new SwatOption(8, 'Strawberry'),
         ];
     }
-
-    // }}}
 }

--- a/demo/include/demos/ChangeOrderDemo.php
+++ b/demo/include/demos/ChangeOrderDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class ChangeOrderDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $order_widget = $ui->getWidget('change_order');
@@ -26,6 +24,4 @@ class ChangeOrderDemo extends Demo
             7 => 'Grapefruit',
             8 => 'Strawberry']);
     }
-
-    // }}}
 }

--- a/demo/include/demos/CheckboxDemo.php
+++ b/demo/include/demos/CheckboxDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class CheckboxDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         // regular checkbox tree
@@ -66,6 +64,4 @@ class CheckboxDemo extends Demo
         $checkbox_entry_list = $ui->getWidget('checkbox_entry_list');
         $checkbox_entry_list->addOptionsByArray($checkbox_entry_list_options);
     }
-
-    // }}}
 }

--- a/demo/include/demos/DetailsViewDemo.php
+++ b/demo/include/demos/DetailsViewDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class DetailsViewDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $details_view = $ui->getWidget('details_view');
@@ -38,8 +36,6 @@ class DetailsViewDemo extends Demo
 
         $details_view->data = $fruit;
     }
-
-    // }}}
 }
 
 /**
@@ -50,8 +46,6 @@ class DetailsViewDemo extends Demo
  */
 class FruitObject
 {
-    // {{{ public properties
-
     public $align = '';
     public $image = '';
     public $image_width = 0;
@@ -63,6 +57,4 @@ class FruitObject
     public $harvest_date;
     public $cost = 0;
     public $text = '';
-
-    // }}}
 }

--- a/demo/include/demos/DisclosureDemo.php
+++ b/demo/include/demos/DisclosureDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class DisclosureDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $radiolist = $ui->getWidget('radio_list');
@@ -34,6 +32,4 @@ class DisclosureDemo extends Demo
 
         $ui->getWidget('note')->add($message, SwatMessageDisplay::DISMISS_OFF);
     }
-
-    // }}}
 }

--- a/demo/include/demos/FieldsetDemo.php
+++ b/demo/include/demos/FieldsetDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class FieldsetDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $radiolist = $ui->getWidget('radio_list');
@@ -26,6 +24,4 @@ class FieldsetDemo extends Demo
             7 => 'Grapefruit',
             8 => 'Strawberry']);
     }
-
-    // }}}
 }

--- a/demo/include/demos/FlydownDemo.php
+++ b/demo/include/demos/FlydownDemo.php
@@ -14,8 +14,6 @@ require_once 'Demo.php';
  */
 class FlydownDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $flydown = $ui->getWidget('flydown');
@@ -142,6 +140,4 @@ class FlydownDemo extends Demo
             ],
         ];
     }
-
-    // }}}
 }

--- a/demo/include/demos/MessageDisplayDemo.php
+++ b/demo/include/demos/MessageDisplayDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class MessageDisplayDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $short_message_display = $ui->getWidget('short_message_display');
@@ -74,6 +72,4 @@ class MessageDisplayDemo extends Demo
         $message->secondary_content = 'This message has secondary content.';
         $long_message_display->add($message);
     }
-
-    // }}}
 }

--- a/demo/include/demos/NavBarDemo.php
+++ b/demo/include/demos/NavBarDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class NavBarDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $navbar = $ui->getWidget('navbar_demo');
@@ -19,6 +17,4 @@ class NavBarDemo extends Demo
         $navbar->addEntry(new SwatNavBarEntry('Demos', '#'));
         $navbar->addEntry(new SwatNavBarEntry('NavBar'));
     }
-
-    // }}}
 }

--- a/demo/include/demos/PaginationDemo.php
+++ b/demo/include/demos/PaginationDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class PaginationDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $ui->getWidget('medium')->setCurrentPage(4);
@@ -22,6 +20,4 @@ class PaginationDemo extends Demo
 
         $ui->getWidget('small')->setCurrentPage(50);
     }
-
-    // }}}
 }

--- a/demo/include/demos/PasswordEntryDemo.php
+++ b/demo/include/demos/PasswordEntryDemo.php
@@ -10,14 +10,10 @@ require_once 'Demo.php';
  */
 class PasswordEntryDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $password = $ui->getWidget('password');
         $confirm_password = $ui->getWidget('confirm_password');
         $confirm_password->password_widget = $password;
     }
-
-    // }}}
 }

--- a/demo/include/demos/ProgressBarDemo.php
+++ b/demo/include/demos/ProgressBarDemo.php
@@ -13,8 +13,6 @@ require_once 'Demo.php';
  */
 class ProgressBarDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $message = new SwatMessage(
@@ -27,6 +25,4 @@ class ProgressBarDemo extends Demo
 
         $ui->getWidget('note')->add($message, SwatMessageDisplay::DISMISS_OFF);
     }
-
-    // }}}
 }

--- a/demo/include/demos/RadioListDemo.php
+++ b/demo/include/demos/RadioListDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class RadioListDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $radiolist = $ui->getWidget('radiolist');
@@ -83,6 +81,4 @@ class RadioListDemo extends Demo
         $radiotable->addDivider();
         $radiotable->addOption(new SwatOption(9, 'I don\'t like fruit'));
     }
-
-    // }}}
 }

--- a/demo/include/demos/SelectListDemo.php
+++ b/demo/include/demos/SelectListDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class SelectListDemo extends Demo
 {
-    // {{{ public function buildDemoUI()
-
     public function buildDemoUI(SwatUI $ui)
     {
         $select_list_options = [
@@ -25,6 +23,4 @@ class SelectListDemo extends Demo
         $select_list = $ui->getWidget('select_list');
         $select_list->addOptionsByArray($select_list_options);
     }
-
-    // }}}
 }

--- a/demo/include/demos/StringDemo.php
+++ b/demo/include/demos/StringDemo.php
@@ -13,8 +13,6 @@ require_once 'Demo.php';
  */
 class StringDemo extends Demo
 {
-    // {{{ private properties
-
     private $strings = [
         'Suspendisse potenti. Cras varius diam. Fusce mollis pharetra sapien. Curabitur vel tellus vel nisi luctus tempus.',
         'Nullam consequat metus porttitor libero. Integer rhoncus. Phasellus tortor.',
@@ -31,9 +29,6 @@ class StringDemo extends Demo
     private $text_blocks = [];
 
     private $unformatted_text_blocks = [];
-
-    // }}}
-    // {{{ public function buildDemoUI()
 
     public function buildDemoUI(SwatUI $ui)
     {
@@ -82,9 +77,6 @@ class StringDemo extends Demo
         $to_xhtml->content = ob_get_clean();
     }
 
-    // }}}
-    // {{{ protected function createLayout()
-
     protected function createLayout()
     {
         return new SiteLayout(
@@ -92,9 +84,6 @@ class StringDemo extends Demo
             '../include/layouts/xhtml/no-source.php'
         );
     }
-
-    // }}}
-    // {{{ private function testEllipsizeRight()
 
     private function testEllipsizeRight($length = 20)
     {
@@ -108,9 +97,6 @@ class StringDemo extends Demo
         echo '</ol>';
     }
 
-    // }}}
-    // {{{ private function testEllipsizeMIddle()
-
     private function testEllipsizeMiddle($length = 20)
     {
         echo '<ol class="string-demo">';
@@ -122,9 +108,6 @@ class StringDemo extends Demo
         }
         echo '</ol>';
     }
-
-    // }}}
-    // {{{ private function testCondense()
 
     private function testCondense()
     {
@@ -138,9 +121,6 @@ class StringDemo extends Demo
             echo '<div class="text-block">' . $condensed_text_block . '</div>';
         }
     }
-
-    // }}}
-    // {{{ private function testCondenseToName()
 
     private function testCondenseToName()
     {
@@ -156,9 +136,6 @@ class StringDemo extends Demo
         echo '</ol>';
     }
 
-    // }}}
-    // {{{ private function testToXHTML()
-
     private function testToXHTML()
     {
         foreach ($this->unformatted_text_blocks as $text_block) {
@@ -173,6 +150,4 @@ class StringDemo extends Demo
                 . nl2br(htmlspecialchars($xhtml_text_block, ENT_COMPAT, 'UTF-8')) . '</div>';
         }
     }
-
-    // }}}
 }

--- a/demo/include/demos/TableViewDemo.php
+++ b/demo/include/demos/TableViewDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class TableViewDemo extends Demo
 {
-    // {{{ public function buildDemoUI();
-
     public function buildDemoUI(SwatUI $ui)
     {
         $message = new SwatMessage(
@@ -53,8 +51,6 @@ class TableViewDemo extends Demo
 
         $table_view->model = $table_store;
     }
-
-    // }}}
 }
 
 /**
@@ -65,8 +61,6 @@ class TableViewDemo extends Demo
  */
 class FruitObject
 {
-    // {{{ public properties
-
     public $image = '';
     public $image_width = 0;
     public $image_height = 0;
@@ -76,6 +70,4 @@ class FruitObject
     public $makes_pie = false;
     public $harvest_date;
     public $cost = 0;
-
-    // }}}
 }

--- a/demo/include/demos/TableViewInputRowDemo.php
+++ b/demo/include/demos/TableViewInputRowDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class TableViewInputRowDemo extends Demo
 {
-    // {{{ public function buildDemoUI();
-
     public function buildDemoUI(SwatUI $ui)
     {
         $message = new SwatMessage(
@@ -44,8 +42,6 @@ class TableViewInputRowDemo extends Demo
 
         $table_view->model = $table_store;
     }
-
-    // }}}
 }
 
 /**
@@ -56,11 +52,7 @@ class TableViewInputRowDemo extends Demo
  */
 class FruitObject
 {
-    // {{{ public properties
-
     public $title = '';
     public $makes_jam = false;
     public $makes_pie = false;
-
-    // }}}
 }

--- a/demo/include/demos/TileViewDemo.php
+++ b/demo/include/demos/TileViewDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class TileViewDemo extends Demo
 {
-    // {{{ public function buildDemoUI();
-
     public function buildDemoUI(SwatUI $ui)
     {
         $data = [
@@ -104,8 +102,6 @@ class TileViewDemo extends Demo
 
         $tile_view->model = $table_store;
     }
-
-    // }}}
 }
 
 /**
@@ -116,8 +112,6 @@ class TileViewDemo extends Demo
  */
 class FruitObject
 {
-    // {{{ public properties
-
     public $image = '';
     public $image_width = 0;
     public $image_height = 0;
@@ -127,6 +121,4 @@ class FruitObject
     public $makes_pie = false;
     public $harvest_date;
     public $cost = 0;
-
-    // }}}
 }

--- a/demo/include/demos/ViewSelectorDemo.php
+++ b/demo/include/demos/ViewSelectorDemo.php
@@ -10,8 +10,6 @@ require_once 'Demo.php';
  */
 class ViewSelectorDemo extends Demo
 {
-    // {{{ public function buildDemoUI();
-
     public function buildDemoUI(SwatUI $ui)
     {
         $data = [
@@ -46,8 +44,6 @@ class ViewSelectorDemo extends Demo
         $table_view = $ui->getWidget('checkbox_table_view');
         $table_view->model = $table_store;
     }
-
-    // }}}
 }
 
 /**
@@ -58,8 +54,6 @@ class ViewSelectorDemo extends Demo
  */
 class FruitObject
 {
-    // {{{ public properties
-
     public $image = '';
     public $image_width = 0;
     public $image_height = 0;
@@ -69,6 +63,4 @@ class FruitObject
     public $makes_pie = false;
     public $harvest_date;
     public $cost = 0;
-
-    // }}}
 }

--- a/demo/include/ui-objects/DemoDocumentationMenuBar.php
+++ b/demo/include/ui-objects/DemoDocumentationMenuBar.php
@@ -13,8 +13,6 @@ require_once 'DemoMenuBar.php';
  */
 class DemoDocumentationMenuBar extends DemoMenuBar
 {
-    // {{{ public function display()
-
     public function display()
     {
         if (count($this->entries) > 0) {
@@ -45,6 +43,4 @@ class DemoDocumentationMenuBar extends DemoMenuBar
             $p_tag->close();
         }
     }
-
-    // }}}
 }

--- a/demo/include/ui-objects/DemoMenuBar.php
+++ b/demo/include/ui-objects/DemoMenuBar.php
@@ -11,13 +11,8 @@
  */
 class DemoMenuBar extends SwatControl
 {
-    // {{{ protected properties
-
     protected $entries = [];
     protected $selected_entry;
-
-    // }}}
-    // {{{ public function display()
 
     public function display()
     {
@@ -52,21 +47,13 @@ class DemoMenuBar extends SwatControl
         $ul_tag->close();
     }
 
-    // }}}
-    // {{{ public function setEntries()
-
     public function setEntries(array $entries)
     {
         $this->entries = $entries;
     }
 
-    // }}}
-    // {{{ public function setSelectedEntry()
-
     public function setSelectedEntry($entry)
     {
         $this->selected_entry = $entry;
     }
-
-    // }}}
 }


### PR DESCRIPTION
- bumped [MDB2](/silverorange/MDB2) package version
- updated tooling to match other packages (some things were missed, I guess)
- remove vim folding blocks
- update the CI pipelines to use `phpcs` and `phpstan`
- update the phpstan baseline
- correct some errors reported by phpstan that can't be baselined

Recommend viewing the changes with whitespace disabled.  Most of the changes to PHP classes are removing the vim folding comments.  However, the main files to focus on are:

- Swat/SwatCellRendererSet.php
- Swat/SwatGroupedFlydown.php
- Swat/SwatHtmlHeadEntrySet.php
- Swat/SwatNavBar.php
- Swat/SwatTableStore.php
- Swat/SwatTreeFlydown.php
- Swat/SwatTreeNode.php
- Swat/SwatViewSelection.php

In those cases, most of the work was adding a return type for functions like `current()` or `count()` or `next()` etc., to satisfy the Iterator or Countable interfaces.  Where it was obvious, I used defined return types (e.g. `int` or `bool`).  Where it was less obvious (mostly when returning an element from an array in a `current()` function), I added a `#[ReturnTypeWillChange]` comment to the method to silence phpstan.  Further work would need to be done to define the internal array property that is being iterated, and make sure all child classes and usages of the class adhere to the typing (this seems like a big task).

Also, for those files, I updated the types of properties that could be easily typed.  i.e. mark it as an `bool` if it has a default value of `false`, or `array` if the default value is `[]` and the docblock has `@var array`.  Again, that `@var` should probably be scoped tighter (e.g. `list<SwatTreeNode>`), but that is a bigger task as well.