### PR TITLE
Improve CI pipeline and repo configuration

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,21 +1,23 @@
-name: 'Setup Node/pnpm'
-description: 'Set up Node, pnpm, and install dependencies'
+name: 'Setup Node.js/pnpm'
+description: 'Set up Node.js, Corepack, pnpm, and install dependencies'
 runs:
   using: composite
   steps:
-    - name: Setup pnpm/corepack
+    - name: Setup pnpm/Corepack
       uses: actions/setup-node@v4
       with:
         node-version-file: 'package.json'
+
+    - name: Enable Corepack
       shell: bash
       run: npm i -g --force corepack && corepack enable
 
-    - name: Setup Node
+    - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version-file: 'package.json'
         cache: 'pnpm'
 
-    - name: Install Node dependencies
+    - name: Install Node.js dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,21 @@
+name: 'Setup Node/pnpm'
+description: 'Set up Node, pnpm, and install dependencies'
+runs:
+  using: composite
+  steps:
+    - name: Setup pnpm/corepack
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: 'package.json'
+      shell: bash
+      run: npm i -g --force corepack && corepack enable
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: 'package.json'
+        cache: 'pnpm'
+
+    - name: Install Node dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm/Corepack
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version-file: 'package.json'
 
@@ -13,7 +13,7 @@ runs:
       run: npm i -g --force corepack && corepack enable
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version-file: 'package.json'
         cache: 'pnpm'

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -1,0 +1,26 @@
+name: 'Setup PHP'
+description: 'Set up PHP, composer, and install dependencies'
+runs:
+  using: composite
+  steps:
+    - name: Setup PHP with any required extensions
+      uses: silverorange/actions-setup-php@v2
+      with:
+        php-version: '8.2'
+        # extensions: gd, imagick
+
+    - name: Get composer cache directory
+      id: composer-cache
+      shell: bash
+      run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache composer dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
+
+    - name: Install PHP dependencies
+      shell: bash
+      run: composer install

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -15,7 +15,7 @@ runs:
       run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
     - name: Cache composer dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/scripts/annotate-junit.php
+++ b/.github/scripts/annotate-junit.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This script takes the JUnit-formatted output from PHPUnit tests,
+ * and converts it to the GitHub annotations format, so that test
+ * results show up nicely in GH Actions' output for PRs.
+ */
+$file = $argv[1] ?? 'build/junit.xml';
+if (!file_exists($file)) {
+    exit(0);
+}
+
+$xml = simplexml_load_file($file);
+if ($xml === false) {
+    exit(0);
+}
+
+foreach ($xml->xpath('//testcase') as $case) {
+    foreach ($case->xpath('failure|error') as $problem) {
+        $src_file = str_replace(getcwd() . '/', '', (string) $case['file']);
+        $line = (string) ($case['line'] ?: 1);
+        $msg = str_replace(
+            ['%', "\r", "\n"],
+            ['%25', '%0D', '%0A'],
+            trim((string) $problem)
+        );
+        printf(
+            "::error file=%s,line=%s,title=%s::%s\n",
+            $src_file,
+            $line,
+            $case['name'],
+            $msg
+        );
+    }
+}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   phpcs:
+    name: PHP Code Style
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,6 +16,7 @@ jobs:
         run: composer run phpcs:ci | ./vendor/bin/cs2pr
 
   phpstan:
+    name: PHP Static Analysis
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +25,7 @@ jobs:
         run: composer run phpstan:ci
 
   prettier:
+    name: Formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +34,7 @@ jobs:
         run: pnpm format
 
   phpunit:
+    name: PHP Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +48,7 @@ jobs:
         run: php .github/scripts/annotate-junit.php build/logs/junit.xml
 
   all-checks:
+    name: All Checks
     if: always()
     needs: [phpcs, phpstan, prettier, phpunit]
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -45,7 +45,7 @@ jobs:
           # list of the problem files to the GH job summary
           if [ "$status" -ne 0 ]; then
             {
-              echo "The following files are not formatted correct; run `pnpm format:fix` to correct them."
+              echo "The following files are not formatted correct; run \`pnpm format:fix\` to correct them."
               echo "$files" | while IFS= read -r file; do
                 [ -n "$file" ] && echo "- \`$file\`"
               done

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -6,52 +6,52 @@ on:
       - master
 
 jobs:
-  runner:
+  phpcs:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-php
+      - name: Check PHP code style
+        run: composer run phpcs:ci | ./vendor/bin/cs2pr
 
-      # Can maybe be replaced with pnpm/action-setup@v4 in the future
-      - name: Setup pnpm/corepack
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: 'package.json'
-      - run: npm i -g --force corepack && corepack enable
+  phpstan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-php
+      - name: Run PHP static analysis
+        run: composer run phpstan:ci
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: 'package.json'
-          cache: 'pnpm'
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node
+      - name: Check formatting
+        run: pnpm format
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Setup PHP with tools
-        uses: silverorange/actions-setup-php@v2
-        with:
-          php-version: '8.2'
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install PHP dependencies
-        run: 'composer install'
-
-      - name: Run tests
-        timeout-minutes: 5
+  phpunit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-php
+      - name: Run PHPUnit tests
         run: |
-          composer run phpcs:ci
-          pnpm format
-          composer run phpstan:ci
-          composer run test
+          mkdir -p build
+          composer run test:ci
+      - name: Annotate PHPUnit failures
+        if: always()
+        run: php .github/scripts/annotate-junit.php build/logs/junit.xml
+
+  all-checks:
+    if: always()
+    needs: [phpcs, phpstan, prettier, phpunit]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all checks passed
+        run: |
+          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
+            echo "One or more checks failed"
+            exit 1
+          fi
+          echo "All checks passed"

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -32,13 +32,25 @@ jobs:
       - uses: ./.github/actions/setup-node
       - name: Check formatting
         run: |
+          # Run the formatting check and capture the status code
           set +e
-          output=$(pnpm format 2>&1)
+          files=$(pnpm run --silent format:ci)
           status=$?
-          echo "$output"
-          echo "$output" | grep '^\[warn\] ' | sed 's/^\[warn\] //' | while read -r file; do
-            echo "::error file=${file}::This file is not formatted; run 'pnpm format:fix' to fix."
-          done
+          set -e
+
+          # if there are errors, then output a markdown-formatted
+          # list of the problem files to the GH job summary
+          if [ "$status" -ne 0 ]; then
+            {
+              echo "$files" | while IFS= read -r file; do
+                [ -n "$file" ] && echo "- \`$file\`"
+              done
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # echo the file list to the normal job log and re-exit
+          # with prettier's original status so the job passes/fails
+          echo "$files"
           exit $status
 
   phpunit:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -10,27 +10,30 @@ jobs:
     name: PHP Code Style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-php
       - name: Check PHP code style
+        shell: bash
         run: composer run phpcs:ci | ./vendor/bin/cs2pr
 
   phpstan:
     name: PHP Static Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-php
       - name: Run PHP static analysis
+        shell: bash
         run: composer run phpstan:ci
 
   prettier:
     name: Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-node
       - name: Check formatting
+        shell: bash
         run: |
           # Run the formatting check and capture the status code
           set +e
@@ -42,6 +45,7 @@ jobs:
           # list of the problem files to the GH job summary
           if [ "$status" -ne 0 ]; then
             {
+              echo "The following files are not formatted correct; run `pnpm format:fix` to correct them."
               echo "$files" | while IFS= read -r file; do
                 [ -n "$file" ] && echo "- \`$file\`"
               done
@@ -57,14 +61,17 @@ jobs:
     name: PHP Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-php
       - name: Run PHPUnit tests
+        shell: bash
         run: |
           mkdir -p build
           composer run test:ci
+
       - name: Annotate PHPUnit failures
         if: always()
+        shell: bash
         run: php .github/scripts/annotate-junit.php build/logs/junit.xml
 
   all-checks:
@@ -74,6 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify all checks passed
+        shell: bash
         run: |
           if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
             echo "One or more checks failed"

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -31,7 +31,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
       - name: Check formatting
-        run: pnpm format
+        run: |
+          set +e
+          output=$(pnpm format 2>&1)
+          status=$?
+          echo "$output"
+          echo "$output" | grep '^\[warn\] ' | sed 's/^\[warn\] //' | while read -r file; do
+            echo "::error file=${file}::This file is not formatted; run 'pnpm format:fix' to fix."
+          done
+          exit $status
 
   phpunit:
     name: PHP Tests

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -6,7 +6,7 @@ use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
 $finder = (new Finder())
     ->in(__DIR__)
-    ->append([__FILE__]);
+    ->ignoreDotFiles(false);
 
 return (new Config())
     ->setParallelConfig(ParallelConfigFactory::detect(null, null, 2 ** 18 - 1))

--- a/composer.json
+++ b/composer.json
@@ -52,10 +52,12 @@
     "silverorange/yui": "^1.0.13"
   },
   "require-dev": {
+    "ext-simplexml": "*",
     "friendsofphp/php-cs-fixer": "3.88.2",
     "phpstan/phpstan": "^2.2",
     "phpunit/phpunit": "^11.5",
-    "rector/rector": "^2.4"
+    "rector/rector": "^2.5",
+    "staabm/annotate-pull-request-from-checkstyle": "^1.8"
   },
   "autoload": {
     "classmap": [
@@ -74,14 +76,15 @@
   },
   "scripts": {
     "phpcs": "./vendor/bin/php-cs-fixer check -v",
-    "phpcs:ci": "./vendor/bin/php-cs-fixer check --config=.php-cs-fixer.php --no-interaction --show-progress=none --diff --using-cache=no -vvv",
+    "phpcs:ci": "./vendor/bin/php-cs-fixer check --config=.php-cs-fixer.php --no-interaction --show-progress=none --using-cache=no --format=checkstyle",
     "phpcs:fix": "./vendor/bin/php-cs-fixer fix -v",
     "phpstan": "./vendor/bin/phpstan analyze",
     "phpstan:baseline": "./vendor/bin/phpstan analyze --generate-baseline",
-    "phpstan:ci": "./vendor/bin/phpstan analyze -vvv --no-progress --memory-limit 2G",
+    "phpstan:ci": "./vendor/bin/phpstan analyze --no-progress --memory-limit 2G --error-format=github",
     "rector": "./vendor/bin/rector --dry-run",
     "rector:fix": "./vendor/bin/rector",
-    "test": "./vendor/bin/phpunit --no-coverage",
+    "test": "./vendor/bin/phpunit --no-coverage --no-logging",
+    "test:ci": "./vendor/bin/phpunit --no-coverage",
     "test:coverage": "rm -rf ./build && XDEBUG_MODE=coverage ./vendor/bin/phpunit && npx serve build/coverage"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f7e81c88b00b22a2cdf2eaa72dcb878",
+    "content-hash": "bf2c4f33e9482a8bc4902c90b3e9b9b5",
     "packages": [
         {
             "name": "league/climate",
@@ -2656,16 +2656,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.5.5",
+            "version": "2.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "9718a72e7f1aacacbdcb6eeed07a47147bce802e"
+                "reference": "ba22f8c087848278fed6b4910d4cf1108096d8d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/9718a72e7f1aacacbdcb6eeed07a47147bce802e",
-                "reference": "9718a72e7f1aacacbdcb6eeed07a47147bce802e",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/ba22f8c087848278fed6b4910d4cf1108096d8d3",
+                "reference": "ba22f8c087848278fed6b4910d4cf1108096d8d3",
                 "shasum": ""
             },
             "require": {
@@ -2704,7 +2704,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.5.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.5.7"
             },
             "funding": [
                 {
@@ -2712,7 +2712,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-09T09:48:44+00:00"
+            "time": "2026-07-13T15:24:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3699,6 +3699,58 @@
                 }
             ],
             "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "staabm/annotate-pull-request-from-checkstyle",
+            "version": "1.8.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/annotate-pull-request-from-checkstyle.git",
+                "reference": "9cab4b00e2f2e86dc54fb88e2a1b4bf15443d6dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/annotate-pull-request-from-checkstyle/zipball/9cab4b00e2f2e86dc54fb88e2a1b4bf15443d6dd",
+                "reference": "9cab4b00e2f2e86dc54fb88e2a1b4bf15443d6dd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-libxml": "*",
+                "ext-simplexml": "*",
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16.1"
+            },
+            "bin": [
+                "cs2pr"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Staab"
+                }
+            ],
+            "keywords": [
+                "Github Actions",
+                "continous integration",
+                "dev"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/annotate-pull-request-from-checkstyle/issues",
+                "source": "https://github.com/staabm/annotate-pull-request-from-checkstyle/tree/1.8.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-05T12:33:44+00:00"
         },
         {
             "name": "staabm/side-effects-detector",
@@ -5093,6 +5145,8 @@
         "ext-mbstring": "*",
         "ext-pcre": "*"
     },
-    "platform-dev": {},
+    "platform-dev": {
+        "ext-simplexml": "*"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "format": "prettier --check .",
+    "format:ci": "prettier --list-different .",
     "format:fix": "prettier --write ."
   },
   "devDependencies": {

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -5,6 +5,7 @@ parameters:
     - Swat
     - SwatDB
     - SwatI18N
+    - tests
   editorUrl: '%%relfile%%:%%line%%'
   editorUrlTitle: '%%relfile%%:%%line%%'
   errorFormat: table

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -23,4 +23,7 @@
             <clover outputFile="build/logs/clover.xml" />
         </report>
     </coverage>
+    <logging>
+        <junit outputFile="build/logs/junit.xml" />
+    </logging>
 </phpunit>

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,22 +1,22 @@
 /**
- * @see https://prettier.io/docs/en/configuration.html
- * @type {import("prettier").Config}
- */
+* @see https://prettier.io/docs/en/configuration.html
+* @type {import("prettier").Config}
+*/
 const config = {
-  singleQuote: true,
-  tabWidth: 2,
-  trailingComma: 'none',
-  plugins: ['@prettier/plugin-xml'],
-  overrides: [
-    {
-      files: '*.xml',
-      options: {
-        tabWidth: 4,
-        xmlQuoteAttributes: 'double',
-        xmlWhitespaceSensitivity: 'ignore'
-      }
-    }
-  ]
+singleQuote: true,
+tabWidth: 2,
+trailingComma: 'none',
+plugins: ['@prettier/plugin-xml'],
+overrides: [
+{
+files: '*.xml',
+options: {
+tabWidth: 4,
+xmlQuoteAttributes: 'double',
+xmlWhitespaceSensitivity: 'ignore'
+}
+}
+]
 };
 
 export default config;

--- a/tests/unit/Swat/SwatStringTest.php
+++ b/tests/unit/Swat/SwatStringTest.php
@@ -1,6 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -9,45 +12,46 @@ use PHPUnit\Framework\TestCase;
 #[CoversMethod(SwatString::class, 'toList')]
 class SwatStringTest extends TestCase
 {
+    #[Test]
     public function testToListSingleItem()
     {
         $result = SwatString::toList(['foo']);
         $this->assertEquals('foo', $result);
     }
 
+    #[Test]
     public function testToListTwoItems()
     {
         $result = SwatString::toList(['foo', 'bar']);
         $this->assertEquals('foo and bar', $result);
     }
 
+    #[Test]
     public function testToListThreeItems()
     {
         $result = SwatString::toList(['foo', 'bar', 'baz']);
         $this->assertEquals('foo, bar, and baz', $result);
     }
 
+    #[Test]
     public function testToListCustomConjunctionAndDelimiter()
     {
         $result = SwatString::toList(['a', 'b', 'c'], 'or', '; ', false);
         $this->assertEquals('a; b or c', $result);
     }
 
+    #[Test]
     public function testToListWithIterator()
     {
         $result = SwatString::toList(new ArrayIterator(['x', 'y']));
         $this->assertEquals('x and y', $result);
     }
 
+    #[Test]
     public function testToListWithNonIterator()
     {
         $this->expectException(SwatException::class);
+        // @phpstan-ignore argument.type
         SwatString::toList('a string');
-    }
-
-    #[Test]
-    public function testIntentionalFailure()
-    {
-        $this->assertTrue(     false);
     }
 }

--- a/tests/unit/Swat/SwatStringTest.php
+++ b/tests/unit/Swat/SwatStringTest.php
@@ -44,4 +44,10 @@ class SwatStringTest extends TestCase
         $this->expectException(SwatException::class);
         SwatString::toList('a string');
     }
+
+    #[Test]
+    public function testIntentionalFailure()
+    {
+        $this->assertTrue(     false);
+    }
 }

--- a/tests/unit/SwatI18N/SwatI18NNumberFormatTest.php
+++ b/tests/unit/SwatI18N/SwatI18NNumberFormatTest.php
@@ -1,6 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -11,7 +14,7 @@ class SwatI18NNumberFormatTest extends TestCase
 {
     protected SwatI18NNumberFormat $format;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->format = new SwatI18NNumberFormat();
         $this->format->decimal_separator = '.';
@@ -19,6 +22,7 @@ class SwatI18NNumberFormatTest extends TestCase
         $this->format->grouping = [3];
     }
 
+    #[Test]
     public function testOverrideValidProperties()
     {
         $newFormat = $this->format->override([
@@ -35,12 +39,14 @@ class SwatI18NNumberFormatTest extends TestCase
         );
     }
 
+    #[Test]
     public function testOverrideInvalidPropertyThrowsException()
     {
         $this->expectException(SwatException::class);
         $this->format->override(['invalid_property' => 'value']);
     }
 
+    #[Test]
     public function testOverrideNullValueDoesNotChangeProperty()
     {
         $newFormat = $this->format->override([
@@ -52,6 +58,7 @@ class SwatI18NNumberFormatTest extends TestCase
         );
     }
 
+    #[Test]
     public function testToString()
     {
         $expected = "decimal_separator => .\nthousands_separator => ,\ngrouping => 3\n";
@@ -61,6 +68,7 @@ class SwatI18NNumberFormatTest extends TestCase
         );
     }
 
+    #[Test]
     public function testToStringWithArrayGrouping()
     {
         $newFormat = $this->format->override([


### PR DESCRIPTION
This adds some improvements to the CI pipeline for public PHP packages:

## Configuration Changes (not part of this PR)

Some changes were made to the repo settings [here](https://github.com/silverorange/swat/settings/branch_protection_rules/80741668):

- `master` branch is now protected
- all changes require a pull request (i.e. you can't push code directly to `master`)
- all PRs require at least one approval
- all PRs require status checks to pass before merging
- branches must be up-to-date before merging

## Action Improvements

- splits the one `runner` job into jobs for each of the testing steps, e.g. `phpcs`, `format`, etc. (and uses composite actions to reduce duplication, improve caching, etc.)
- adds a concurrency setting, so that a new commit will cancel any existing jobs for the same PR
- bumps the `actions/checkout`, `actions/cache` and `actions/setup-node` versions to the latest
    - `silverorange/actions-setup-php` was also brought up-to-date with the upstream version, although we might need to add a tag as well to fix "Node 20" warnings
- sets `persist-credentials: false` for `action/checkout` (recommended security improvement)
- all jobs must pass for pipeline to succeed
    - this is done with an aggregating `All Checks` job
    - catches not only failures but also skipped jobs (which would otherwise pass the branch protection rules)
    - any future additions to the pipeline just need to be added to the workflow code and won't require updating the repo settings

## Action Output

- Prettier issues are listed on the summary page (e.g. https://github.com/silverorange/swat/actions/runs/30101473053)
- PHPCS, PHPUnit, and PHPStan issues are output as GitHub annotations, so they appear inline on the PR's "Files changed" tab
    - PHPUnit failures are also listed on the summary page

## Non-CI Improvements

- add a `.gitattributes` file that lists paths to be excluded when running `git archive`
    - this command is what GitHub uses to create archives
    - these archives are what Composer downloads for `dist` packages
    - this reduces the distributed package size, while keeping the full set of files available for development

## Future Improvements

- general practice is to pin `uses:` actions to SHA commit hashes, rather than tags like `@v7`, etc.
    - tags are moveable, which means unsecure code could get added to those actions, then run in any workflow that uses those actions
    - see https://docs.zizmor.sh/audits/#unpinned-uses for details
    - it means a bit more work when auditing PRs that update the hashes, but [Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/keeping-your-actions-up-to-date-with-dependabot) could be used to keep them up-to-date automatically
    - I'm not 100% clear on how this would work with `silverorange/actions-*` repos since those are "validated" forks of the official actions
    - pinning to hashes could mean we don't need to fork those repos at all; since the hash would just point to the latest version of the upstream that we have validated
- add Dependabot to the repo to help keep 3rd-party dependencies up-to-date with minimal manual effort
- adding a tool like [zizmor](https://zizmor.sh/) to add static analysis to workflow files as part of the CI pipeline
    - PRs that try and change the pipeline config are then audited to prevent unintended changes from getting committed and/or security issues from being added