### PR TITLE
Fix PHPStan Level 0 issues

### DIFF
--- a/Swat/SwatActionItem.php
+++ b/Swat/SwatActionItem.php
@@ -143,7 +143,7 @@ class SwatActionItem extends SwatControl implements SwatUIParent
      */
     public function getAvailableHtmlHeadEntrySet()
     {
-        $set = parent::geAvailabletHtmlHeadEntrySet();
+        $set = parent::getAvailableHtmlHeadEntrySet();
 
         if ($this->widget !== null) {
             $set->addEntrySet($this->widget->getAvailableHtmlHeadEntrySet());

--- a/Swat/SwatButton.php
+++ b/Swat/SwatButton.php
@@ -324,7 +324,7 @@ class SwatButton extends SwatInputControl
     /**
      * Gets the inline JavaScript required for this control.
      *
-     * @return stirng the inline JavaScript required for this control
+     * @return string the inline JavaScript required for this control
      */
     protected function getInlineJavaScript()
     {

--- a/Swat/SwatChangeOrder.php
+++ b/Swat/SwatChangeOrder.php
@@ -84,7 +84,7 @@ class SwatChangeOrder extends SwatOptionControl implements SwatState
         $list_div->class = 'swat-change-order-list';
         $list_div->open();
 
-        $option_div = new SwatHtmltag('div');
+        $option_div = new SwatHtmlTag('div');
         $option_div->class = 'swat-change-order-item';
 
         foreach ($ordered_options as $option) {

--- a/Swat/SwatFieldset.php
+++ b/Swat/SwatFieldset.php
@@ -61,7 +61,7 @@ class SwatFieldset extends SwatDisplayableContainer implements SwatTitleable
      *
      * Implements the {SwatTitleable::getTitle()} interface.
      *
-     * @return the title of this fieldset
+     * @return string the title of this fieldset
      */
     public function getTitle()
     {

--- a/Swat/SwatForm.php
+++ b/Swat/SwatForm.php
@@ -319,8 +319,6 @@ class SwatForm extends SwatDisplayableContainer
      *
      * This form is only marked as processed if it was submitted by the user.
      *
-     * @return true if this form was actually submitted, false otherwise
-     *
      * @see SwatContainer::process()
      */
     public function process()

--- a/Swat/SwatHtmlHeadEntry.php
+++ b/Swat/SwatHtmlHeadEntry.php
@@ -103,7 +103,7 @@ abstract class SwatHtmlHeadEntry extends SwatObject
      */
     public function getIECondition()
     {
-        return $this->ie_conditional;
+        return $this->ie_condition;
     }
 
     /**

--- a/Swat/SwatInputCell.php
+++ b/Swat/SwatInputCell.php
@@ -428,8 +428,8 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
             $copy_clone = $clone->copy($id_suffix);
             $copy_clone->parent = $copy;
             $copy->clones[$replicator_id] = $copy_clone;
-            if ($copy_child->id !== null) {
-                $copy->children_by_id[$copy_child->id] = $copy_child;
+            if ($copy_clone->id !== null) {
+                $copy->children_by_id[$copy_clone->id] = $copy_clone;
             }
 
             $clone->widgets[$replicator_id] = [];

--- a/Swat/SwatListEntry.php
+++ b/Swat/SwatListEntry.php
@@ -256,7 +256,7 @@ class SwatListEntry extends SwatEntry
      * For list entry, this is a delimiter separated string containing the
      * elements of {@link SwatListEntry::$values}.
      *
-     * @param array $value the value to format for display
+     * @param string $value the value to format for display
      *
      * @return string the values displayed in the XHTML input
      */

--- a/Swat/SwatRadioNoteBook.php
+++ b/Swat/SwatRadioNoteBook.php
@@ -219,10 +219,9 @@ class SwatRadioNoteBook extends SwatInputControl implements SwatUIParent
     {
         echo get_class($this), ' ', $this->id;
 
-        $children = $this->getChildren();
-        if (count($children) > 0) {
+        if (count($this->children) > 0) {
             echo '<ul>';
-            foreach ($children as $child) {
+            foreach ($this->children as $child) {
                 echo '<li>';
                 $child->printWidgetTree();
                 echo '</li>';

--- a/Swat/SwatTableView.php
+++ b/Swat/SwatTableView.php
@@ -10,7 +10,7 @@
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
-class SwatTableView extends SwatView implements SwatUIParent
+class SwatTableView extends SwatView
 {
     /**
      * The column of this table-view that data in the model is currently being

--- a/Swat/SwatTileView.php
+++ b/Swat/SwatTileView.php
@@ -13,7 +13,7 @@
  *
  * @see       SwatTile
  */
-class SwatTileView extends SwatView implements SwatUIParent
+class SwatTileView extends SwatView
 {
     /**
      * Whether to show a "check all" widget.

--- a/Swat/SwatTreeNode.php
+++ b/Swat/SwatTreeNode.php
@@ -111,7 +111,7 @@ abstract class SwatTreeNode extends SwatObject implements RecursiveIterator, Cou
      */
     public function getChildren(): ?RecursiveIterator
     {
-        return $this->children;
+        return new RecursiveArrayIterator($this->children);
     }
 
     /**

--- a/Swat/SwatUIObject.php
+++ b/Swat/SwatUIObject.php
@@ -157,11 +157,6 @@ abstract class SwatUIObject extends SwatObject
         );
     }
 
-    public function addInlineScript($script)
-    {
-        $this->inline_scripts->add($script);
-    }
-
     /**
      * Gets the first ancestor object of a specific class.
      *

--- a/Swat/SwatUIParent.php
+++ b/Swat/SwatUIParent.php
@@ -26,9 +26,9 @@ interface SwatUIParent
      * this object. Widgets are ordered in the array as they are found in
      * a breadth-first traversal of the subtree.
      *
-     * @param string $class_name optional class name. If set, only UI-objects
-     *                           that are instances of <i>$class_name</i> are
-     *                           returned.
+     * @param ?class-string $class_name optional class name. If set, only UI-objects
+     *                                  that are instances of <i>$class_name</i> are
+     *                                  returned.
      *
      * @return array the descendant UI-objects of this object. If descendant
      *               objects have identifiers, the identifier is used as the

--- a/Swat/SwatView.php
+++ b/Swat/SwatView.php
@@ -6,7 +6,7 @@
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
-abstract class SwatView extends SwatControl
+abstract class SwatView extends SwatControl implements SwatUIParent
 {
     /**
      * A data structure that holds the data to display in this view.

--- a/Swat/SwatYUIComponent.php
+++ b/Swat/SwatYUIComponent.php
@@ -15,7 +15,7 @@ class SwatYUIComponent extends SwatObject
 {
     private $id;
     private $dependencies = [];
-    private $html_head_entries = [];
+    private $html_head_entry_set = [];
     private $beta = false;
 
     /**

--- a/Swat/exceptions/SwatIntegerOverflowException.php
+++ b/Swat/exceptions/SwatIntegerOverflowException.php
@@ -12,10 +12,8 @@ class SwatIntegerOverflowException extends OverflowException
      * Sign.
      *
      * The sign of the integer, either positive or negative
-     *
-     * @var int
      */
-    protected $sign;
+    protected int $sign;
 
     /**
      * Creates a new invalid type exception.
@@ -25,7 +23,7 @@ class SwatIntegerOverflowException extends OverflowException
      * @param int    $sign    the sign of the integer, either positive or
      *                        negative
      */
-    public function __construct($message = null, $code = 0, $sign = 1)
+    public function __construct(string $message = '', int $code = 0, int $sign = 1)
     {
         parent::__construct($message, $code);
 
@@ -37,7 +35,7 @@ class SwatIntegerOverflowException extends OverflowException
      *
      * @return int the sign of the integer, either positive or negative
      */
-    public function getSign()
+    public function getSign(): int
     {
         return $this->sign;
     }

--- a/SwatI18N/SwatI18NLocale.php
+++ b/SwatI18N/SwatI18NLocale.php
@@ -687,7 +687,7 @@ class SwatI18NLocale extends SwatObject
             if ($string > (float) PHP_INT_MAX) {
                 throw new SwatIntegerOverflowException(
                     'Floating point value is too big to be an integer',
-                    null,
+                    0,
                     1,
                 );
             }
@@ -695,7 +695,7 @@ class SwatI18NLocale extends SwatObject
             if ($string < (float) (-PHP_INT_MAX - 1)) {
                 throw new SwatIntegerOverflowException(
                     'Floating point value is too small to be an integer',
-                    null,
+                    0,
                     -1,
                 );
             }
@@ -1002,7 +1002,7 @@ class SwatI18NLocale extends SwatObject
                 $grouping_total = floor($grouping_total / pow(10, $grouping));
                 if ($grouping_total > 0) {
                     $grouping_value = str_pad(
-                        $grouping_value,
+                        (string) $grouping_value,
                         $grouping,
                         '0',
                         STR_PAD_LEFT,
@@ -1039,7 +1039,7 @@ class SwatI18NLocale extends SwatObject
 
                         if ($grouping_total > 0) {
                             $grouping_value = str_pad(
-                                $grouping_value,
+                                (string) $grouping_value,
                                 $grouping,
                                 '0',
                                 STR_PAD_LEFT,
@@ -1086,7 +1086,7 @@ class SwatI18NLocale extends SwatObject
             $frac_part = abs(fmod($value, 1));
             $frac_part = round($frac_part * pow(10, $fractional_digits));
             $frac_part = str_pad(
-                $frac_part,
+                (string) $frac_part,
                 $fractional_digits,
                 '0',
                 STR_PAD_LEFT,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,55 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to an undefined static method SwatControl\:\:geAvailabletHtmlHeadEntrySet\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: Swat/SwatActionItem.php
-
-		-
-			message: '#^Class SwatHtmlTag referenced with incorrect case\: SwatHtmltag\.$#'
-			identifier: class.nameCase
-			count: 1
-			path: Swat/SwatChangeOrder.php
-
-		-
-			message: '#^Method SwatForm\:\:process\(\) should return true but return statement is missing\.$#'
-			identifier: return.missing
-			count: 2
-			path: Swat/SwatForm.php
-
-		-
-			message: '#^Access to an undefined property SwatHtmlHeadEntry\:\:\$ie_conditional\.$#'
-			identifier: property.notFound
-			count: 1
-			path: Swat/SwatHtmlHeadEntry.php
-
-		-
-			message: '#^Undefined variable\: \$copy_child$#'
-			identifier: variable.undefined
-			count: 3
-			path: Swat/SwatInputCell.php
-
-		-
-			message: '#^Call to an undefined method SwatRadioNoteBook\:\:getChildren\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: Swat/SwatRadioNoteBook.php
-
-		-
-			message: '#^Access to an undefined property SwatUIObject\:\:\$inline_scripts\.$#'
-			identifier: property.notFound
-			count: 1
-			path: Swat/SwatUIObject.php
-
-		-
 			message: '#^Call to an undefined method SwatView\:\:getDescendants\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: Swat/SwatView.php
-
-		-
-			message: '#^Access to an undefined property SwatYUIComponent\:\:\$html_head_entry_set\.$#'
-			identifier: property.notFound
-			count: 3
-			path: Swat/SwatYUIComponent.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: '#^Call to an undefined method SwatView\:\:getDescendants\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: Swat/SwatView.php

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -9,3 +9,12 @@ parameters:
     - SwatI18N
   editorUrl: '%%relFile%%:%%line%%'
   editorUrlTitle: '%%relFile%%:%%line%%'
+# Checks from higher levels that we want to include here
+# Level 2
+  checkClassCaseSensitivity: true
+  checkPhpDocMissingReturn: true
+#  checkThisOnly: false
+# Level 3
+  checkPhpDocMethodSignatures: true
+# Level 5
+#  checkFunctionArgumentTypes: true


### PR DESCRIPTION
Most of the issues fixed were fixing typos, obvious copy-paste issues, or mis-capitalized class names.

## Issues Fixed That Need Validation:

- [x] `SwatUiObject::addInlineScript()` references an `add()` method on an `$inline_scripts` property which does not exist.  I don't see this method used anywhere else in Swat, nor in EM:RAP or CourseHost, so I've removed it. https://github.com/silverorange/swat/pull/175/files#diff-8ec479556982c4d7fc7b48826ac8b6213aeb0a566419f48f09e348498d7d13e5L160

## Outstanding Issues:

- [x] `SwatView` does not have a `getDescendants()` method, and there aren't any other methods that would be obvious candidates (i.e. it's just a typo).  https://github.com/silverorange/swat/blob/master/Swat/SwatView.php#L77

