### PR TITLE
Phpstan level 1 issues

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 5
         run: |
-          pnpm prettier
           composer run phpcs:ci
           composer run phpstan:ci
+          composer run phpunit
+          pnpm prettier

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,14 @@
 vendor/
 node_modules/
 
+# testing and code styling output
+/build/
+.php-cs-fixer.cache
+.phpunit.result.cache
+
 # misc
 .DS_Store
 .env
 .idea/
-.php-cs-fixer.cache
 *.swp
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,12 @@ pipeline {
             }
         }
 
+        stage('Run Test Suite') {
+            steps {
+                sh 'composer run phpunit'
+            }
+        }
+
         stage('Check Formating') {
             steps {
                 sh 'n -d exec engine pnpm prettier'

--- a/Swat/SwatByteCellRenderer.php
+++ b/Swat/SwatByteCellRenderer.php
@@ -14,7 +14,7 @@ class SwatByteCellRenderer extends SwatCellRenderer
     /**
      * Value in bytes.
      *
-     * @var float
+     * @var int
      */
     public $value;
 

--- a/Swat/SwatCascadeFlydown.php
+++ b/Swat/SwatCascadeFlydown.php
@@ -166,7 +166,7 @@ class SwatCascadeFlydown extends SwatFlydown
             // if the options array doesn't exist for this parent_value, then
             // assume that means we don't want any values in this flydown for
             // that option.
-            $options = [new SwatOption(null, null)];
+            $options = [new SwatOption(null, '')];
         }
 
         return $options;

--- a/Swat/SwatCellRendererSet.php
+++ b/Swat/SwatCellRendererSet.php
@@ -212,7 +212,7 @@ class SwatCellRendererSet extends SwatObject implements Iterator, Countable
         throw new SwatObjectNotFoundException(
             'Set does not contain that many renderers.',
             0,
-            $position,
+            (string) $position,
         );
     }
 

--- a/Swat/SwatCheckboxCellRenderer.php
+++ b/Swat/SwatCheckboxCellRenderer.php
@@ -153,7 +153,7 @@ class SwatCheckboxCellRenderer extends SwatCellRenderer implements SwatViewSelec
         echo '<span class="swat-checkbox-shim"></span>';
         echo '</span>';
 
-        if ($this->title !== null) {
+        if (isset($label_tag)) {
             $label_tag->displayContent();
             $label_tag->close();
         }

--- a/Swat/SwatCheckboxTree.php
+++ b/Swat/SwatCheckboxTree.php
@@ -170,7 +170,7 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
                 : $is_parent_selected && !$is_selected;
 
         return array_reduce(
-            $node->getChildren(),
+            iterator_to_array($node->getChildren()),
             function ($carry, $child) use ($is_selected) {
                 return $carry && $this->validate($child, $is_selected);
             },
@@ -269,7 +269,7 @@ class SwatCheckboxTree extends SwatCheckboxList implements SwatState
 
         // display children
         $child_nodes = $node->getChildren();
-        if (count($child_nodes) > 0) {
+        if (iterator_count($child_nodes) > 0) {
             echo '<ul>';
             foreach ($child_nodes as $child_node) {
                 $nodes = $this->displayNode($child_node, $nodes, $index);

--- a/Swat/SwatContainer.php
+++ b/Swat/SwatContainer.php
@@ -481,7 +481,7 @@ class SwatContainer extends SwatWidget implements SwatUIParent
      * called elsewhere. To add a widget to a container use
      * {@link SwatContainer::add()}.
      *
-     * @param SwatWidget $child a reference to the child object to add
+     * @param SwatObject $child a reference to the child object to add
      *
      * @throws SwatInvalidClassException
      */

--- a/Swat/SwatDate.php
+++ b/Swat/SwatDate.php
@@ -905,7 +905,7 @@ class SwatDate extends DateTime implements Stringable
      *
      * This method is provided for backwards compatibility with PEAR::Date.
      *
-     * @return float the second of this date
+     * @return int the second of this date
      */
     public function getSecond()
     {
@@ -1143,7 +1143,7 @@ class SwatDate extends DateTime implements Stringable
      */
     public function setTZ(DateTimeZone $time_zone): DateTime
     {
-        return $this->addSeconds($this->format('Z'))
+        return $this->addSeconds((float) $this->format('Z'))
             ->setTimezone($time_zone)
             ->subtractSeconds($this->format('Z'));
     }
@@ -1482,7 +1482,7 @@ class SwatDate extends DateTime implements Stringable
      */
     public function setSecond($second): DateTime
     {
-        return $this->setTime($this->getHour(), $this->getMinute(), $second);
+        return $this->setTime($this->getHour(), $this->getMinute(), (int) $second);
     }
 
     /**

--- a/Swat/SwatDate.php
+++ b/Swat/SwatDate.php
@@ -1480,7 +1480,15 @@ class SwatDate extends DateTime implements Stringable
      */
     public function setSecond($second): DateTime
     {
-        return $this->setTime($this->getHour(), $this->getMinute(), (int) $second);
+        $whole_second = (int) $second;
+        $microsecond = (int) (abs($second - $whole_second) * 1_000_000);
+
+        return $this->setTime(
+            $this->getHour(),
+            $this->getMinute(),
+            $whole_second,
+            $microsecond
+        );
     }
 
     /**

--- a/Swat/SwatDate.php
+++ b/Swat/SwatDate.php
@@ -692,8 +692,6 @@ class SwatDate extends DateTime implements Stringable
      */
     public static function getTimeZoneAbbreviations(): array
     {
-        static $shortnames = null;
-
         if (self::$tz_abbreviations === null) {
             self::$tz_abbreviations = [];
 
@@ -737,10 +735,10 @@ class SwatDate extends DateTime implements Stringable
         $key = $time_zone->getName();
 
         if (array_key_exists($key, $abbreviations)) {
-            $abbreviation = $abbreviations[$key];
+            return $abbreviations[$key];
         }
 
-        return $abbreviation;
+        return [];
     }
 
     /**

--- a/Swat/SwatDateEntry.php
+++ b/Swat/SwatDateEntry.php
@@ -530,11 +530,7 @@ class SwatDateEntry extends SwatInputControl implements SwatState
     {
         $this->valid_range_start->setTZById('UTC');
 
-        return SwatDate::compare(
-            $this->value,
-            $this->valid_range_start,
-            true,
-        ) >= 0;
+        return SwatDate::compare($this->value, $this->valid_range_start) >= 0;
     }
 
     /**
@@ -548,7 +544,7 @@ class SwatDateEntry extends SwatInputControl implements SwatState
     {
         $this->valid_range_end->setTZById('UTC');
 
-        return SwatDate::compare($this->value, $this->valid_range_end, true)
+        return SwatDate::compare($this->value, $this->valid_range_end)
             < 0;
     }
 
@@ -764,7 +760,7 @@ class SwatDateEntry extends SwatInputControl implements SwatState
             for ($i = $start_day; $i <= $end_day; $i++) {
                 $flydown->addOption($i, $i);
             }
-        } elseif (SwatDate::compare($end_check, $range_end, true) != -1) {
+        } elseif (SwatDate::compare($end_check, $range_end) != -1) {
             // extra days at the beginning of the next month allowed
             $days_in_month = $this->valid_range_start->getDaysInMonth();
 

--- a/Swat/SwatDateEntry.php
+++ b/Swat/SwatDateEntry.php
@@ -393,7 +393,7 @@ class SwatDateEntry extends SwatInputControl implements SwatState
     /**
      * Sets the current state of this date entry widget.
      *
-     * @param bool $state the new state of this date entry widget
+     * @param mixed $state the new state of this date entry widget
      *
      * @see SwatState::setState()
      */
@@ -720,7 +720,7 @@ class SwatDateEntry extends SwatInputControl implements SwatState
         $text = '';
 
         if ($this->show_month_number) {
-            $text .= str_pad($month, 2, '0', STR_PAD_LEFT) . ' - ';
+            $text .= sprintf('%02d', $month) . ' - ';
         }
 
         $date = new SwatDate('2010-' . $month . '-01');

--- a/Swat/SwatEntry.php
+++ b/Swat/SwatEntry.php
@@ -350,7 +350,7 @@ class SwatEntry extends SwatInputControl implements SwatState
     protected function getNonce()
     {
         if ($this->nonce === null) {
-            $this->nonce = 'n' . md5(rand());
+            $this->nonce = 'n' . md5((string) rand());
         }
 
         return $this->nonce;

--- a/Swat/SwatError.php
+++ b/Swat/SwatError.php
@@ -379,7 +379,11 @@ class SwatError
 
             if (array_key_exists('args', $entry)) {
                 $arguments = htmlspecialchars(
-                    $this->getArguments($entry['args'], $function, $class),
+                    string: $this->getArguments(
+                        $entry['args'],
+                        $function,
+                        $class
+                    ),
                     encoding: 'UTF-8',
                 );
             } else {

--- a/Swat/SwatError.php
+++ b/Swat/SwatError.php
@@ -323,8 +323,8 @@ class SwatError
             }
 
             printf(
-                "%s. In file '%s' on line %s.\n%sMethod: %s%s%s(%s)\n",
-                str_pad(--$count, 6, ' ', STR_PAD_LEFT),
+                "%6d. In file '%s' on line %s.\n%sMethod: %s%s%s(%s)\n",
+                --$count,
                 array_key_exists('file', $entry) ? $entry['file'] : 'unknown',
                 array_key_exists('line', $entry) ? $entry['line'] : 'unknown',
                 str_repeat(' ', 8),
@@ -380,8 +380,7 @@ class SwatError
             if (array_key_exists('args', $entry)) {
                 $arguments = htmlspecialchars(
                     $this->getArguments($entry['args'], $function, $class),
-                    null,
-                    'UTF-8',
+                    encoding: 'UTF-8',
                 );
             } else {
                 $arguments = '';

--- a/Swat/SwatGroupedFlydown.php
+++ b/Swat/SwatGroupedFlydown.php
@@ -119,7 +119,7 @@ class SwatGroupedFlydown extends SwatTreeFlydown
 
         if (
             $level == 1
-            && count($children) > 0
+            && iterator_count($children) > 0
             && end($flydown_option->value) === null
             && !($flydown_option instanceof SwatFlydownDivider)
         ) {

--- a/Swat/SwatHtmlHeadEntrySetDisplayer.php
+++ b/Swat/SwatHtmlHeadEntrySetDisplayer.php
@@ -139,13 +139,13 @@ class SwatHtmlHeadEntrySetDisplayer extends SwatObject
         // add combines to set of entries
         foreach ($info['combines'] as $combine) {
             if (mb_substr($combine, -4) === '.css') {
-                $class_name = 'SwatStyleSheetHtmlHeadEntry';
+                $class_name = SwatStyleSheetHtmlHeadEntry::class;
             } elseif (mb_substr($combine, -5) === '.less') {
-                $class_name = 'SwatLessStyleSheetHtmlHeadEntry';
+                $class_name = SwatLessStyleSheetHtmlHeadEntry::class;
             } else {
-                $class_name = 'SwatJavaScriptHtmlHeadEntry';
+                $class_name = SwatJavaScriptHtmlHeadEntry::class;
             }
-            $entries[$combine] = new $class_name($combine, '__combine__');
+            $entries[$combine] = new $class_name($combine);
         }
 
         // remove files included in combines

--- a/Swat/SwatInputCell.php
+++ b/Swat/SwatInputCell.php
@@ -124,7 +124,7 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
      * This creates a cloned widget for the given numeric identifier and then
      * displays the widget.
      *
-     * @param mixed $row_identifier
+     * @param int $row_identifier
      */
     public function display($row_identifier)
     {
@@ -228,9 +228,8 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
      *
      * This is useful if you are deleting a row from an input row.
      *
-     * @param int replicator_id the replicator id of the cloned widget to
-     *                 unset
-     * @param mixed $replicator_id
+     * @param int $replicator_id the replicator id of the cloned widget to
+     *                           unset
      *
      * @see SwatTableViewInputRow::removeReplicatedRow()
      */

--- a/Swat/SwatInputCell.php
+++ b/Swat/SwatInputCell.php
@@ -469,11 +469,11 @@ class SwatInputCell extends SwatUIObject implements SwatUIParent, SwatTitleable
     /**
      * Gets a cloned widget given a unique identifier.
      *
-     * @param string $replicator_id the unique identifier of the new cloned
-     *                              widget. The actual cloned widget id is
-     *                              constructed from this identifier and from
-     *                              the input row that this input cell belongs
-     *                              to.
+     * @param int $replicator_id the unique identifier of the new cloned
+     *                           widget. The actual cloned widget id is
+     *                           constructed from this identifier and from
+     *                           the input row that this input cell belongs
+     *                           to.
      *
      * @return SwatWidget the new cloned widget or the cloned widget retrieved
      *                    from the {@link SwatInputCell::$clones} array

--- a/Swat/SwatNumber.php
+++ b/Swat/SwatNumber.php
@@ -87,15 +87,16 @@ class SwatNumber extends SwatObject
             $locale = setlocale(LC_ALL, '0');
 
             static $formatters = [];
-            if (!isset($formatter[$locale])) {
-                $formatter[$locale] = new NumberFormatter(
+
+            if (!isset($formatters[$locale])) {
+                $formatters[$locale] = new NumberFormatter(
                     $locale,
                     NumberFormatter::ORDINAL,
                 );
             }
 
             // format ordinal
-            $ordinal_value = $formatter[$locale]->format($value);
+            $ordinal_value = $formatters[$locale]->format($value);
 
             // decompose to latin-1 characters (removes superscripts)
             $ordinal_value = Normalizer::normalize(

--- a/Swat/SwatNumber.php
+++ b/Swat/SwatNumber.php
@@ -84,7 +84,7 @@ class SwatNumber extends SwatObject
 
         if (extension_loaded('intl')) {
             // get current locale
-            $locale = setlocale(LC_ALL, 0);
+            $locale = setlocale(LC_ALL, '0');
 
             static $formatters = [];
             if (!isset($formatter[$locale])) {

--- a/Swat/SwatNumericEntry.php
+++ b/Swat/SwatNumericEntry.php
@@ -74,7 +74,7 @@ abstract class SwatNumericEntry extends SwatEntry
                 $minimum_value = str_replace(
                     '%',
                     '%%',
-                    $this->getDisplayValue($this->minimum_value),
+                    $this->getDisplayValue((string) $this->minimum_value),
                 );
 
                 $message->primary_content = sprintf(
@@ -92,7 +92,7 @@ abstract class SwatNumericEntry extends SwatEntry
                 $maximum_value = str_replace(
                     '%',
                     '%%',
-                    $this->getDisplayValue($this->maximum_value),
+                    $this->getDisplayValue((string) $this->maximum_value),
                 );
 
                 $message->primary_content = sprintf(

--- a/Swat/SwatPercentageEntry.php
+++ b/Swat/SwatPercentageEntry.php
@@ -22,7 +22,7 @@ class SwatPercentageEntry extends SwatFloatEntry
     {
         if (is_numeric($value)) {
             $value = $value * 100;
-            $value = parent::getDisplayValue($value);
+            $value = parent::getDisplayValue((string) $value);
             $value = $value . '%';
         } else {
             $value = parent::getDisplayValue($value);

--- a/Swat/SwatRadioButtonCellRenderer.php
+++ b/Swat/SwatRadioButtonCellRenderer.php
@@ -144,7 +144,7 @@ class SwatRadioButtonCellRenderer extends SwatCellRenderer implements SwatViewSe
         echo '<span class="swat-radio-shim"></span>';
         echo '</span>';
 
-        if ($this->title !== null) {
+        if (isset($label_tag)) {
             $label_tag->displayContent();
             $label_tag->close();
         }

--- a/Swat/SwatRatingCellRenderer.php
+++ b/Swat/SwatRatingCellRenderer.php
@@ -83,28 +83,13 @@ class SwatRatingCellRenderer extends SwatNumericCellRenderer
 
     public function getDisplayValue()
     {
-        switch ($this->round_mode) {
-            case self::ROUND_FLOOR:
-                $value = floor($this->value);
-                break;
-
-            case self::ROUND_CEIL:
-                $value = ceil($this->value);
-                break;
-
-            case self::ROUND_UP:
-                $value = round($this->value, $this->precision);
-                break;
-
-            case self::ROUND_NONE:
-                $value = $this->value;
-                break;
-
-            case self::ROUND_HALF:
-                $value = round($this->value * 2) / 2;
-                break;
-        }
-
-        return $value;
+        return match ($this->round_mode) {
+            self::ROUND_FLOOR => floor($this->value),
+            self::ROUND_CEIL  => ceil($this->value),
+            self::ROUND_UP    => round($this->value, $this->precision),
+            self::ROUND_NONE  => $this->value,
+            self::ROUND_HALF  => round($this->value * 2) / 2,
+            default           => throw new SwatException('Invalid round mode.'),
+        };
     }
 }

--- a/Swat/SwatRatingCellRenderer.php
+++ b/Swat/SwatRatingCellRenderer.php
@@ -50,7 +50,7 @@ class SwatRatingCellRenderer extends SwatNumericCellRenderer
         } elseif ($this->value !== null) {
             $locale = SwatI18NLocale::get();
 
-            $value = $this->getDisplayValue();
+            $value = $this->getRoundedValue();
             $difference = $this->maximum_value - $value;
 
             $rating_class = floor(10 * min($value, $this->maximum_value));
@@ -83,12 +83,17 @@ class SwatRatingCellRenderer extends SwatNumericCellRenderer
 
     public function getDisplayValue()
     {
+        return (string) $this->getRoundedValue();
+    }
+
+    protected function getRoundedValue()
+    {
         return match ($this->round_mode) {
             self::ROUND_FLOOR => floor($this->value),
             self::ROUND_CEIL  => ceil($this->value),
             self::ROUND_UP    => round($this->value, $this->precision),
             self::ROUND_NONE  => $this->value,
-            self::ROUND_HALF  => round($this->value * 2) / 2,
+            self::ROUND_HALF  => round($this->value * 2) / 2.0,
             default           => throw new SwatException('Invalid round mode.'),
         };
     }

--- a/Swat/SwatRatingCellRenderer.php
+++ b/Swat/SwatRatingCellRenderer.php
@@ -60,9 +60,9 @@ class SwatRatingCellRenderer extends SwatNumericCellRenderer
             $outer_span->class = 'rating ' . $rating_class;
             $outer_span->open();
 
-            $content = str_repeat('★', ceil($value));
+            $content = str_repeat('★', (int) ceil($value));
             if ($difference > 0) {
-                $content .= str_repeat('☆', floor($difference));
+                $content .= str_repeat('☆', (int) floor($difference));
             }
 
             $value_tag = new SwatHtmlTag('span');

--- a/Swat/SwatRemoveInputCell.php
+++ b/Swat/SwatRemoveInputCell.php
@@ -73,7 +73,7 @@ class SwatRemoveInputCell extends SwatInputCell
     {
         $widget = $this->getClonedWidget($replicator_id);
         // substitute the replicator_id into the content block's contents
-        $widget->content = str_replace('%s', $replicator_id, $widget->content);
+        $widget->content = str_replace('%s', (string) $replicator_id, $widget->content);
         $widget->display();
     }
 

--- a/Swat/SwatString.php
+++ b/Swat/SwatString.php
@@ -1439,7 +1439,7 @@ class SwatString extends SwatObject
      * Convert an iterable object or array into a human-readable, delimited
      * list.
      *
-     * @param array|Iterator $iterator                the object to convert to a list
+     * @param array|Iterator $array                   the object to convert to a list
      * @param string         $conjunction             the list's conjunction. Usually 'and' or
      *                                                'or'.
      * @param string         $delimiter               the list delimiter. If list items should
@@ -1457,46 +1457,40 @@ class SwatString extends SwatObject
      *       different locales.
      */
     public static function toList(
-        $iterator,
+        $array,
         $conjunction = 'and',
         $delimiter = ', ',
         $display_final_delimiter = true,
     ) {
-        if (is_array($iterator)) {
-            $iterator = new ArrayIterator($iterator);
+        if ($array instanceof Iterator) {
+            $array = iterator_to_array($array);
         }
 
-        if (!$iterator instanceof Iterator) {
+        if (!is_array($array)) {
             throw new SwatException('Value is not an Iterator or array');
         }
 
-        if (count($iterator) === 1) {
-            $iterator->rewind();
-            $list = $iterator->current();
-        } else {
-            $count = 0;
-            $list = '';
+        $count = count($array);
 
-            foreach ($iterator as $value) {
-                if ($count != 0) {
-                    if ($count == count($iterator) - 1) {
-                        $list
-                            .= $display_final_delimiter && count($iterator) > 2
-                                ? $delimiter
-                                : ' ';
-
-                        if ($conjunction != '') {
-                            $list .= $conjunction . ' ';
-                        }
-                    } else {
-                        $list .= $delimiter;
-                    }
-                }
-
-                $list .= $value;
-                $count++;
-            }
+        if ($count === 0) {
+            return '';
         }
+
+        if ($count === 1) {
+            return reset($array);
+        }
+
+        $last = array_pop($array);
+        $list = implode($delimiter, $array);
+        if ($display_final_delimiter && $count > 2) {
+            $list .= $delimiter;
+        } else {
+            $list .= ' ';
+        }
+        if ($conjunction !== '') {
+            $list .= $conjunction . ' ';
+        }
+        $list .= $last;
 
         return $list;
     }

--- a/Swat/SwatString.php
+++ b/Swat/SwatString.php
@@ -959,7 +959,7 @@ class SwatString extends SwatObject
         }
 
         if ($locale !== null) {
-            $old_locale = setlocale(LC_ALL, 0);
+            $old_locale = setlocale(LC_ALL, '0');
             if (setlocale(LC_ALL, $locale) === false) {
                 throw new SwatException(
                     sprintf(
@@ -1023,7 +1023,7 @@ class SwatString extends SwatObject
     public static function getInternationalCurrencySymbol($locale = null)
     {
         if ($locale !== null) {
-            $old_locale = setlocale(LC_MONETARY, 0);
+            $old_locale = setlocale(LC_MONETARY, '0');
             if (setlocale(LC_MONETARY, $locale) === false) {
                 throw new SwatException(
                     sprintf(
@@ -1104,7 +1104,7 @@ class SwatString extends SwatObject
         );
 
         if ($locale !== null) {
-            $old_locale = setlocale(LC_ALL, 0);
+            $old_locale = setlocale(LC_ALL, '0');
             if (setlocale(LC_ALL, $locale) === false) {
                 throw new SwatException(
                     sprintf(
@@ -1290,7 +1290,6 @@ class SwatString extends SwatObject
         $pad_string = ' ',
         $pad_type = STR_PAD_RIGHT,
     ) {
-        $output = '';
         $length = $pad_length - mb_strlen($input);
 
         if ($pad_string === null || mb_strlen($pad_string) === 0) {
@@ -1302,17 +1301,17 @@ class SwatString extends SwatObject
                 case STR_PAD_LEFT:
                     $padding = str_repeat(
                         $pad_string,
-                        ceil($length / mb_strlen($pad_string)),
+                        (int) ceil($length / mb_strlen($pad_string)),
                     );
                     $output = mb_substr($padding, 0, $length) . $input;
                     break;
 
                 case STR_PAD_BOTH:
-                    $left_length = floor($length / 2);
-                    $right_length = ceil($length / 2);
+                    $left_length = (int) floor($length / 2);
+                    $right_length = (int) ceil($length / 2);
                     $padding = str_repeat(
                         $pad_string,
-                        ceil($right_length / mb_strlen($pad_string)),
+                        (int) ceil($right_length / mb_strlen($pad_string)),
                     );
                     $output
                         = mb_substr($padding, 0, $left_length)
@@ -1325,7 +1324,7 @@ class SwatString extends SwatObject
                 default:
                     $padding = str_repeat(
                         $pad_string,
-                        ceil($length / mb_strlen($pad_string)),
+                        (int) ceil($length / mb_strlen($pad_string)),
                     );
                     $output = $input . mb_substr($padding, 0, $length);
             }

--- a/Swat/SwatTableViewInputRow.php
+++ b/Swat/SwatTableViewInputRow.php
@@ -661,6 +661,10 @@ class SwatTableViewInputRow extends SwatTableViewRow
             $colspan += $column->getXhtmlColspan();
         }
 
+        if (!isset($column)) {
+            $column = reset($columns);
+        }
+
         $close_length = $this->parent->getXhtmlColspan() - $position - 1;
 
         $tr_tag = new SwatHtmlTag('tr');

--- a/Swat/SwatTableViewInputRow.php
+++ b/Swat/SwatTableViewInputRow.php
@@ -639,6 +639,12 @@ class SwatTableViewInputRow extends SwatTableViewRow
     {
         $columns = $this->parent->getVisibleColumns();
 
+        // If there are no columns in the table view, we cannot display an
+        // enter-another row.
+        if (count($columns) === 0) {
+            return;
+        }
+
         $this->createEmbeddedWidgets();
 
         /*

--- a/Swat/SwatTimeEntry.php
+++ b/Swat/SwatTimeEntry.php
@@ -552,11 +552,7 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         $this->valid_range_start->setDay(self::$date_day);
         $this->valid_range_start->setTZById('UTC');
 
-        return SwatDate::compare(
-            $this->value,
-            $this->valid_range_start,
-            true,
-        ) >= 0;
+        return SwatDate::compare($this->value, $this->valid_range_start) >= 0;
     }
 
     /**
@@ -573,7 +569,7 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         $this->valid_range_end->setDay(self::$date_day);
         $this->valid_range_end->setTZById('UTC');
 
-        return SwatDate::compare($this->value, $this->valid_range_end, true)
+        return SwatDate::compare($this->value, $this->valid_range_end)
             <= 0;
     }
 

--- a/Swat/SwatTimeEntry.php
+++ b/Swat/SwatTimeEntry.php
@@ -408,7 +408,7 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
     /**
      * Sets the current state of this time entry widget.
      *
-     * @param bool $state the new state of this time entry widget
+     * @param mixed $state the new state of this time entry widget
      *
      * @see SwatState::setState()
      */
@@ -616,7 +616,7 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
     /**
      * Creates the hour flydown for this time entry.
      *
-     * @return the hour flydown for this time entry
+     * @return SwatFlydown the hour flydown for this time entry
      */
     private function createHourFlydown()
     {
@@ -647,7 +647,7 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         $flydown->classes = ['swat-time-entry-minute'];
 
         for ($i = 0; $i <= 59; $i++) {
-            $flydown->addOption($i, str_pad($i, 2, '0', STR_PAD_LEFT));
+            $flydown->addOption($i, sprintf('%02d', $i));
         }
 
         return $flydown;
@@ -664,7 +664,7 @@ class SwatTimeEntry extends SwatInputControl implements SwatState
         $flydown->classes = ['swat-time-entry-second'];
 
         for ($i = 0; $i <= 59; $i++) {
-            $flydown->addOption($i, str_pad($i, 2, '0', STR_PAD_LEFT));
+            $flydown->addOption($i, sprintf('%02d', $i));
         }
 
         return $flydown;

--- a/Swat/SwatTreeFlydown.php
+++ b/Swat/SwatTreeFlydown.php
@@ -159,7 +159,7 @@ class SwatTreeFlydown extends SwatFlydown
         if ($this->value === null) {
             $this->path = [];
         } else {
-            $this->path = $this->value;
+            $this->path = [$this->value];
             $this->value = end($this->path);
         }
     }

--- a/Swat/SwatTreeNode.php
+++ b/Swat/SwatTreeNode.php
@@ -8,7 +8,7 @@
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  *
- * @template T of SwatTreeNode
+ * @template T of static
  *
  * @implements RecursiveIterator<int, T>
  */

--- a/Swat/SwatUI.php
+++ b/Swat/SwatUI.php
@@ -192,11 +192,15 @@ class SwatUI extends SwatObject
             $validate = self::$validate_mode;
         }
 
-        $xml_file = null;
-
-        if (file_exists($filename)) {
-            $xml_file = $filename;
+        if (!file_exists($filename)) {
+            throw new SwatFileNotFoundException(
+                "SwatML file not found: '{$filename}'.",
+                0,
+                $filename,
+            );
         }
+
+        $xml_file = $filename;
 
         // try to guess the translation callback based on the
         // filename of the xml
@@ -217,14 +221,6 @@ class SwatUI extends SwatObject
             && extension_loaded('gettext')
         ) {
             $this->translation_callback = 'gettext';
-        }
-
-        if ($xml_file === null) {
-            throw new SwatFileNotFoundException(
-                "SwatML file not found: '{$filename}'.",
-                0,
-                $xml_file,
-            );
         }
 
         $errors = libxml_use_internal_errors(true);

--- a/Swat/SwatUI.php
+++ b/Swat/SwatUI.php
@@ -518,25 +518,25 @@ class SwatUI extends SwatObject
     /**
      * Attaches a widget to a parent widget in the widget tree.
      *
-     * @param SwatUIObject $object the object to attach
-     * @param SwatUIParent $parent the parent to attach the widget to
+     * @param SwatUIObject $object the widget to attach
+     * @param SwatUIObject $parent the parent to which to attach the widget
      *
      * @throws SwatDoesNotImplementException
      */
-    private function attachToParent(SwatUIObject $object, SwatUIParent $parent)
+    private function attachToParent(SwatUIObject $object, SwatUIObject $parent)
     {
         if ($parent instanceof SwatUIParent) {
             $parent->addChild($object);
-        } else {
-            $class_name = get_class($parent);
 
-            throw new SwatDoesNotImplementException(
-                "Can not add object to parent. '{$class_name}' does not "
-                    . 'implement SwatUIParent.',
-                0,
-                $parent,
-            );
+            return;
         }
+        $class_name = $parent::class;
+
+        throw new SwatDoesNotImplementException(
+            "Can not add object to parent. '{$class_name}' does not implement SwatUIParent.",
+            0,
+            $parent,
+        );
     }
 
     /**

--- a/Swat/SwatWidgetCellRenderer.php
+++ b/Swat/SwatWidgetCellRenderer.php
@@ -71,6 +71,8 @@ class SwatWidgetCellRenderer extends SwatCellRenderer implements SwatUIParent, S
     /**
      * Fulfills SwatUIParent::addChild().
      *
+     * @param SwatWidget $child
+     *
      * @throws SwatException
      */
     public function addChild(SwatObject $child)

--- a/Swat/exceptions/SwatException.php
+++ b/Swat/exceptions/SwatException.php
@@ -354,7 +354,11 @@ class SwatException extends Exception
 
             if (array_key_exists('args', $entry)) {
                 $arguments = htmlspecialchars(
-                    $this->getArguments($entry['args'], $function, $class),
+                    string: $this->getArguments(
+                        $entry['args'],
+                        $function,
+                        $class
+                    ),
                     encoding: 'UTF-8',
                 );
             } else {

--- a/Swat/exceptions/SwatException.php
+++ b/Swat/exceptions/SwatException.php
@@ -295,8 +295,8 @@ class SwatException extends Exception
             }
 
             printf(
-                "%s. In file '%s' on line %s.\n%sMethod: %s%s%s(%s)\n",
-                str_pad(--$count, 6, ' ', STR_PAD_LEFT),
+                "%6d. In file '%s' on line %s.\n%sMethod: %s%s%s(%s)\n",
+                --$count,
                 array_key_exists('file', $entry) ? $entry['file'] : 'unknown',
                 array_key_exists('line', $entry) ? $entry['line'] : 'unknown',
                 str_repeat(' ', 8),
@@ -355,8 +355,7 @@ class SwatException extends Exception
             if (array_key_exists('args', $entry)) {
                 $arguments = htmlspecialchars(
                     $this->getArguments($entry['args'], $function, $class),
-                    null,
-                    'UTF-8',
+                    encoding: 'UTF-8',
                 );
             } else {
                 $arguments = '';

--- a/Swat/exceptions/SwatObjectNotFoundException.php
+++ b/Swat/exceptions/SwatObjectNotFoundException.php
@@ -11,16 +11,16 @@ class SwatObjectNotFoundException extends SwatException
     /**
      * The object id that was searched for.
      *
-     * @var string
+     * @var ?string
      */
     protected $object_id;
 
     /**
      * Creates a new object not found exception.
      *
-     * @param string $message   the message of the exception
-     * @param int    $code      the code of the exception
-     * @param string $object_id the object id that was searched for
+     * @param string  $message   the message of the exception
+     * @param int     $code      the code of the exception
+     * @param ?string $object_id the object id that was searched for
      */
     public function __construct($message = null, $code = 0, $object_id = null)
     {

--- a/SwatDB/SwatDB.php
+++ b/SwatDB/SwatDB.php
@@ -1033,9 +1033,11 @@ class SwatDB extends SwatObject
                 $current_group = $row->group_id;
             }
 
-            $current_parent->addChild(
-                new SwatDataTreeNode($row->id, $row->title),
-            );
+            if (isset($current_parent)) {
+                $current_parent->addChild(
+                    new SwatDataTreeNode($row->id, $row->title),
+                );
+            }
 
             $row = $rs->fetchRow(MDB2_FETCHMODE_OBJECT);
         }
@@ -1298,6 +1300,11 @@ class SwatDB extends SwatObject
                 ) {
                     break;
                 }
+            }
+
+            if (!isset($entry)) {
+                // fallback if all entries are in SwatDB package
+                $entry = end($trace);
             }
 
             $class = array_key_exists('class', $entry) ? $entry['class'] : null;

--- a/SwatDB/SwatDBDataObject.php
+++ b/SwatDB/SwatDBDataObject.php
@@ -54,7 +54,7 @@ class SwatDBDataObject extends SwatObject implements Serializable, SwatDBRecorda
     private $deprecated_properties = [];
 
     /**
-     * @var MDB2
+     * @var MDB2_Driver_Common
      */
     protected $db;
 

--- a/SwatDB/SwatDBRecordsetWrapper.php
+++ b/SwatDB/SwatDBRecordsetWrapper.php
@@ -130,6 +130,7 @@ abstract class SwatDBRecordsetWrapper extends SwatObject implements
         $this->setDatabase($rs->db);
 
         do {
+            /** @var stdClass $row */
             $row = $rs->fetchRow(MDB2_FETCHMODE_OBJECT);
             while ($row) {
                 $object = $this->instantiateRowWrapperObject($row);

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "3.88.2",
-    "phpstan/phpstan": "^2.1"
+    "phpstan/phpstan": "^2.1",
+    "phpunit/phpunit": "^11.5"
   },
   "autoload": {
     "classmap": [
@@ -71,13 +72,20 @@
       "SwatI18N/"
     ]
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/"
+    }
+  },
   "scripts": {
     "phpcs": "./vendor/bin/php-cs-fixer check -v",
     "phpcs:ci": "./vendor/bin/php-cs-fixer check --config=.php-cs-fixer.php --no-interaction --show-progress=none --diff --using-cache=no -vvv",
     "phpcs:write": "./vendor/bin/php-cs-fixer fix -v",
     "phpstan": "./vendor/bin/phpstan analyze",
     "phpstan:ci": "./vendor/bin/phpstan analyze -vvv --no-progress --memory-limit 2G",
-    "phpstan:baseline": "./vendor/bin/phpstan analyze --generate-baseline"
+    "phpstan:baseline": "./vendor/bin/phpstan analyze --generate-baseline",
+    "phpunit": "./vendor/bin/phpunit --no-coverage",
+    "phpunit:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit && npx serve build/coverage"
   },
   "config": {
     "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -73,9 +73,9 @@
     ]
   },
   "autoload-dev": {
-    "psr-4": {
-      "Tests\\": "tests/"
-    }
+    "classmap": [
+      "tests/"
+    ]
   },
   "scripts": {
     "phpcs": "./vendor/bin/php-cs-fixer check -v",
@@ -85,7 +85,7 @@
     "phpstan:ci": "./vendor/bin/phpstan analyze -vvv --no-progress --memory-limit 2G",
     "phpstan:baseline": "./vendor/bin/phpstan analyze --generate-baseline",
     "phpunit": "./vendor/bin/phpunit --no-coverage",
-    "phpunit:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit && npx serve build/coverage"
+    "phpunit:coverage": "rm -rf ./build && XDEBUG_MODE=coverage ./vendor/bin/phpunit && npx serve build/coverage"
   },
   "config": {
     "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51e2a3810f6355a8bd17a0a471f5f321",
+    "content-hash": "a2e9e812c640f1301fea8f72446a2dd7",
     "packages": [
         {
             "name": "league/climate",
@@ -1314,6 +1314,242 @@
             "time": "2025-09-27T00:24:15+00:00"
         },
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+            },
+            "time": "2025-08-13T20:13:15+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
             "name": "phpstan/phpstan",
             "version": "2.1.16",
             "source": {
@@ -1370,6 +1606,450 @@
                 }
             ],
             "time": "2025-05-16T09:40:10+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "4f7722aa9a7b76aa775e2d9d4e95d1ea16eeeef4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4f7722aa9a7b76aa775e2d9d4e95d1ea16eeeef4",
+                "reference": "4f7722aa9a7b76aa775e2d9d4e95d1ea16eeeef4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.4.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.0",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.2"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.11"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-27T14:37:49+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/118cfaaa8bc5aef3287bf315b6060b1174754af6",
+                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-27T05:02:59+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.42",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "1c6cb5dfe412af3d0dfd414cfd110e3b9cfdbc3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1c6cb5dfe412af3d0dfd414cfd110e3b9cfdbc3c",
+                "reference": "1c6cb5dfe412af3d0dfd414cfd110e3b9cfdbc3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.11",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.2",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.42"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-28T12:09:13+00:00"
         },
         {
             "name": "psr/container",
@@ -2001,6 +2681,326 @@
             "time": "2024-06-11T12:45:25+00:00"
         },
         {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "85c77556683e6eee4323e4c5468641ca0237e2e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/85c77556683e6eee4323e4c5468641ca0237e2e8",
+                "reference": "85c77556683e6eee4323e4c5468641ca0237e2e8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T08:07:46+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
             "name": "sebastian/diff",
             "version": "6.0.2",
             "source": {
@@ -2066,6 +3066,657 @@
                 }
             ],
             "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
         },
         {
             "name": "symfony/console",
@@ -3293,6 +4944,56 @@
                 }
             ],
             "time": "2025-04-20T20:18:16+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:36:25+00:00"
         }
     ],
     "aliases": [],

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -2,7 +2,7 @@ includes:
 	- phpstan-baseline.neon
 
 parameters:
-  level: 0
+  level: 1
   paths:
     - Swat
     - SwatDB

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -17,4 +17,4 @@ parameters:
 # Level 3
   checkPhpDocMethodSignatures: true
 # Level 5
-#  checkFunctionArgumentTypes: true
+  checkFunctionArgumentTypes: true

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -6,7 +6,7 @@
 >
     <testsuites>
         <testsuite name="Unit">
-            <directory>tests/Unit</directory>
+            <directory>tests/unit</directory>
         </testsuite>
     </testsuites>
     <source>

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>Swat</directory>
+            <directory>SwatDB</directory>
+            <directory>SwatI18N</directory>
+        </include>
+    </source>
+    <coverage>
+        <report>
+            <html outputDirectory="build/coverage"/>
+        </report>
+    </coverage>
+</phpunit>

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -19,6 +19,7 @@
     <coverage>
         <report>
             <html outputDirectory="build/coverage"/>
+            <clover outputFile="build/logs/clover.xml"/>
         </report>
     </coverage>
 </phpunit>

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -11,9 +11,9 @@
     </testsuites>
     <source>
         <include>
-            <directory>Swat</directory>
-            <directory>SwatDB</directory>
-            <directory>SwatI18N</directory>
+            <directory suffix=".php">.</directory>
+            <directory suffix=".php">SwatDB</directory>
+            <directory suffix=".php">SwatI18N</directory>
         </include>
     </source>
     <coverage>

--- a/tests/Unit/Swat/SwatStringTest.php
+++ b/tests/Unit/Swat/SwatStringTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Swat;
+
+use PHPUnit\Framework\TestCase;
+
+class SwatStringTest extends TestCase
+{
+    public function testToListSingleItem()
+    {
+        $result = \SwatString::toList(['foo']);
+        $this->assertEquals('foo', $result);
+    }
+
+    public function testToListTwoItems()
+    {
+        $result = \SwatString::toList(['foo', 'bar']);
+        $this->assertEquals('foo and bar', $result);
+    }
+
+    public function testToListThreeItems()
+    {
+        $result = \SwatString::toList(['foo', 'bar', 'baz']);
+        $this->assertEquals('foo, bar, and baz', $result);
+    }
+
+    public function testToListCustomConjunctionAndDelimiter()
+    {
+        $result = \SwatString::toList(['a', 'b', 'c'], 'or', '; ', false);
+        $this->assertEquals('a; b or c', $result);
+    }
+
+    public function testToListWithIterator()
+    {
+        $result = \SwatString::toList(new \ArrayIterator(['x', 'y']));
+        $this->assertEquals('x and y', $result);
+    }
+
+    public function testToListWithNonIterator()
+    {
+        $this->expectException(\SwatException::class);
+        \SwatString::toList('a string');
+    }
+}

--- a/tests/Unit/Swat/SwatStringTest.php
+++ b/tests/Unit/Swat/SwatStringTest.php
@@ -4,6 +4,11 @@ namespace Tests\Unit\Swat;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
 class SwatStringTest extends TestCase
 {
     public function testToListSingleItem()

--- a/tests/Unit/SwatI18N/SwatI18NNumberFormatTest.php
+++ b/tests/Unit/SwatI18N/SwatI18NNumberFormatTest.php
@@ -4,6 +4,11 @@ namespace tests\Unit\SwatI18N;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
 class SwatI18NNumberFormatTest extends TestCase
 {
     protected \SwatI18NNumberFormat $format;

--- a/tests/Unit/SwatI18N/SwatI18NNumberFormatTest.php
+++ b/tests/Unit/SwatI18N/SwatI18NNumberFormatTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace tests\Unit\SwatI18N;
+
+use PHPUnit\Framework\TestCase;
+
+class SwatI18NNumberFormatTest extends TestCase
+{
+    protected \SwatI18NNumberFormat $format;
+
+    public function setUp(): void
+    {
+        $this->format = new \SwatI18NNumberFormat();
+        $this->format->decimal_separator = '.';
+        $this->format->thousands_separator = ',';
+        $this->format->grouping = [3];
+    }
+
+    public function testOverrideValidProperties()
+    {
+        $newFormat = $this->format->override([
+            'decimal_separator'   => ',',
+            'thousands_separator' => '.',
+        ]);
+
+        $this->assertNotSame($this->format, $newFormat);
+        $this->assertEquals(',', $newFormat->decimal_separator);
+        $this->assertEquals('.', $newFormat->thousands_separator);
+        $this->assertEquals(
+            [3],
+            $newFormat->grouping
+        );
+    }
+
+    public function testOverrideInvalidPropertyThrowsException()
+    {
+        $this->expectException(\SwatException::class);
+        $this->format->override(['invalid_property' => 'value']);
+    }
+
+    public function testOverrideNullValueDoesNotChangeProperty()
+    {
+        $newFormat = $this->format->override([
+            'decimal_separator' => null,
+        ]);
+        $this->assertEquals(
+            '.',
+            $newFormat->decimal_separator
+        );
+    }
+
+    public function testToString()
+    {
+        $expected = "decimal_separator => .\nthousands_separator => ,\ngrouping => 3\n";
+        $this->assertEquals(
+            $expected,
+            (string) $this->format
+        );
+    }
+
+    public function testToStringWithArrayGrouping()
+    {
+        $newFormat = $this->format->override([
+            'grouping' => 3,
+        ]);
+        $expected = "decimal_separator => .\nthousands_separator => ,\ngrouping => 3\n";
+        $this->assertEquals(
+            $expected,
+            (string) $newFormat
+        );
+    }
+}

--- a/tests/unit/Swat/SwatStringTest.php
+++ b/tests/unit/Swat/SwatStringTest.php
@@ -1,49 +1,47 @@
 <?php
 
-namespace Tests\Unit\Swat;
-
+use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversMethod(SwatString::class, 'toList')]
 class SwatStringTest extends TestCase
 {
     public function testToListSingleItem()
     {
-        $result = \SwatString::toList(['foo']);
+        $result = SwatString::toList(['foo']);
         $this->assertEquals('foo', $result);
     }
 
     public function testToListTwoItems()
     {
-        $result = \SwatString::toList(['foo', 'bar']);
+        $result = SwatString::toList(['foo', 'bar']);
         $this->assertEquals('foo and bar', $result);
     }
 
     public function testToListThreeItems()
     {
-        $result = \SwatString::toList(['foo', 'bar', 'baz']);
+        $result = SwatString::toList(['foo', 'bar', 'baz']);
         $this->assertEquals('foo, bar, and baz', $result);
     }
 
     public function testToListCustomConjunctionAndDelimiter()
     {
-        $result = \SwatString::toList(['a', 'b', 'c'], 'or', '; ', false);
+        $result = SwatString::toList(['a', 'b', 'c'], 'or', '; ', false);
         $this->assertEquals('a; b or c', $result);
     }
 
     public function testToListWithIterator()
     {
-        $result = \SwatString::toList(new \ArrayIterator(['x', 'y']));
+        $result = SwatString::toList(new ArrayIterator(['x', 'y']));
         $this->assertEquals('x and y', $result);
     }
 
     public function testToListWithNonIterator()
     {
-        $this->expectException(\SwatException::class);
-        \SwatString::toList('a string');
+        $this->expectException(SwatException::class);
+        SwatString::toList('a string');
     }
 }

--- a/tests/unit/SwatI18N/SwatI18NNumberFormatTest.php
+++ b/tests/unit/SwatI18N/SwatI18NNumberFormatTest.php
@@ -1,21 +1,19 @@
 <?php
 
-namespace tests\Unit\SwatI18N;
-
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversClass(SwatI18NNumberFormat::class)]
 class SwatI18NNumberFormatTest extends TestCase
 {
-    protected \SwatI18NNumberFormat $format;
+    protected SwatI18NNumberFormat $format;
 
     public function setUp(): void
     {
-        $this->format = new \SwatI18NNumberFormat();
+        $this->format = new SwatI18NNumberFormat();
         $this->format->decimal_separator = '.';
         $this->format->thousands_separator = ',';
         $this->format->grouping = [3];
@@ -39,7 +37,7 @@ class SwatI18NNumberFormatTest extends TestCase
 
     public function testOverrideInvalidPropertyThrowsException()
     {
-        $this->expectException(\SwatException::class);
+        $this->expectException(SwatException::class);
         $this->format->override(['invalid_property' => 'value']);
     }
 


### PR DESCRIPTION
Fixes all level 1 issues and those that are caught with `checkFunctionArgumentTypes: true`

... with one exception that I'm sure how best to fix:

```
 ------ --------------------------------------------------------------------------------- 
  Line   Swat/SwatCascadeFlydown.php                                                      
 ------ --------------------------------------------------------------------------------- 
  169    Parameter #2 $title of class SwatOption constructor expects string, null given.  
         🪪 argument.type                                                                 
         ✏️ Swat/SwatCascadeFlydown.php:169                                               
 ------ --------------------------------------------------------------------------------- 
```

~Instead of doing `$options = [new SwatOption(null, null)];` could we just do `$options = [];`?  If not, then we would need to change the constructor of `SwatOption` to allow a null title.~

✅ Switched to use `SwatOption(null, '')` now as it matches other places in the code.


```
 ------ ---------------------------------------- 
  Line   Swat/SwatTableViewInputRow.php          
 ------ ---------------------------------------- 
  680    Variable $column might not be defined.  
         🪪 variable.undefined                   
         ✏️ Swat/SwatTableViewInputRow.php:680   
 ------ ---------------------------------------- 
```
❓ My guess is that somewhere in `SwatTableViewInputRow::displayEnterAnotherRow()` we should return early (and not output anything?) if `$columns` is empty.
